### PR TITLE
(maint) Bump stdlib dependency for future parser

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0"},
     {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0"}
   ]
 }


### PR DESCRIPTION
puppetlabs-stdlib 4.6.0 had future parser fixes in it, so require the
latest. This module requires future parser.