### PR TITLE
Bump stdlib dep

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 4.4.0"},
     {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0"}
   ]
 }


### PR DESCRIPTION
I picked 4.4.0 because it's the oldest supported version that has the most recent commit to `downcase`.