### PR TITLE
(PUP-4658) Update acceptance for fix

### DIFF
--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -117,7 +117,7 @@ describe 'puppet_agent class' do
     describe file('/etc/puppetlabs/mcollective/server.cfg') do
       it { is_expected.to exist }
       its(:content) {
-        is_expected.to include 'libdir = /usr/libexec/mcollective/plugins:/opt/puppetlabs/mcollective/plugins'
+        is_expected.to include 'libdir = /opt/puppetlabs/mcollective/plugins:/usr/libexec/mcollective/plugins'
         is_expected.to include 'logfile = /var/log/puppetlabs/mcollective.log'
         is_expected.to include 'plugin.yaml = /etc/mcollective/facts.yaml:/etc/puppetlabs/mcollective/facts.yaml'
       }
@@ -126,7 +126,7 @@ describe 'puppet_agent class' do
     describe file('/etc/puppetlabs/mcollective/client.cfg') do
       it { is_expected.to exist }
       its(:content) {
-        is_expected.to include 'libdir = /usr/libexec/mcollective/plugins:/opt/puppetlabs/mcollective/plugins'
+        is_expected.to include 'libdir = /opt/puppetlabs/mcollective/plugins:/usr/libexec/mcollective/plugins'
         is_expected.to include 'logfile = /var/log/puppetlabs/mcollective.log'
         is_expected.to_not match /plugin.yaml[ ]*=/
       }


### PR DESCRIPTION
A prior commit for this ticket changed the order if mcollective's libdir
config, but not the acceptance test verifying it. Update the acceptance
test to pass again.