### PR TITLE
(PUP-4603) Use Puppet Server 2.1+ for acceptance tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,16 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 group :test do
-  gem "rake"
-  gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.8.1'
-  gem "rspec", '< 3.2.0'
-  gem "rspec-puppet"
-  gem "puppetlabs_spec_helper"
-  gem "metadata-json-lint"
-  gem "rspec-puppet-facts"
+  gem 'rake', '~> 10.4'
+  gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.8'
+  gem 'rspec', '< 3.2.0' # https://github.com/rspec/rspec-core/issues/1864
+  gem 'rspec-puppet', '~> 2.2'
+  gem 'puppetlabs_spec_helper', '~> 0.10'
+  gem 'metadata-json-lint', '~> 0.0'
+  gem 'rspec-puppet-facts', '~> 0.10'
 end
 
 group :system_tests do
-  gem "beaker", '~> 2.11.0'
-  gem "beaker-rspec"
+  gem 'beaker', '~> 2.14'
+  gem 'beaker-rspec', '~> 5.1'
 end

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -72,17 +72,17 @@ describe 'puppet_agent class' do
   context 'agent run' do
     before(:all) {
       setup_puppet_on default, :agent => true
-      pp = "file { '#{master.puppet['confdir']}/manifests/site.pp': ensure => file, content => 'class { \"puppet_agent\": }' }"
+      pp = "file { '#{master.puppet['codedir']}/environments/production/manifests/site.pp': ensure => file, content => 'class { \"puppet_agent\": }' }"
       apply_manifest_on(master, pp, :catch_failures => true)
     }
     after (:all) {
       teardown_puppet_on default
-      pp = "file { '#{master.puppet['confdir']}/manifests/site.pp': ensure => absent }"
+      pp = "file { '#{master.puppet['codedir']}/environments/production/manifests/site.pp': ensure => absent }"
       apply_manifest_on(master, pp, :catch_failures => true)
     }
 
     it 'should work idempotently with no errors' do
-      with_puppet_running_on(master, parser_opts, master.tmpdir('puppet')) do
+      with_puppet_running_on(master, server_opts, master.tmpdir('puppet')) do
         on default, puppet("agent --test --server #{master}"), { :acceptable_exit_codes => [0,2] }
       end
     end
@@ -105,12 +105,12 @@ describe 'puppet_agent class' do
   context 'with mcollective configured' do
     before(:all) {
       setup_puppet_on default, :mcollective => true, :agent => true
-      pp = "file { '#{master.puppet['confdir']}/manifests/site.pp': ensure => file, content => 'class { \"puppet_agent\": }' }"
+      pp = "file { '#{master.puppet['codedir']}/environments/production/manifests/site.pp': ensure => file, content => 'class { \"puppet_agent\": }' }"
       apply_manifest_on(master, pp, :catch_failures => true)
     }
     after (:all) {
       teardown_puppet_on default
-      pp = "file { '#{master.puppet['confdir']}/manifests/site.pp': ensure => absent }"
+      pp = "file { '#{master.puppet['codedir']}/environments/production/manifests/site.pp': ensure => absent }"
       apply_manifest_on(master, pp, :catch_failures => true)
     }
 
@@ -122,7 +122,7 @@ describe 'puppet_agent class' do
     end
 
     it 'should work idempotently with no errors' do
-      with_puppet_running_on(master, parser_opts, master.tmpdir('puppet')) do
+      with_puppet_running_on(master, server_opts, master.tmpdir('puppet')) do
         on default, puppet("agent --test --server #{master}"), { :acceptable_exit_codes => [0,2] }
       end
     end

--- a/spec/classes/puppet_agent_prepare_spec.rb
+++ b/spec/classes/puppet_agent_prepare_spec.rb
@@ -6,17 +6,22 @@ MCO_PLUGIN_YAML = '/etc/puppetlabs/mcollective/facts.yaml'
 MCO_LOGFILE = '/var/log/puppetlabs/mcollective.log'
 
 describe 'puppet_agent::prepare' do
-  context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
-      context "on #{os}" do
-        let(:facts) do
-          facts.merge({
-            :puppet_ssldir => '/dev/null/ssl',
-            :puppet_config => '/dev/null/puppet.conf',
-            :mco_server_config => nil,
-            :mco_client_config => nil,
-          })
-        end
+  context 'supported operating system families' do
+    ['Debian', 'RedHat'].each do |osfamily|
+      facts = {
+        :operatingsystem => 'foo',
+        :architecture => 'bar',
+        :osfamily => osfamily,
+        :lsbdistid => osfamily,
+        :lsbdistcodename => 'baz',
+        :puppet_ssldir => '/dev/null/ssl',
+        :puppet_config => '/dev/null/puppet.conf',
+        :mco_server_config => nil,
+        :mco_client_config => nil,
+      }
+
+      context "on #{osfamily}" do
+        let(:facts) { facts }
 
         [
           MCO_CFG,
@@ -31,9 +36,7 @@ describe 'puppet_agent::prepare' do
           ].each do |mco_settings|
             context "with mco_config = #{mco_config} and mco_settings = #{mco_settings}" do
               let(:facts) {
-                facts.merge( {
-                  :puppet_ssldir => '/dev/null/ssl',
-                  :puppet_config => '/dev/null/puppet.conf',
+                facts.merge({
                   :mco_server_config => mco_config[:server],
                   :mco_client_config => mco_config[:client],
                   :mco_server_settings => mco_settings,

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -27,18 +27,16 @@ PROJ_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 TEST_FILES = File.expand_path(File.join(File.dirname(__FILE__), 'acceptance', 'files'))
 
 unless ENV['BEAKER_provision'] == 'no'
-  # Install repos on hosts
-  hosts.each do |host|
-    install_puppetlabs_release_repo(host)
-
-    if ENV['SHA']
-      step "Setup dev repositories"
-      install_puppetlabs_dev_repo(host, 'puppet', ENV['SHA'])
-    end
-  end
+  # Install release repo for puppet 3.x
+  install_puppetlabs_release_repo default
 
   # Install puppet-server on master
-  install_package master, 'puppet-server'
+  options['is_puppetserver'] = true
+  master['puppetservice'] = 'puppetserver'
+  master['puppetserver-confdir'] = '/etc/puppetlabs/puppetserver/conf.d'
+  master['type'] = 'aio'
+  install_puppet_agent_on master, {}
+  install_package master, 'puppetserver'
   master['use-service'] = true
 
   step "Install module and dependencies"
@@ -48,6 +46,7 @@ unless ENV['BEAKER_provision'] == 'no'
   on master, puppet('module', 'install', 'puppetlabs-apt'), { :acceptable_exit_codes => [0,1] }
 
   # Install activemq on master
+  install_puppetlabs_release_repo master
   install_package master, 'activemq'
 
   ['truststore', 'keystore'].each do |ext|
@@ -69,7 +68,12 @@ def parser_opts
   {
     :main => {:stringify_facts => false, :parser => 'future', :color => 'ansi'},
     :agent => {:stringify_facts => false, :cfacter => true, :ssldir => '$vardir/ssl'},
-    :master => {:stringify_facts => false, :cfacter => true},
+  }
+end
+
+def server_opts
+  {
+    :master => {:autosign => true},
   }
 end
 
@@ -104,47 +108,9 @@ def setup_puppet_on(host, opts = {})
   end
 
   if opts[:agent]
-    hostname = on(master, 'facter hostname').stdout.strip
-    fqdn = on(master, 'facter fqdn').stdout.strip
-
-    if master.use_service_scripts?
-      step "Ensure puppet is stopped"
-      # Passenger, in particular, must be shutdown for the cert setup steps to work,
-      # but any running puppet master will interfere with webrick starting up and
-      # potentially ignore the puppet.conf changes.
-      on(master, puppet('resource', 'service', master['puppetservice'], "ensure=stopped"))
-    end
-
     step "Clear SSL on all hosts"
     hosts.each do |host|
-      ssldir = on(host, puppet('agent --configprint ssldir')).stdout.chomp
-      on(host, "rm -rf '#{ssldir}'")
-    end
-
-    step "Master: Start Puppet Master"
-    stop_firewall_on host
-    master_opts = {
-      :main => {
-        :dns_alt_names => "puppet,#{hostname},#{fqdn}",
-      },
-      :__service_args__ => {
-        # apache2 service scripts can't restart if we've removed the ssl dir
-        :bypass_service_script => true,
-      },
-    }
-    with_puppet_running_on(master, master_opts, master.tmpdir('puppet')) do
-      step "Agents: Run agent --test first time to gen CSR"
-      on host, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [1]
-
-      step "Master: sign all certs"
-      on master, puppet("cert --sign --all"), :acceptable_exit_codes => [0,24]
-
-      step "Agents: Run agent --test second time to obtain signed cert"
-      on host, puppet("agent --test --server #{master}"), :acceptable_exit_codes => [0,2]
-    end
-
-    if master.graceful_restarts?
-      on(master, puppet('resource', 'service', master['puppetservice'], "ensure=running"))
+      on(host, "rm -rf '#{host.puppet['ssldir']}'")
     end
   else
     step "Install module and dependencies"

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -27,9 +27,6 @@ PROJ_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 TEST_FILES = File.expand_path(File.join(File.dirname(__FILE__), 'acceptance', 'files'))
 
 unless ENV['BEAKER_provision'] == 'no'
-  # Work-around for BKR-262
-  @logger = logger
-
   # Install repos on hosts
   hosts.each do |host|
     install_puppetlabs_release_repo(host)


### PR DESCRIPTION
- (maint) Update Beaker to latest and pin gems
- (maint) Remove work-around for BKR-262
- (PUP-4603) Use Puppet Server 2.1+