### PR TITLE
(maint) Use BKR-314 and BKR-317 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: ruby
+sudo: false
 bundler_args: --without system_tests
 before_install: rm Gemfile.lock || true
 script: bundle exec rake test

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,6 @@ group :test do
 end
 
 group :system_tests do
-  gem 'beaker', '~> 2.15'
+  gem 'beaker', '~> 2.16'
   gem 'beaker-rspec', '~> 5.1'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,6 @@ group :test do
 end
 
 group :system_tests do
-  gem 'beaker', '~> 2.14'
+  gem 'beaker', '~> 2.15'
   gem 'beaker-rspec', '~> 5.1'
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -100,7 +100,7 @@ end
 def setup_puppet_on(host, opts = {})
   opts = {:agent => false, :mcollective => false}.merge(opts)
 
-  step "Setup puppet on #{host}"
+  puts "Setup puppet on #{host}"
   install_puppet_on host
 
   configure_puppet_on(host, parser_opts)
@@ -128,7 +128,7 @@ def setup_puppet_on(host, opts = {})
   end
 
   if opts[:agent]
-    step "Clear SSL on all hosts and disable firewalls"
+    puts "Clear SSL on all hosts and disable firewalls"
     hosts.each do |host|
       stop_firewall_on host
       on(host, "rm -rf '#{host.puppet['ssldir']}'")
@@ -144,7 +144,7 @@ def configure_agent_on(host, agent_run = false)
 end
 
 def teardown_puppet_on(host)
-  step "Purge puppet from #{host}"
+  puts "Purge puppet from #{host}"
   # Note pc1_repo is specific to the module's manifests. This is knowledge we need to clean
   # the machine after each run.
   case host['platform']

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -45,7 +45,7 @@ unless ENV['BEAKER_provision'] == 'no'
     master['puppetservice'] = 'puppetserver'
     master['puppetserver-confdir'] = '/etc/puppetlabs/puppetserver/conf.d'
     master['type'] = 'aio'
-    install_puppet_agent_on master, {}
+    install_puppet_agent_on master, {:puppet_agent_version => '1.2.1'}
     install_package master, 'puppetserver'
     master['use-service'] = true
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -40,9 +40,6 @@ unless ENV['BEAKER_provision'] == 'no'
     end
     install_pe
   else
-    # Install release repo for puppet 3.x
-    install_puppetlabs_release_repo default
-
     # Install puppet-server on master
     options['is_puppetserver'] = true
     master['puppetservice'] = 'puppetserver'
@@ -104,9 +101,7 @@ def setup_puppet_on(host, opts = {})
   opts = {:agent => false, :mcollective => false}.merge(opts)
 
   step "Setup puppet on #{host}"
-  install_package host, 'puppet'
-  add_foss_defaults_on host
-  add_puppet_paths_on host
+  install_puppet_on host
 
   configure_puppet_on(host, parser_opts)
 
@@ -144,10 +139,7 @@ def setup_puppet_on(host, opts = {})
 end
 
 def configure_agent_on(host, agent_run = false)
-  remove_foss_defaults_on host
-  add_aio_defaults_on host
-  add_puppet_paths_on host
-
+  configure_defaults_on host, 'aio'
   install_modules_on host unless agent_run
 end
 
@@ -172,7 +164,7 @@ file { ['/etc/puppet', '/etc/puppetlabs', '/etc/mcollective']: ensure => absent,
 package { ['puppet-agent', 'puppet', 'mcollective', 'mcollective-client']: ensure => purged }
   EOS
   on host, puppet('apply', '-e', "\"#{pp}\"")
-  remove_aio_defaults_on host
+  remove_defaults_on host
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
BKR-314 and BKR-317 identified issues with using Beaker helpers for
upgrade scenarios. Simplify the acceptance setup by using Beaker helpers
now that they're fixed.

Beaker 2.15 was released with fixes for [BKR-314](https://tickets.puppetlabs.com/browse/BKR-314) and [BKR-317](https://tickets.puppetlabs.com/browse/BKR-317).