### PR TITLE
(PUP-4690) Migrate SSL stuff based on individual settings

### DIFF
--- a/lib/facter/settings.rb
+++ b/lib/facter/settings.rb
@@ -11,3 +11,19 @@ Facter.add('puppet_config') do
     Puppet.settings['config']
   end
 end
+
+Facter.add('puppet_sslpaths') do
+  setcode do
+    result = {}
+    settings = ['privatedir', 'privatekeydir', 'publickeydir', 'certdir', 'requestdir', 'hostcrl']
+    settings.each do |setting|
+      path = Puppet.settings[setting]
+      exists = File.exist? path
+      result[setting] = {
+        'path'    => path,
+        'path_exists'  => exists,
+      }
+    end
+    result
+  end
+end

--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -16,11 +16,40 @@ class puppet_agent::prepare {
     ensure => directory,
   }
 
-  file { $::puppet_agent::params::ssldir:
-    ensure  => directory,
-    source  => $::puppet_ssldir,
-    backup  => false,
-    recurse => true,
+  $ssl_dir = $::puppet_agent::params::ssldir
+  file { $ssl_dir:
+    ensure   => directory,
+    source   => $::puppet_ssldir,
+    backup   => false,
+    recurse  => false,
+  }
+
+  $sslpaths = {
+    'certdir'       => 'certs',
+    'privatedir'    => 'private',
+    'privatekeydir' => 'private_keys',
+    'publickeydir'  => 'public_keys',
+    'requestdir'    => 'certificate_requests',
+  }
+
+  $sslpaths.each |String $setting, String $subdir| {
+    if $::puppet_sslpaths[$setting]['path_exists'] {
+      file { "${ssl_dir}/${subdir}":
+        ensure  => directory,
+        source  => $::puppet_sslpaths[$setting]['path'],
+        backup  => false,
+        recurse => true,
+      }
+    }
+  }
+
+  # The only one that's a file, not a directory.
+  if $::puppet_sslpaths['hostcrl']['path_exists'] {
+    file { "${ssl_dir}/crl.pem":
+      ensure  => file,
+      source  => $::puppet_sslpaths['hostcrl']['path'],
+      backup  => false
+    }
   }
 
   $puppetconf = $::puppet_agent::params::config

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -8,6 +8,32 @@ describe 'puppet_agent' do
           facts.merge({
             :puppet_ssldir   => '/dev/null/ssl',
             :puppet_config   => '/dev/null/puppet.conf',
+            :puppet_sslpaths => {
+              'privatedir'    => {
+                'path'   => '/dev/null/ssl/private',
+                'path_exists' => true,
+              },
+              'privatekeydir' => {
+                'path'   => '/dev/null/ssl/private_keys',
+                'path_exists' => true,
+              },
+              'publickeydir'  => {
+                'path'   => '/dev/null/ssl/public_keys',
+                'path_exists' => true,
+              },
+              'certdir'       => {
+                'path'   => '/dev/null/ssl/certs',
+                'path_exists' => true,
+              },
+              'requestdir'    => {
+                'path'   => '/dev/null/ssl/certificate_requests',
+                'path_exists' => true,
+              },
+              'hostcrl'       => {
+                'path'   => '/dev/null/ssl/crl.pem',
+                'path_exists' => true,
+              },
+            },
           })
         end
 

--- a/spec/unit/facter/settings_spec.rb
+++ b/spec/unit/facter/settings_spec.rb
@@ -17,3 +17,20 @@ describe 'puppet_config fact' do
     it { is_expected.to eq('/dev/null/puppet.conf') }
   end
 end
+
+describe "puppet_sslpaths fact" do
+  subject { Facter.fact("puppet_sslpaths".to_sym).value }
+  after(:each) { Facter.clear }
+
+  { 'privatedir'    => 'ssl/private',
+    'privatekeydir' => 'ssl/private_keys',
+    'publickeydir'  => 'ssl/public_keys',
+    'certdir'       => 'ssl/certs',
+    'requestdir'    => 'ssl/certificate_requests',
+    'hostcrl'       => 'ssl/crl.pem',
+  }.each_pair do |name, path|
+    describe name do
+      it { is_expected.to include(name => { 'path' => "/dev/null/#{path}", 'path_exists' => false})}
+    end
+  end
+end


### PR DESCRIPTION
Previously the ssldir was migrated monolithically. Unfortunately,
Puppet allows setting paths for several parts of the ssldir
individually. This now will take those disparate settings and combine
them into one ssldir post-migration.

It's a lot like voltron, but with more SSL.

This does not yet have acceptance, as beaker-rspec with vagrant and virtualbox is causing me grief. I'll get acceptance up ASAP, but for now the code itself is reviewable.