### PR TITLE
(PUP-4746, PUP-4735) Fix mco setting fact and add tests

### DIFF
--- a/lib/facter/mco_config.rb
+++ b/lib/facter/mco_config.rb
@@ -16,13 +16,21 @@
       settings = nil
       config = Facter.fact("mco_#{node}_config".to_sym)
       if config and config.value
-        settings = Hash[File.readlines(config.value).select {|v|
+        settings = {}
+
+        File.readlines(config.value).select {|v|
           v.lstrip =~ /[^#].+=.+/
         }.map {|x|
           x.split('=', 2).map {|s| s.strip}
         }.select {|k, v|
           k == 'libdir' || k == 'plugin.yaml'
-        }]
+        }.each {|k, v|
+          if settings[k]
+            settings[k] += ':' + v
+          else
+            settings[k] = v
+          end
+        }
       end
       settings
     end

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -159,7 +159,8 @@ describe 'puppet_agent class' do
     describe file('/etc/puppetlabs/mcollective/server.cfg') do
       it { is_expected.to exist }
       its(:content) {
-        is_expected.to include 'libdir = /opt/puppetlabs/mcollective/plugins:/usr/libexec/mcollective/plugins'
+        is_expected.to include 'libdir = /opt/puppetlabs/mcollective/plugins'
+        is_expected.to include 'libdir = /usr/libexec/mcollective/plugins'
         is_expected.to include 'logfile = /var/log/puppetlabs/mcollective.log'
         is_expected.to include 'plugin.yaml = /etc/mcollective/facts.yaml:/etc/puppetlabs/mcollective/facts.yaml'
       }
@@ -168,7 +169,7 @@ describe 'puppet_agent class' do
     describe file('/etc/puppetlabs/mcollective/client.cfg') do
       it { is_expected.to exist }
       its(:content) {
-        is_expected.to include 'libdir = /opt/puppetlabs/mcollective/plugins:/usr/libexec/mcollective/plugins'
+        is_expected.to include 'libdir = /opt/puppetlabs/mcollective/plugins:/usr/share/mcollective/plugins:/usr/libexec/mcollective'
         is_expected.to include 'logfile = /var/log/puppetlabs/mcollective.log'
         is_expected.to_not match /plugin.yaml[ ]*=/
       }

--- a/spec/acceptance/files/client.cfg.erb
+++ b/spec/acceptance/files/client.cfg.erb
@@ -1,6 +1,7 @@
 main_collective = mcollective
 collectives = mcollective
-libdir = /usr/libexec/mcollective/plugins
+libdir = /usr/share/mcollective/plugins
+libdir = /usr/libexec/mcollective
 logger_type = console
 loglevel = warn
 

--- a/spec/acceptance/files/server.cfg.erb
+++ b/spec/acceptance/files/server.cfg.erb
@@ -1,6 +1,7 @@
 main_collective = mcollective
 collectives = mcollective
 libdir = /usr/libexec/mcollective/plugins
+libdir = /opt/puppetlabs/mcollective/plugins
 logfile = /var/log/mcollective.log
 loglevel = info
 daemonize = 1


### PR DESCRIPTION
* (PUP-4746) Update mco settings custom fact
    Without this change, mco_*_settings will only return the 1st declaration
    of a setting in the config file. Update the fact to return values from
    all declarations.

* (PUP-4735) Modify acceptance test for mco config
    MCollective config files can contain multiple declarations of the same
    property. Ensure acceptance testing covers that case.