### PR TITLE
(PUP-4478) Fix tests on Ubuntu

### DIFF
--- a/manifests/osfamily/debian.pp
+++ b/manifests/osfamily/debian.pp
@@ -7,6 +7,14 @@ class puppet_agent::osfamily::debian {
     key        => {
       'id'     => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
       'server' => 'pgp.mit.edu',
-    }
+    },
+    notify     => Notify['pc1_repo_force'],
+  }
+
+  # apt_update doesn't inherit the future class dependency, so it
+  # can wait until the end of the run to exec. Force it to happen now.
+  notify { 'pc1_repo_force':
+      message => 'forcing apt update for pc1_repo',
+      require => Exec['apt_update'],
   }
 }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -72,7 +72,7 @@ describe 'puppet_agent class' do
   context 'agent run' do
     before(:all) {
       setup_puppet_on default, :agent => true
-      pp = "file { '#{master.puppet['codedir']}/environments/production/manifests/site.pp': ensure => file, content => 'class { \"puppet_agent\": }' }"
+      pp = "file { '#{master.puppet['codedir']}/environments/production/manifests/site.pp': ensure => file, content => 'class { \"puppet_agent\": service_names => [\"mcollective\"] }' }"
       apply_manifest_on(master, pp, :catch_failures => true)
     }
     after (:all) {
@@ -95,11 +95,6 @@ describe 'puppet_agent class' do
       it { is_expected.to be_installed }
     end
 
-    describe service('puppet') do
-      it { is_expected.to be_enabled }
-      it { is_expected.to be_running }
-    end
-
     describe service('mcollective') do
       it { is_expected.to be_enabled }
       it { is_expected.to be_running }
@@ -109,7 +104,7 @@ describe 'puppet_agent class' do
   context 'with mcollective configured' do
     before(:all) {
       setup_puppet_on default, :mcollective => true, :agent => true
-      pp = "file { '#{master.puppet['codedir']}/environments/production/manifests/site.pp': ensure => file, content => 'class { \"puppet_agent\": }' }"
+      pp = "file { '#{master.puppet['codedir']}/environments/production/manifests/site.pp': ensure => file, content => 'class { \"puppet_agent\": service_names => [\"mcollective\"] }' }"
       apply_manifest_on(master, pp, :catch_failures => true)
     }
     after (:all) {
@@ -137,11 +132,6 @@ describe 'puppet_agent class' do
 
     describe package('puppet-agent') do
       it { is_expected.to be_installed }
-    end
-
-    describe service('puppet') do
-      it { is_expected.to be_enabled }
-      it { is_expected.to be_running }
     end
 
     describe service('mcollective') do


### PR DESCRIPTION
### (PUP-4478) Fix apt refreshes on Ubuntu
The module requires that apt update before installing the package.
Class level dependencies don't seem to enforce that, so add an explicit
sentinel to force the apt_update exec to run before finishing the repo
setup.
### (maint) Skip testing service start on agent runs
In some cases having the `puppet` service running when trying to run
`puppet agent` manually to verify idempotency results in an error, because
the service has also started an agent run at the same time.

`puppet apply` tests that the service is started after upgrade. Disable
starting the `puppet` service during agent runs to avoid the race
condition.