### PR TITLE
(PE-10132) Add PE support for SLES 12, Debian, RedHat platforms

### DIFF
--- a/lib/puppet/parser/functions/uri_host_from_string.rb
+++ b/lib/puppet/parser/functions/uri_host_from_string.rb
@@ -1,0 +1,14 @@
+require 'uri'
+
+module Puppet::Parser::Functions
+  newfunction(:uri_host_from_string, :arity => 1, :type => :rvalue, :doc => <<-EOS
+  Return a uri host from a string
+  EOS
+  ) do |args|
+
+    uri = URI(args[0])
+
+    return uri.host
+  end
+end
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,6 +15,7 @@
 #
 class puppet_agent (
   $arch          = $::architecture,
+  $is_pe         = $::puppet_agent::params::_is_pe,
   $package_name  = $::puppet_agent::params::package_name,
   $service_names = $::puppet_agent::params::service_names,
   $source        = $::puppet_agent::params::_source,

--- a/manifests/osfamily/debian.pp
+++ b/manifests/osfamily/debian.pp
@@ -3,8 +3,14 @@ class puppet_agent::osfamily::debian {
 
   include apt
 
+  $source = $::puppet_agent::source ? {
+    undef   => 'http://apt.puppetlabs.com',
+    default => $::puppet_agent::source,
+  }
+
+
   apt::source { 'pc1_repo':
-    location   => 'http://apt.puppetlabs.com',
+    location   => $source,
     repos      => 'PC1',
     key        => {
       'id'     => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',

--- a/manifests/osfamily/debian.pp
+++ b/manifests/osfamily/debian.pp
@@ -3,7 +3,7 @@ class puppet_agent::osfamily::debian {
 
   include apt
 
-  if $::is_pe {
+  if $::puppet_agent::is_pe {
     $pe_server_version = pe_build_version()
     $source = "${::puppet_agent::source}/${pe_server_version}/${::platform_tag}"
     $source_host = uri_host_from_string($source)

--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -8,6 +8,11 @@ class puppet_agent::osfamily::redhat {
     $urlbit = 'el/$releasever'
   }
 
+  $source = $::puppet_agent::source ? {
+    undef   => "https://yum.puppetlabs.com/${urlbit}/PC1/${::architecture}",
+    default => $::puppet_agent::source,
+  }
+
   $keyname = 'RPM-GPG-KEY-puppetlabs'
   $gpg_path = "/etc/pki/rpm-gpg/${keyname}"
 
@@ -33,7 +38,7 @@ class puppet_agent::osfamily::redhat {
   }
 
   yumrepo { 'pc1_repo':
-    baseurl  => "https://yum.puppetlabs.com/${urlbit}/PC1/${::architecture}",
+    baseurl  => $source,
     descr    => "Puppet Labs PC1 Repository",
     enabled  => true,
     gpgcheck => '1',

--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -8,7 +8,7 @@ class puppet_agent::osfamily::redhat {
     $urlbit = 'el/$releasever'
   }
 
-  if $::is_pe {
+  if $::puppet_agent::is_pe {
     # If this is PE, we're using a self signed certificate, so need to disable SSL verification
     $sslverify = 'False'
     $pe_server_version = pe_build_version()

--- a/manifests/osfamily/suse.pp
+++ b/manifests/osfamily/suse.pp
@@ -1,0 +1,66 @@
+class puppet_agent::osfamily::suse {
+  if $::operatingsystem != 'SLES' or $::puppet_agent::is_pe == false {
+    fail("${::operatingsystem} not supported")
+  }
+
+  case $::operatingsystemmajrelease {
+    '12': {
+      # Import the GPG key
+      $keyname = 'RPM-GPG-KEY-puppetlabs'
+      $gpg_path = "/etc/pki/rpm-gpg/${keyname}"
+
+      file { ['/etc/pki', '/etc/pki/rpm-gpg']:
+        ensure => directory,
+      }
+
+      file { $gpg_path:
+        ensure => present,
+        owner  => 0,
+        group  => 0,
+        mode   => '0644',
+        source => "puppet:///modules/puppet_agent/${keyname}",
+      }
+
+      # Given the path to a key, see if it is imported, if not, import it
+      exec {  "import-${keyname}":
+        path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+        command   => "rpm --import ${gpg_path}",
+        unless    => "rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < ${gpg_path}) | cut --characters=11-18 | tr [A-Z] [a-z]`",
+        require   => File[$gpg_path],
+        logoutput => 'on_failure',
+      }
+
+
+      # Set up a zypper repository by creating a .repo file which mimics a ini file
+      $pe_server_version = pe_build_version()
+      $source = "${::puppet_agent::source}/${pe_server_version}/${::platform_tag}"
+
+      $repo_file = '/etc/zypp/repos.d/pc1_repo.repo'
+      $repo_name = 'pc1_repo'
+
+      # In Puppet Enterprise, agent packages are served by the same server
+      # as the master, which can be using either a self signed CA, or an external CA.
+      # Zypper has issues with validating a self signed CA, so for now disable ssl verification.
+      $repo_settings = {
+        'name'        => $repo_name,
+        'enabled'     => '1',
+        'autorefresh' => '0',
+        'baseurl'     => "${source}?ssl_verify=no",
+        'type'        => 'rpm-md',
+      }
+
+      $repo_settings.each |String $setting, String $value| {
+        ini_setting { "zypper ${repo_name} ${setting}":
+          ensure  => present,
+          path    => $repo_file,
+          section => $repo_name,
+          setting => $setting,
+          value   => $value,
+        }
+      }
+    }
+    default: {
+      fail("${::operatingsystem} ${::operatingsystemmajrelease} not supported")
+    }
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,10 +5,18 @@
 #
 class puppet_agent::params {
 
-  # Need to determine if we are going to use cgi and patterns will continue to match
-  # https://puppetlabs.com/misc/pe-files prior to setting, also package installs work
-  # some distros so it will not be needed
-  $_source = undef
+  # If this is PE, by default the packages are kept on the master,
+  # However if they are in a large environment with compile masters,
+  # they may have the packages on a different server.
+  if $::is_pe {
+    # The repo structure on the PE master is the following:
+    # https://server:8140/packages/pe_version/os-os_version-os_arch
+    # https://server:8140/packages/3.8.0/el-7-x86_64
+    $_source = "https://${::servername}:8140/packages"
+  }
+  else {
+    $_source = undef
+  }
 
   case $::osfamily {
     'RedHat', 'Amazon', 'Debian': {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,7 +19,7 @@ class puppet_agent::params {
   }
 
   case $::osfamily {
-    'RedHat', 'Amazon', 'Debian': {
+    'RedHat', 'Amazon', 'Debian', 'Suse': {
       $package_name = 'puppet-agent'
       $service_names = ['puppet', 'mcollective']
 

--- a/metadata.json
+++ b/metadata.json
@@ -38,6 +38,12 @@
         "14.04",
         "14.10"
       ]
+    },
+    {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "12"
+      ]
     }
   ],
   "dependencies": [

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -1,49 +1,69 @@
 require 'spec_helper'
 
 describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >= "4.0.0" do
-  let(:facts) {{
+  facts = {
     :lsbdistid => 'Debian',
     :osfamily => 'Debian',
     :lsbdistcodename => 'wheezy',
     :operatingsystem => 'Debian',
     :architecture => 'x64',
-    :puppet_ssldir   => '/dev/null/ssl',
-    :puppet_config   => '/dev/null/puppet.conf',
-    :puppet_sslpaths => {
-      'privatedir'    => {
-        'path'   => '/dev/null/ssl/private',
-        'path_exists' => true,
-      },
-      'privatekeydir' => {
-        'path'   => '/dev/null/ssl/private_keys',
-        'path_exists' => true,
-      },
-      'publickeydir'  => {
-        'path'   => '/dev/null/ssl/public_keys',
-        'path_exists' => true,
-      },
-      'certdir'       => {
-        'path'   => '/dev/null/ssl/certs',
-        'path_exists' => true,
-      },
-      'requestdir'    => {
-        'path'   => '/dev/null/ssl/certificate_requests',
-        'path_exists' => true,
-      },
-      'hostcrl'       => {
-        'path'   => '/dev/null/ssl/crl.pem',
-        'path_exists' => true,
-      },}
-  }}
+      :servername   => 'master.example.vm',
+      :clientcert   => 'foo.example.vm',
+  }
+
+  let(:facts) { facts }
 
   it { is_expected.to contain_class('apt') }
 
-  it { is_expected.to contain_apt__source('pc1_repo').with({
-    'location' => 'http://apt.puppetlabs.com',
-    'repos'    => 'PC1',
-    'key'      => {
-      'id'     => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
-      'server' => 'pgp.mit.edu',
-    },
-  }) }
+  context 'when PE' do
+    before(:each) do
+      # Need to mock the function pe_build_version
+      pe_build_version = {}
+
+      Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) {
+        |args| pe_build_version.call()
+      }
+
+      pe_build_version.stubs(:call).returns('4.0.0')
+    end
+
+    let(:facts) {
+      facts.merge({
+        :is_pe        => true,
+        :platform_tag => 'debian-7-x86_64',
+      })
+    }
+
+    apt_settings = [
+      "Acquire::https::master.example.vm::CaInfo \"/etc/puppetlabs/puppet/ssl/certs/ca.pem\";",
+      "Acquire::https::master.example.vm::SslCert \"/etc/puppetlabs/puppet/ssl/certs/foo.example.vm.pem\";",
+      "Acquire::https::master.example.vm::SslKey \"/etc/puppetlabs/puppet/ssl/private_keys/foo.example.vm.pem\";",
+      "Acquire::http:::proxy::master.example.vm DIRECT;",
+    ]
+    it { is_expected.to contain_apt__setting('conf-pc1_repo').with({
+      'priority' => 90,
+      'content'  => apt_settings.join(''),
+    }) }
+
+    it { is_expected.to contain_apt__source('pc1_repo').with({
+      'location' => 'https://master.example.vm:8140/packages/4.0.0/debian-7-x86_64',
+      'repos'    => 'PC1',
+      'key'      => {
+        'id'     => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
+        'server' => 'pgp.mit.edu',
+      },
+    }) }
+
+  end
+
+  context 'when FOSS' do
+    it { is_expected.to contain_apt__source('pc1_repo').with({
+      'location' => 'http://apt.puppetlabs.com',
+      'repos'    => 'PC1',
+      'key'      => {
+        'id'     => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
+        'server' => 'pgp.mit.edu',
+      },
+    }) }
+  end
 end

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+describe 'puppet_agent::osfamily::suse' do
+  before(:each) do
+    # Need to mock the function pe_build_version
+    pe_build_version = {}
+
+    Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) {
+      |args| pe_build_version.call()
+    }
+
+    pe_build_version.stubs(:call).returns('4.0.0')
+  end
+
+  facts = {
+    :is_pe                     => true,
+    :osfamily                  => 'Suse',
+    :operatingsystem           => 'SLES',
+    :operatingsystemmajrelease => '12',
+  }
+
+  describe 'not supported' do
+    context 'when not PE' do
+      let(:facts) do
+        facts.merge({
+          :is_pe => false,
+        })
+      end
+
+      it { should compile.and_raise_error(/SLES not supported/) }
+    end
+
+    context 'when not SLES' do
+      let(:facts) do
+        facts.merge({
+          :is_pe           => false,
+          :operatingsystem => 'OpenSuse',
+        })
+      end
+
+      it { should compile.and_raise_error(/OpenSuse not supported/) }
+    end
+
+    context "when operatingsystemmajrelease is not supported" do
+      ['10', '11'].each do |os_version|
+        context "when SLES #{os_version}" do
+          let(:facts) do
+            facts.merge({
+              :is_pe                     => true,
+              :osfamily                  => 'Suse',
+              :operatingsystem           => 'SLES',
+              :operatingsystemmajrelease => os_version
+            })
+          end
+
+          it { should compile.and_raise_error(/SLES #{os_version} not supported/) }
+        end
+      end
+    end
+  end
+
+  describe 'supported' do
+    context "when operatingsystemmajrelease is supported" do
+      ['12'].each do |os_version|
+        context "when SLES #{os_version}" do
+          let(:facts) do
+            facts.merge({
+              :operatingsystemmajrelease => os_version,
+              :platform_tag              => "sles-#{os_version}-x86_64",
+            })
+          end
+
+          it { is_expected.to contain_exec('import-RPM-GPG-KEY-puppetlabs').with({
+            'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
+            'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
+            'unless'    => 'rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs) | cut --characters=11-18 | tr [A-Z] [a-z]`',
+            'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs]',
+            'logoutput' => 'on_failure',
+          }) }
+
+          ['/etc/pki', '/etc/pki/rpm-gpg'].each do |path|
+            it { is_expected.to contain_file(path).with({
+              'ensure' => 'directory',
+            }) }
+          end
+
+          it { is_expected.to contain_file('/etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs').with({
+            'ensure' => 'present',
+            'owner'  => '0',
+            'group'  => '0',
+            'mode'   => '0644',
+            'source' => 'puppet:///modules/puppet_agent/RPM-GPG-KEY-puppetlabs',
+          }) }
+
+          {
+            'name'        => 'pc1_repo',
+            'enabled'      => '1',
+            'autorefresh' => '0',
+            'baseurl'     => "/4.0.0/sles-#{os_version}-x86_64?ssl_verify=no",
+            'type'        => 'rpm-md',
+          }.each do |setting, value|
+              it { is_expected.to contain_ini_setting("zypper pc1_repo #{setting}").with({
+                'path'    => '/etc/zypp/repos.d/pc1_repo.repo',
+                'section' => 'pc1_repo',
+                'setting' => setting,
+                'value'   => value,
+              }) }
+            end
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'puppet_agent::osfamily::suse' do
+describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >= "4.0.0" do
   before(:each) do
     # Need to mock the function pe_build_version
     pe_build_version = {}
@@ -17,9 +17,12 @@ describe 'puppet_agent::osfamily::suse' do
     :osfamily                  => 'Suse',
     :operatingsystem           => 'SLES',
     :operatingsystemmajrelease => '12',
+    :architecture              => 'x64',
+    :servername                => 'master.example.vm',
+    :clientcert                => 'foo.example.vm',
   }
 
-  describe 'not supported' do
+  describe 'unsupported environment' do
     context 'when not PE' do
       let(:facts) do
         facts.merge({
@@ -59,7 +62,7 @@ describe 'puppet_agent::osfamily::suse' do
     end
   end
 
-  describe 'supported' do
+  describe 'supported environment' do
     context "when operatingsystemmajrelease is supported" do
       ['12'].each do |os_version|
         context "when SLES #{os_version}" do
@@ -96,7 +99,7 @@ describe 'puppet_agent::osfamily::suse' do
             'name'        => 'pc1_repo',
             'enabled'      => '1',
             'autorefresh' => '0',
-            'baseurl'     => "/4.0.0/sles-#{os_version}-x86_64?ssl_verify=no",
+            'baseurl'     => "https://master.example.vm:8140/packages/4.0.0/sles-#{os_version}-x86_64?ssl_verify=no",
             'type'        => 'rpm-md',
           }.each do |setting, value|
               it { is_expected.to contain_ini_setting("zypper pc1_repo #{setting}").with({

--- a/spec/classes/puppet_agent_prepare_spec.rb
+++ b/spec/classes/puppet_agent_prepare_spec.rb
@@ -14,36 +14,8 @@ describe 'puppet_agent::prepare' do
         :osfamily => osfamily,
         :lsbdistid => osfamily,
         :lsbdistcodename => 'baz',
-        :puppet_ssldir => '/dev/null/ssl',
-        :puppet_config => '/dev/null/puppet.conf',
         :mco_server_config => nil,
         :mco_client_config => nil,
-        :puppet_sslpaths => {
-          'privatedir'    => {
-            'path'   => '/dev/null/ssl/private',
-            'path_exists' => true,
-          },
-          'privatekeydir' => {
-            'path'   => '/dev/null/ssl/private_keys',
-            'path_exists' => true,
-          },
-          'publickeydir'  => {
-            'path'   => '/dev/null/ssl/public_keys',
-            'path_exists' => true,
-          },
-          'certdir'       => {
-            'path'   => '/dev/null/ssl/certs',
-            'path_exists' => true,
-          },
-          'requestdir'    => {
-            'path'   => '/dev/null/ssl/certificate_requests',
-            'path_exists' => true,
-          },
-          'hostcrl'       => {
-            'path'   => '/dev/null/ssl/crl.pem',
-            'path_exists' => true,
-          },
-        },
       }
 
       context "on #{osfamily}" do

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -4,38 +4,7 @@ describe 'puppet_agent' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
-        let(:facts) do
-          facts.merge({
-            :puppet_ssldir   => '/dev/null/ssl',
-            :puppet_config   => '/dev/null/puppet.conf',
-            :puppet_sslpaths => {
-              'privatedir'    => {
-                'path'   => '/dev/null/ssl/private',
-                'path_exists' => true,
-              },
-              'privatekeydir' => {
-                'path'   => '/dev/null/ssl/private_keys',
-                'path_exists' => true,
-              },
-              'publickeydir'  => {
-                'path'   => '/dev/null/ssl/public_keys',
-                'path_exists' => true,
-              },
-              'certdir'       => {
-                'path'   => '/dev/null/ssl/certs',
-                'path_exists' => true,
-              },
-              'requestdir'    => {
-                'path'   => '/dev/null/ssl/certificate_requests',
-                'path_exists' => true,
-              },
-              'hostcrl'       => {
-                'path'   => '/dev/null/ssl/crl.pem',
-                'path_exists' => true,
-              },
-            },
-          })
-        end
+        let(:facts) { facts }
 
         if Puppet.version < "3.8.0"
           it { expect { is_expected.to contain_package('puppet_agent') }.to raise_error(Puppet::Error, /upgrading requires Puppet 3.8/) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,37 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'rspec-puppet-facts'
 include RspecPuppetFacts
+
+
+RSpec.configure do |c|
+  c.default_facts = {
+    :puppet_ssldir   => '/dev/null/ssl',
+    :puppet_config   => '/dev/null/puppet.conf',
+    :puppet_sslpaths => {
+      'privatedir'    => {
+        'path'   => '/dev/null/ssl/private',
+        'path_exists' => true,
+      },
+      'privatekeydir' => {
+        'path'   => '/dev/null/ssl/private_keys',
+        'path_exists' => true,
+      },
+      'publickeydir'  => {
+        'path'   => '/dev/null/ssl/public_keys',
+        'path_exists' => true,
+      },
+      'certdir'       => {
+        'path'   => '/dev/null/ssl/certs',
+        'path_exists' => true,
+      },
+      'requestdir'    => {
+        'path'   => '/dev/null/ssl/certificate_requests',
+        'path_exists' => true,
+      },
+      'hostcrl'       => {
+        'path'   => '/dev/null/ssl/crl.pem',
+        'path_exists' => true,
+      },
+    },
+  }
+end


### PR DESCRIPTION
This PR adds support for upgrading PE agents from 3.8 to 4.0.

Changes include:
* Passing the `source` parameter through to RedHat and Debian platforms
* Using the PE Masters repositories instead of FOSS for Debian and RedHat

TODO:
Update Windows source
Add support for following platforms:
SLES 10-11 (Zypper)
OSX