### PR TITLE
(PE-10132) Remove old PE 3.8 repo

### DIFF
--- a/manifests/osfamily/debian.pp
+++ b/manifests/osfamily/debian.pp
@@ -32,6 +32,22 @@ class puppet_agent::osfamily::debian {
       content  => $_apt_settings.join(''),
       priority => 90,
     }
+
+    # Due to the file paths changing on the PE Master, the 3.8 repository is no longer valid.
+    # On upgrade, remove the repo file so that a dangling reference is not left behind returning
+    # a 404 on subsequent runs.
+
+    # Pass in an empty content string since apt requires it even though we are removing it
+    apt::setting {'list-puppet-enterprise-installer':
+      ensure  => absent,
+      content => '',
+    }
+
+    apt::setting { 'conf-pe-repo':
+      ensure   => absent,
+      priority => '90',
+      content  => '',
+    }
   }
   else {
     $source = $::puppet_agent::source ? {

--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -23,6 +23,13 @@ class puppet_agent::osfamily::redhat {
 
     $pe_server_version = pe_build_version()
     $source = "${::puppet_agent::source}/${pe_server_version}/${::platform_tag}"
+
+    # Due to the file paths changing on the PE Master, the 3.8 repository is no longer valid.
+    # On upgrade, remove the repo file so that a dangling reference is not left behind returning
+    # a 404 on subsequent runs.
+    yumrepo { 'puppetlabs-pepackages':
+      ensure => absent,
+    }
   }
   else {
     $source = $::puppet_agent::source ? {

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -34,6 +34,17 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
       })
     }
 
+    it { is_expected.to contain_apt__setting('conf-pe-repo').with({
+      'priority' => 90,
+      'content'  => '',
+      'ensure'   => 'absent',
+    }) }
+
+    it { is_expected.to contain_apt__setting('list-puppet-enterprise-installer').with({
+      'content'  => '',
+      'ensure'   => 'absent',
+    }) }
+
     apt_settings = [
       "Acquire::https::master.example.vm::CaInfo \"/etc/puppetlabs/puppet/ssl/certs/ca.pem\";",
       "Acquire::https::master.example.vm::SslCert \"/etc/puppetlabs/puppet/ssl/certs/foo.example.vm.pem\";",
@@ -57,6 +68,9 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
   end
 
   context 'when FOSS' do
+    it { is_expected.not_to contain_apt__setting('conf-pe-repo') }
+    it { is_expected.not_to contain_apt__setting('list-puppet-enterprise-installer') }
+
     it { is_expected.to contain_apt__source('pc1_repo').with({
       'location' => 'http://apt.puppetlabs.com',
       'repos'    => 'PC1',

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -36,6 +36,7 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
       }) }
 
       context 'when FOSS' do
+        it { is_expected.not_to contain_yumrepo('puppetlabs-pepackages').with_ensure('absent') }
         it { is_expected.to contain_yumrepo('pc1_repo').with({
           'baseurl' => "https://yum.puppetlabs.com/#{urlbit}/PC1/x64",
           'enabled' => 'true',
@@ -62,6 +63,8 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
             :platform_tag => 'el-7-x86_64',
           })
         }
+
+        it { is_expected.to contain_yumrepo('puppetlabs-pepackages').with_ensure('absent') }
 
         it { is_expected.to contain_yumrepo('pc1_repo').with({
           'baseurl' => "https://master.example.vm:8140/packages/4.0.0/el-7-x86_64",


### PR DESCRIPTION
Previous to this commit, for PE users upgrading that had originally
installed via the simplified installer, the old repo definition was left
around pointing to a file path on the master that no longer exists due
to file path changes.