### PR TITLE
(PUP-4808) Remove Ubuntu 14.10 support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -89,7 +89,7 @@ This module supports:
 * RHEL 5, 6, 7
 * Centos 5, 6, 7
 * Debian 6, 7
-* Ubuntu 12.04, 14.04, 14.10
+* Ubuntu 12.04, 14.04
 * Windows Server 2003 or later
 
 ###Known issues

--- a/metadata.json
+++ b/metadata.json
@@ -35,8 +35,7 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "12.04",
-        "14.04",
-        "14.10"
+        "14.04"
       ]
     },
     {


### PR DESCRIPTION
Ubuntu 14.10 never saw a Puppet 3.x package release, so this module has
no useful functionality on that platform. Remove the mention about
supporting it.