### PR TITLE
(PUP-4886) Clear settings at global level

### DIFF
--- a/manifests/prepare/puppet_config.pp
+++ b/manifests/prepare/puppet_config.pp
@@ -12,7 +12,7 @@ class puppet_agent::prepare::puppet_config {
   }
 
 # manage puppet.conf contents, using inifile module
-  ['master', 'agent', 'main'].each |$loop_section| {
+  ['', 'master', 'agent', 'main'].each |$loop_section| {
     $section = $loop_section
     [# Removed settings
       'allow_variables_with_dashes', 'async_storeconfigs', 'binder', 'catalog_format', 'certdnsnames',

--- a/spec/classes/puppet_agent_prepare_spec.rb
+++ b/spec/classes/puppet_agent_prepare_spec.rb
@@ -134,7 +134,7 @@ describe 'puppet_agent::prepare' do
           'backup' => 'false',
         }) }
 
-        ['agent', 'main', 'master'].each do |section|
+        ['', 'agent', 'main', 'master'].each do |section|
           ['allow_variables_with_dashes',
            'async_storeconfigs',
            'binder',


### PR DESCRIPTION
Without this change, settings at the global level in puppet.conf
(outside a section) would not be cleared, and get inheritted by each
section. This would lead to incorrect configurations.

Also clear settings at the global level.