### PR TITLE
Remove classfile puppet.conf setting, update for PE windows

### DIFF
--- a/manifests/prepare/puppet_config.pp
+++ b/manifests/prepare/puppet_config.pp
@@ -26,7 +26,7 @@ class puppet_agent::prepare::puppet_config {
       # Deprecated for global config
       'config_version', 'manifest', 'modulepath',
       # Settings that should be reset to defaults
-      'disable_warnings', 'vardir', 'rundir', 'libdir', 'confdir', 'ssldir'].each |$setting| {
+      'disable_warnings', 'vardir', 'rundir', 'libdir', 'confdir', 'ssldir', 'classfile'].each |$setting| {
       ini_setting { "${section}/${setting}":
         ensure  => absent,
         section => $section,

--- a/manifests/windows/install.pp
+++ b/manifests/windows/install.pp
@@ -12,8 +12,17 @@ class puppet_agent::windows::install {
     default   => $::puppet_agent::arch
   }
 
+  if $::puppet_agent::is_pe {
+    $_agent_version = chomp(file('/opt/puppetlabs/puppet/VERSION'))
+    $_pe_server_version = pe_build_version()
+    $_https_source = "https://pm.puppetlabs.com/puppet-agent/${_pe_server_version}/${_agent_version}/repos/windows/puppet-agent-${_arch}.msi"
+  }
+  else {
+    $_https_source = "https://downloads.puppetlabs.com/windows/puppet-agent-${_arch}-latest.msi"
+  }
+
   $_source = $::puppet_agent::source ? {
-    undef          => "https://downloads.puppetlabs.com/windows/puppet-agent-${_arch}-latest.msi",
+    undef          => $_https_source,
     /^[a-zA-Z]:/ => windows_native_path($::puppet_agent::source),
     default        => $::puppet_agent::source,
   }

--- a/spec/classes/puppet_agent_prepare_spec.rb
+++ b/spec/classes/puppet_agent_prepare_spec.rb
@@ -194,7 +194,8 @@ describe 'puppet_agent::prepare' do
            'vardir',
            'rundir',
            'libdir',
-           'confdir'].each do |setting|
+           'confdir',
+           'classfile'].each do |setting|
              it { is_expected.to contain_ini_setting("#{section}/#{setting}").with_ensure('absent') }
            end
         end


### PR DESCRIPTION
This PR contains two fixes for PE users:

The first is reseting the `classfile` puppet.conf setting for mco inventory. The second is specifying the agent version to that of the compiling master instead of latest.