### PR TITLE
(PUP-4925) Label a known issue with Server 2003

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -108,9 +108,9 @@ This module supports:
 In addition, there are several known issues with Windows:
 
 * To upgrade the agent by executing `puppet agent -t` interactively in a console, you must close the console and wait for the upgrade to finish before attempting to use the `puppet` command again.
-* MSI installation failures do not produce any error. If the install fails, puppet_agent continues to be applied to the agent.
-   If this happens, you'll need to examine the MSI log file to determine the failure's cause. You can find the location of the log file in the debug output from either a puppet apply or an agent run; the log file name follows the pattern `puppet-<timestamp>-installer.log`.
-   * On Windows Server 2003, only x86 is supported, and the `arch` parameter is ignored. If you try to force an upgrade to x64, Puppet installs the x86 version with no error message.
+* MSI installation failures do not produce any error. If the install fails, puppet_agent continues to be applied to the agent. If this happens, you'll need to examine the MSI log file to determine the failure's cause. You can find the location of the log file in the debug output from either a puppet apply or an agent run; the log file name follows the pattern `puppet-<timestamp>-installer.log`.
+* On Windows Server 2003, only x86 is supported, and the `arch` parameter is ignored. If you try to force an upgrade to x64, Puppet installs the x86 version with no error message.
+* On Windows Server 2003 with Puppet Enterprise, the default download location is unreachable. You can work around this issue by specifying an alternate download URL in the `source` parameter.
  
 ##Development
 


### PR DESCRIPTION
Windows Server 2003 and 2003R2 are unable to download resources from
pm.puppetlabs.com. Label this a known issue with a work-around, with
plans to address in a future release.