### PR TITLE
(PE-10915) Add SLES 10 upgrade for PE

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,8 +38,17 @@ class puppet_agent (
       class { '::puppet_agent::windows::install': }
     }
     else {
-      class { '::puppet_agent::prepare': } ->
-      class { '::puppet_agent::install': } ->
+
+      if $::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '10' {
+        $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.sles10.${::architecture}.rpm"
+      }
+
+      class { '::puppet_agent::prepare':
+        package_file_name => $_package_file_name,
+      } ->
+      class { '::puppet_agent::install':
+        package_file_name => $_package_file_name,
+      } ->
       class { '::puppet_agent::service': }
 
       contain '::puppet_agent::prepare'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,10 +2,39 @@
 #
 # This class is called from puppet_agent for install.
 #
-class puppet_agent::install {
+# === Parameters
+#
+# [package_file_name]
+#   The puppet-agent package file name.
+#   (see puppet_agent::prepare::package_file_name)
+#
+class puppet_agent::install(
+  $package_file_name = undef,
+) {
   assert_private()
+
+  if $::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '10' {
+    contain puppet_agent::install::remove_packages
+
+    exec { 'replace puppet.conf removed by package removal':
+      path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+      command   => "cp ${puppet_agent::params::confdir}/puppet.conf.rpmsave ${puppet_agent::params::config}",
+      creates   => $puppet_agent::params::config,
+      require   => Class['puppet_agent::install::remove_packages'],
+      before    => Package[$puppet_agent::package_name],
+      logoutput => 'on_failure',
+    }
+
+    $_package_options = {
+      provider        => 'rpm',
+      source          => "/opt/puppetlabs/packages/${package_file_name}",
+    }
+  } else {
+    $_package_options = {}
+  }
 
   package { $::puppet_agent::package_name:
     ensure => present,
+    *      => $_package_options,
   }
 }

--- a/manifests/install/remove_packages.pp
+++ b/manifests/install/remove_packages.pp
@@ -1,0 +1,40 @@
+# == Class puppet_agent::install::remove_packages
+#
+# This class is used in puppet_agent::install by platforms lacking a package
+# manager, where we are required to manually remove the old pe-* packages prior
+# to installing puppet-agent.
+#
+class puppet_agent::install::remove_packages {
+  assert_private()
+
+  if versioncmp("${::clientversion}", '4.0.0') < 0 {
+    # We only need to remove these packages if we are transitioning from PE
+    # versions that are pre AIO.
+    [
+      'pe-augeas',
+      'pe-mcollective-common',
+      'pe-rubygem-deep-merge',
+      'pe-mcollective',
+      'pe-puppet-enterprise-release',
+      'pe-libldap',
+      'pe-libyaml',
+      'pe-ruby-stomp',
+      'pe-ruby-augeas',
+      'pe-ruby-shadow',
+      'pe-hiera',
+      'pe-facter',
+      'pe-puppet',
+      'pe-openssl',
+      'pe-ruby',
+      'pe-ruby-rgen',
+      'pe-virt-what',
+      'pe-ruby-ldap',
+    ].each |$old_package| {
+      package { $old_package:
+        ensure            => absent,
+        uninstall_options => '--nodeps',
+        provider          => 'rpm',
+      }
+    }
+  }
+}

--- a/manifests/osfamily/debian.pp
+++ b/manifests/osfamily/debian.pp
@@ -1,4 +1,6 @@
-class puppet_agent::osfamily::debian {
+class puppet_agent::osfamily::debian(
+  $package_file_name = undef,
+) {
   assert_private()
 
   include apt

--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -1,4 +1,6 @@
-class puppet_agent::osfamily::redhat {
+class puppet_agent::osfamily::redhat(
+  $package_file_name = undef,
+) {
   assert_private()
 
   if $::operatingsystem == 'Fedora' {

--- a/manifests/osfamily/suse.pp
+++ b/manifests/osfamily/suse.pp
@@ -1,9 +1,19 @@
-class puppet_agent::osfamily::suse {
+class puppet_agent::osfamily::suse(
+  $package_file_name = undef,
+) {
+  assert_private()
+
   if $::operatingsystem != 'SLES' or $::puppet_agent::is_pe == false {
     fail("${::operatingsystem} not supported")
   }
 
   case $::operatingsystemmajrelease {
+    '10': {
+      class { 'puppet_agent::prepare::package':
+        package_file_name => $package_file_name,
+      }
+      contain puppet_agent::prepare::package
+    }
     '11', '12': {
       # Import the GPG key
       $keyname = 'RPM-GPG-KEY-puppetlabs'

--- a/manifests/osfamily/windows.pp
+++ b/manifests/osfamily/windows.pp
@@ -1,4 +1,6 @@
-class puppet_agent::osfamily::windows {
+class puppet_agent::osfamily::windows(
+  $package_file_name = undef,
+) {
   assert_private()
   # No specifics as install takes care of this
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -52,6 +52,13 @@ class puppet_agent::params {
     }
   }
 
+  # The aio puppet-agent version currently installed on the compiling master
+  # (only used in PE)
+  $master_agent_version = $_is_pe ? {
+    true    => pe_compiling_server_aio_build(),
+    default => undef,
+  }
+
   $ssldir = "${confdir}/ssl"
   $config = "${confdir}/puppet.conf"
 

--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -2,7 +2,16 @@
 #
 # This class is called from puppet_agent to prepare for the upgrade.
 #
-class puppet_agent::prepare {
+# === Parameters
+#
+# [package_file_name]
+#   The file name, with platform and version, of the puppet-agent package to be
+#   downloaded and installed.  Older systems and package managers may require
+#   us to manually download the puppet-agent package.
+#
+class puppet_agent::prepare(
+  $package_file_name = undef,
+){
   include puppet_agent::params
   $_windows_client = downcase($::osfamily) == 'windows'
   if $_windows_client {
@@ -47,7 +56,11 @@ class puppet_agent::prepare {
 
   case $::osfamily {
     'redhat', 'debian', 'windows', 'solaris', 'aix', 'suse': {
-      contain downcase("::puppet_agent::osfamily::${::osfamily}")
+      $_osfamily_class = downcase("::puppet_agent::osfamily::${::osfamily}")
+      class { $_osfamily_class:
+        package_file_name => $package_file_name
+      }
+      contain $_osfamily_class
     }
     default: {
       fail("puppet_agent not supported on ${::osfamily}")

--- a/manifests/prepare/package.pp
+++ b/manifests/prepare/package.pp
@@ -1,0 +1,33 @@
+# == Class puppet_agent::prepare::package
+#
+# The only job this class has is to ensure that the correct puppet-agent
+# package is downloaded locally for installation.  This is used on platforms
+# without package managers capable of working with a remote https repository.
+#
+# [package_file_name]
+#   The puppet-agent package file to retrieve from the master.
+#
+class puppet_agent::prepare::package(
+  $package_file_name,
+) {
+  assert_private()
+
+  # Guard this so that we do not perform expensive checksum logic on the master
+  # for the large puppet-agent file if we have already upgraded.
+  if $puppet_agent::params::master_agent_version != $::aio_agent_version {
+    $pe_server_version = pe_build_version()
+
+    $source = "puppet:///pe_packages/${pe_server_version}/${::platform_tag}/${package_file_name}"
+
+    file { ['/opt/puppetlabs', '/opt/puppetlabs/packages']:
+      ensure => directory,
+    }
+    file { "/opt/puppetlabs/packages/${package_file_name}":
+      ensure => present,
+      owner  => 0,
+      group  => 0,
+      mode   => '0644',
+      source => $source,
+    }
+  }
+}

--- a/manifests/windows/install.pp
+++ b/manifests/windows/install.pp
@@ -13,7 +13,7 @@ class puppet_agent::windows::install {
   }
 
   if $::puppet_agent::is_pe {
-    $_agent_version = chomp(file('/opt/puppetlabs/puppet/VERSION'))
+    $_agent_version = $puppet_agent::params::master_agent_version
     $_pe_server_version = pe_build_version()
     $_https_source = "https://pm.puppetlabs.com/puppet-agent/${_pe_server_version}/${_agent_version}/repos/windows/puppet-agent-${_arch}.msi"
   }

--- a/metadata.json
+++ b/metadata.json
@@ -41,6 +41,8 @@
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
+        "10",
+        "11",
         "12"
       ]
     },

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -17,14 +17,15 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
 
   context 'when PE' do
     before(:each) do
-      # Need to mock the function pe_build_version
-      pe_build_version = {}
+      # Need to mock the function PE functions
 
-      Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) {
-        |args| pe_build_version.call()
-      }
+      Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
+        '4.0.0'
+      end
 
-      pe_build_version.stubs(:call).returns('4.0.0')
+      Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
+        '1.2.5'
+      end
     end
 
     let(:facts) {

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -17,7 +17,7 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
 
   context 'when PE' do
     before(:each) do
-      # Need to mock the function PE functions
+      # Need to mock the PE functions
 
       Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
         '4.0.0'

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -47,7 +47,7 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
 
       context 'when PE' do
         before(:each) do
-          # Need to mock the function PE functions
+          # Need to mock the PE functions
 
           Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
             '4.0.0'

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -47,14 +47,15 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
 
       context 'when PE' do
         before(:each) do
-          # Need to mock the function pe_build_version
-          pe_build_version = {}
+          # Need to mock the function PE functions
 
-          Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) {
-            |args| pe_build_version.call()
-          }
+          Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
+            '4.0.0'
+          end
 
-          pe_build_version.stubs(:call).returns('4.0.0')
+          Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
+            '1.2.5'
+          end
         end
 
         let(:facts) {

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >= "4.0.0" do
   before(:each) do
-    # Need to mock the function PE functions
+    # Need to mock the PE functions
     Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
       "4.0.0"
     end
@@ -43,27 +43,65 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
 
       it { expect { catalogue }.to raise_error(/OpenSuse not supported/) }
     end
-
-    context "when operatingsystemmajrelease is not supported" do
-      ['10'].each do |os_version|
-        context "when SLES #{os_version}" do
-          let(:facts) do
-            facts.merge({
-              :is_pe                     => true,
-              :osfamily                  => 'Suse',
-              :operatingsystem           => 'SLES',
-              :operatingsystemmajrelease => os_version
-            })
-          end
-
-          it { expect { catalogue }.to raise_error(/SLES #{os_version} not supported/) }
-        end
-      end
-    end
   end
 
   describe 'supported environment' do
-    context "when operatingsystemmajrelease is supported" do
+    context "when operatingsystemmajrelease 10 is supported" do
+      let(:facts) do
+        facts.merge({
+          :operatingsystemmajrelease => '10',
+          :platform_tag              => "sles-10-x86_64",
+          :architecture              => "x86_64",
+        })
+      end
+
+      it { is_expected.to contain_file('/opt/puppetlabs') }
+      it { is_expected.to contain_file('/opt/puppetlabs/packages') }
+      it do
+        is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.sles10.x86_64.rpm').with_ensure('present')
+        is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.sles10.x86_64.rpm').with_source('puppet:///pe_packages/4.0.0/sles-10-x86_64/puppet-agent-1.2.5-1.sles10.x86_64.rpm')
+      end
+
+      [
+        'pe-augeas',
+        'pe-mcollective-common',
+        'pe-rubygem-deep-merge',
+        'pe-mcollective',
+        'pe-puppet-enterprise-release',
+        'pe-libldap',
+        'pe-libyaml',
+        'pe-ruby-stomp',
+        'pe-ruby-augeas',
+        'pe-ruby-shadow',
+        'pe-hiera',
+        'pe-facter',
+        'pe-puppet',
+        'pe-openssl',
+        'pe-ruby',
+        'pe-ruby-rgen',
+        'pe-virt-what',
+        'pe-ruby-ldap',
+      ].each do |package|
+        it do
+          is_expected.to contain_package(package).with_ensure('absent')
+          is_expected.to contain_package(package).with_uninstall_options('--nodeps')
+          is_expected.to contain_package(package).with_provider('rpm')
+        end
+      end
+
+      it do
+        is_expected.to contain_exec('replace puppet.conf removed by package removal').with_command('cp /etc/puppetlabs/puppet/puppet.conf.rpmsave /etc/puppetlabs/puppet/puppet.conf')
+        is_expected.to contain_exec('replace puppet.conf removed by package removal').with_creates('/etc/puppetlabs/puppet/puppet.conf')
+      end
+
+      it do
+        is_expected.to contain_package('puppet-agent').with_ensure('present')
+        is_expected.to contain_package('puppet-agent').with_provider('rpm')
+        is_expected.to contain_package('puppet-agent').with_source('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.sles10.x86_64.rpm')
+      end
+    end
+
+    context "when operatingsystemmajrelease 11 or 12 is supported" do
       ['11', '12'].each do |os_version|
         context "when SLES #{os_version}" do
           let(:facts) do
@@ -108,7 +146,11 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
                 'setting' => setting,
                 'value'   => value,
               }) }
-            end
+          end
+
+          it do
+            is_expected.to contain_package('puppet-agent')
+          end
         end
       end
     end

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >= "4.0.0" do
   before(:each) do
-    # Need to mock the function pe_build_version
-    pe_build_version = {}
+    # Need to mock the function PE functions
+    Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
+      "4.0.0"
+    end
 
-    Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) {
-      |args| pe_build_version.call()
-    }
-
-    pe_build_version.stubs(:call).returns('4.0.0')
+    Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
+      '1.2.5'
+    end
   end
 
   facts = {

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -30,7 +30,7 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
         })
       end
 
-      it { should compile.and_raise_error(/SLES not supported/) }
+      it { expect { catalogue }.to raise_error(/SLES not supported/) }
     end
 
     context 'when not SLES' do
@@ -41,7 +41,7 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
         })
       end
 
-      it { should compile.and_raise_error(/OpenSuse not supported/) }
+      it { expect { catalogue }.to raise_error(/OpenSuse not supported/) }
     end
 
     context "when operatingsystemmajrelease is not supported" do
@@ -56,7 +56,7 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
             })
           end
 
-          it { should compile.and_raise_error(/SLES #{os_version} not supported/) }
+          it { expect { catalogue }.to raise_error(/SLES #{os_version} not supported/) }
         end
       end
     end

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'puppet_agent', :unless => Puppet.version =~ /^(3\.7|4.\d+)\.\d+/
 
         context 'is_pe' do
           before(:each) do
-            # Need to mock the function PE functions
+            # Need to mock the PE functions
 
             Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
               '4.0.0'

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'puppet_agent', :unless => Puppet.version =~ /^(3\.7|4.\d+)\.\d+/
     {'5.1' => {:expect_arch => 'x86', :appdata => 'C:/Document and Settings/All Users/Application Data/Puppetlabs'},
      '6.1' => {:expect_arch => 'x64', :appdata => 'C:/ProgramData/Puppetlabs'}}.each do |kernelmajversion, values|
       context "Windows Kernelmajversion #{kernelmajversion}" do
-        let(:facts) { {
+        facts = {
           :architecture => 'x64',
           :env_temp_variable => 'C:\tmp',
           :kernelmajversion => kernelmajversion,
@@ -20,24 +20,25 @@ RSpec.describe 'puppet_agent', :unless => Puppet.version =~ /^(3\.7|4.\d+)\.\d+/
           :mco_confdir => "#{values[:appdata]}/mcollective/etc",
           :puppet_agent_pid => 42,
           :system32 => 'C:\windows\sysnative',
-        } }
+        }
+
+        let(:facts) { facts }
+
         context 'is_pe' do
           before(:each) do
-            # Need to mock the function pe_build_version
-            pe_build_version = {}
-            file = {}
+            # Need to mock the function PE functions
 
-            Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) {
-              |args| pe_build_version.call()
-            }
-            Puppet::Parser::Functions.newfunction(:file, :type => :rvalue) {
-              |args| file.call(args[0])
-            }
+            Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
+              '4.0.0'
+            end
 
-            pe_build_version.stubs(:call).returns('4.0.0')
-            file.stubs(:call).with('/opt/puppetlabs/puppet/VERSION').returns('1.2.1.1')
+            Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
+              '1.2.1.1'
+            end
           end
-          let(:params) {{ :is_pe => true }}
+
+          let(:facts) { facts.merge({:is_pe => true}) }
+
           it {
             is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
               %r[#{Regexp.escape("msiexec.exe /qn /norestart /i \"https://pm.puppetlabs.com/puppet-agent/4.0.0/1.2.1.1/repos/windows/puppet-agent-#{values[:expect_arch]}.msi\"")}])


### PR DESCRIPTION
Introduces support for upgrading SLES 10 agents in PE. SLES 10 does not
have tools for securely handling remote package management.

* puppet-agent package is downloaded from a pe_packages fileserver mount
prepared separately on the master (in puppet_enterprise module)
* the package is downloaded with a File resource, but only if agent node
is not already at the current aio version
* because of limitations in the rpm package provider, it is not feasible
to get the install of the new puppet-agent package to run with '-U
--replacepkgs' flags that would allow rpm to correctly uninstall
conflicting superseded pe-* packages, so we remove those prior to
install. (Passing '-U --replacepkgs' in install_options parameter ends
up failing:

Error: Execution of '/bin/rpm -i "-U --replacepkgs"
/opt/puppetlabs/packages/puppet-agent-1.2.5-1.sles10.x86_64.rpm'
returned 1: -U --replacepkgs: not an rpm package (or package manifest)

* I'm threading package_file_name parameter through because it varies by
platform and ends up being needed both in the prepare and the install
phase for these special case platforms.
