### PR TITLE
Issue/master/pe 10914 add osx 109 upgrade

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,10 @@ class puppet_agent (
         $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.sles10.${::architecture}.rpm"
       } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '10' {
         $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.i386.pkg.gz"
+      } elsif $::operatingsystem == 'Darwin' and $::macosx_productversion_major == '10.9' {
+        $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.osx10.9.dmg"
+      } else {
+        $_package_file_name = undef
       }
 
       class { '::puppet_agent::prepare':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -38,6 +38,13 @@ class puppet_agent::install(
       source    => "/opt/puppetlabs/packages/${_unzipped_package_name}",
       require   => Class['puppet_agent::install::remove_packages'],
     }
+  } elsif $::operatingsystem == 'Darwin' and $::macosx_productversion_major == '10.9' {
+    contain puppet_agent::install::remove_packages
+
+    $_package_options = {
+      source    => "/opt/puppetlabs/packages/${package_file_name}",
+      require   => Class['puppet_agent::install::remove_packages'],
+    }
   } else {
     $_package_options = {}
   }

--- a/manifests/install/remove_packages.pp
+++ b/manifests/install/remove_packages.pp
@@ -9,63 +9,70 @@ class puppet_agent::install::remove_packages {
 
   if versioncmp("${::clientversion}", '4.0.0') < 0 {
 
-    $package_options = $::operatingsystem ? {
-      'SLES'  => {
-        uninstall_options => '--nodeps',
-        provider          => 'rpm',
-      },
-      'Solaris' => {
-        adminfile => '/opt/puppetlabs/packages/solaris-noask',
-      },
-      default => {
+    if $::operatingsystem == 'Darwin' {
+
+      contain '::puppet_agent::install::remove_packages_osx'
+
+    } else {
+
+      $package_options = $::operatingsystem ? {
+        'SLES'  => {
+          uninstall_options => '--nodeps',
+          provider          => 'rpm',
+        },
+        'Solaris' => {
+          adminfile => '/opt/puppetlabs/packages/solaris-noask',
+        },
+        default => {
+        }
       }
-    }
 
-    $packages = $::operatingsystem ? {
-      'Solaris' => [
-        'PUPpuppet',
-        'PUPaugeas',
-        'PUPdeep-merge',
-        'PUPfacter',
-        'PUPhiera',
-        'PUPlibyaml',
-        'PUPmcollective',
-        'PUPopenssl',
-        'PUPpuppet-enterprise-release',
-        'PUPruby',
-        'PUPruby-augeas',
-        'PUPruby-rgen',
-        'PUPruby-shadow',
-        'PUPstomp',
-      ],
-      default => [
-        'pe-augeas',
-        'pe-mcollective-common',
-        'pe-rubygem-deep-merge',
-        'pe-mcollective',
-        'pe-puppet-enterprise-release',
-        'pe-libldap',
-        'pe-libyaml',
-        'pe-ruby-stomp',
-        'pe-ruby-augeas',
-        'pe-ruby-shadow',
-        'pe-hiera',
-        'pe-facter',
-        'pe-puppet',
-        'pe-openssl',
-        'pe-ruby',
-        'pe-ruby-rgen',
-        'pe-virt-what',
-        'pe-ruby-ldap',
-      ]
-    }
+      $packages = $::operatingsystem ? {
+        'Solaris' => [
+          'PUPpuppet',
+          'PUPaugeas',
+          'PUPdeep-merge',
+          'PUPfacter',
+          'PUPhiera',
+          'PUPlibyaml',
+          'PUPmcollective',
+          'PUPopenssl',
+          'PUPpuppet-enterprise-release',
+          'PUPruby',
+          'PUPruby-augeas',
+          'PUPruby-rgen',
+          'PUPruby-shadow',
+          'PUPstomp',
+        ],
+        default => [
+          'pe-augeas',
+          'pe-mcollective-common',
+          'pe-rubygem-deep-merge',
+          'pe-mcollective',
+          'pe-puppet-enterprise-release',
+          'pe-libldap',
+          'pe-libyaml',
+          'pe-ruby-stomp',
+          'pe-ruby-augeas',
+          'pe-ruby-shadow',
+          'pe-hiera',
+          'pe-facter',
+          'pe-puppet',
+          'pe-openssl',
+          'pe-ruby',
+          'pe-ruby-rgen',
+          'pe-virt-what',
+          'pe-ruby-ldap',
+        ]
+      }
 
-    # We only need to remove these packages if we are transitioning from PE
-    # versions that are pre AIO.
-    $packages.each |$old_package| {
-      package { $old_package:
-        ensure => absent,
-        *      => $package_options,
+      # We only need to remove these packages if we are transitioning from PE
+      # versions that are pre AIO.
+      $packages.each |$old_package| {
+        package { $old_package:
+          ensure => absent,
+          *      => $package_options,
+        }
       }
     }
   }

--- a/manifests/install/remove_packages_osx.pp
+++ b/manifests/install/remove_packages_osx.pp
@@ -1,0 +1,60 @@
+# == Class puppet_agent::install::remove_packages_osx
+#
+# Sadly, special handling is required to clear up puppet_enterprise installation
+# on 3.8.
+#
+class puppet_agent::install::remove_packages_osx {
+  assert_private()
+
+  if $::puppet_agent::is_pe {
+    # shutdown services
+    service { 'pe-puppet':
+      ensure => stopped,
+    }->
+    service { 'pe-mcollective':
+      ensure => stopped,
+    }->
+
+    # remove old users and groups
+    user { 'pe-puppet':
+      ensure => absent,
+    }->
+    user { 'pe-mcollective':
+      ensure => absent,
+    }->
+
+    # remove old /opt/puppet files
+    file { '/opt/puppet':
+      ensure => absent,
+      force  => true,
+      backup => false,
+    }
+    # Can't delete /var/opt/lib/pe-puppet or we get errors because
+    # /var/opt/lib/pe-puppet/state is missing when puppet run tries to save
+    # report
+
+    # forget packages
+    [
+      'pe-augeas',
+      'pe-ruby-augeas',
+      'pe-openssl',
+      'pe-ruby',
+      'pe-cfpropertylist',
+      'pe-facter',
+      'pe-puppet',
+      'pe-mcollective',
+      'pe-hiera',
+      'pe-puppet-enterprise-release',
+      'pe-stomp',
+      'pe-libyaml',
+      'pe-ruby-rgen',
+      'pe-deep-merge',
+      'pe-ruby-shadow',
+    ].each |$package| {
+      exec { "forget ${package}":
+        command => "/usr/sbin/pkgutil --forget com.puppetlabs.${package}",
+        require => File['/opt/puppet'],
+      }
+    }
+  }
+}

--- a/manifests/osfamily/darwin.pp
+++ b/manifests/osfamily/darwin.pp
@@ -1,0 +1,14 @@
+class puppet_agent::osfamily::darwin(
+  $package_file_name = undef,
+) {
+  assert_private()
+
+  if $::macosx_productversion_major != '10.9' {
+    fail("${::macosx_productname} ${::maxosx_productversion_major} not supported")
+  }
+ 
+  class { 'puppet_agent::prepare::package':
+    package_file_name => $package_file_name,
+  }
+  contain puppet_agent::prepare::package
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 # == Class puppet_agent::params
 #
-# This class is meant to be called from puppet_agent.
+# This class is meant to be called from puppet_agent
 # It sets variables according to platform.
 #
 class puppet_agent::params {
@@ -22,7 +22,7 @@ class puppet_agent::params {
   }
 
   case $::osfamily {
-    'RedHat', 'Amazon', 'Debian', 'Suse', 'Solaris': {
+    'RedHat', 'Amazon', 'Debian', 'Suse', 'Solaris', 'Darwin': {
       $package_name = 'puppet-agent'
       $service_names = ['puppet', 'mcollective']
 

--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -55,7 +55,7 @@ class puppet_agent::prepare(
   # the osfamily of the client being configured.
 
   case $::osfamily {
-    'redhat', 'debian', 'windows', 'solaris', 'aix', 'suse': {
+    'redhat', 'debian', 'windows', 'solaris', 'aix', 'suse', 'darwin': {
       $_osfamily_class = downcase("::puppet_agent::osfamily::${::osfamily}")
       class { $_osfamily_class:
         package_file_name => $package_file_name

--- a/manifests/prepare/package.pp
+++ b/manifests/prepare/package.pp
@@ -22,12 +22,28 @@ class puppet_agent::prepare::package(
     file { ['/opt/puppetlabs', '/opt/puppetlabs/packages']:
       ensure => directory,
     }
-    file { "/opt/puppetlabs/packages/${package_file_name}":
-      ensure => present,
-      owner  => 0,
-      group  => 0,
-      mode   => '0644',
-      source => $source,
-    }
+
+    #    case $::osfamily {
+    #      'Darwin': {
+    #        exec { "curl ${package_file_name} for osx":
+    #          path    => '/bin:/usr/bin:/sbin:/usr/sbin',
+    #          cwd     => "/opt/puppetlabs/packages",
+    #          command => "curl --cacert ${::puppet_agent::params::ssldir} https://${servername}:8140/packages/current/${::platform_tag}/${package_file_name}",
+    #          creates  => "/opt/puppetlabs/packages/${package_file_name}",
+    #          require => File['/opt/puppetlabs/packages'],
+    #        }
+    #      }
+    #      default: {
+        file { "/opt/puppetlabs/packages/${package_file_name}":
+          ensure  => present,
+          owner   => 0,
+          group   => 0,
+          mode    => '0644',
+          source  => $source,
+          backup  => false,
+          require => File['/opt/puppetlabs/packages'],
+        }
+        #      }
+        #    }
   }
 }

--- a/manifests/prepare/package.pp
+++ b/manifests/prepare/package.pp
@@ -23,27 +23,14 @@ class puppet_agent::prepare::package(
       ensure => directory,
     }
 
-    #    case $::osfamily {
-    #      'Darwin': {
-    #        exec { "curl ${package_file_name} for osx":
-    #          path    => '/bin:/usr/bin:/sbin:/usr/sbin',
-    #          cwd     => "/opt/puppetlabs/packages",
-    #          command => "curl --cacert ${::puppet_agent::params::ssldir} https://${servername}:8140/packages/current/${::platform_tag}/${package_file_name}",
-    #          creates  => "/opt/puppetlabs/packages/${package_file_name}",
-    #          require => File['/opt/puppetlabs/packages'],
-    #        }
-    #      }
-    #      default: {
-        file { "/opt/puppetlabs/packages/${package_file_name}":
-          ensure  => present,
-          owner   => 0,
-          group   => 0,
-          mode    => '0644',
-          source  => $source,
-          backup  => false,
-          require => File['/opt/puppetlabs/packages'],
-        }
-        #      }
-        #    }
+    file { "/opt/puppetlabs/packages/${package_file_name}":
+      ensure  => present,
+      owner   => 0,
+      group   => 0,
+      mode    => '0644',
+      source  => $source,
+      backup  => false,
+      require => File['/opt/puppetlabs/packages'],
+    }
   }
 }

--- a/spec/classes/puppet_agent_osfamily_darwin_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_darwin_spec.rb
@@ -1,0 +1,64 @@
+require 'spec_helper'
+
+describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >= "4.0.0" do
+  before(:each) do
+    # Need to mock the PE functions
+    Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
+      "4.0.0"
+    end
+
+    Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
+      '1.2.5'
+    end
+  end
+
+  facts = {
+    :is_pe                       => true,
+    :osfamily                    => 'Darwin',
+    :operatingsystem             => 'Darwin',
+    :macosx_productversion_major => '10.9',
+    :architecture                => 'x86_64',
+    :servername                  => 'master.example.vm',
+    :clientcert                  => 'foo.example.vm',
+  }
+
+  describe 'unsupported environment' do
+    context 'when not PE' do
+      let(:facts) do
+        facts.merge({
+          :is_pe => false,
+        })
+      end
+
+      it { expect { catalogue }.to raise_error(/Darwin not supported/) }
+    end
+  end
+
+  describe 'not yet supported releases' do
+    context 'when OSX 10.10' do
+      let(:facts) do
+        facts.merge({
+          :is_pe => true,
+          :osx_productversion_major => '10.10',
+        })
+      end
+
+      it { expect { catalogue }.to raise_error(/Darwin 10\.10 not supported/) }
+    end
+  end
+
+  describe 'supported environment' do
+    context "when OSX 10.9" do
+      let(:facts) do
+        facts.merge({
+          :is_pe                       => true,
+          :platform_tag                => "osx-10.9-x86_64",
+          :macosx_productversion_major => '10.9',
+        })
+      end
+
+      it { should compile.with_all_deps }
+      it { is_expected.to contain_package('puppet-agent').with_source('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.osx10.9.dmg') }
+    end
+  end
+end


### PR DESCRIPTION
Not pretty, but it does seem to work.

In particular the remove_packages_osx class is ugly and needs review.  Deleting all of /opt/puppet seems dubious.  We might be able to instead use a script to selectively rm files from 'pkgutil --list' output.

Specs need to be finished.