### PR TITLE
(PE-13179) Puppet Agent Module: Update metadata.json to include Anken…

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -25,6 +25,14 @@
       ]
     },
     {
+      "operatingsystem": "Darwin",
+      "operatingsystemrelease": [
+        "10.9",
+        "10.10",
+        "10.11"
+       ]
+    },
+    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "6",
@@ -69,7 +77,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">= 3.8.1 < 2015.3.0"
+      "version_requirement": ">= 3.8.1 < 2016.1.0"
     },
     {
       "name": "puppet",


### PR DESCRIPTION
…y release

Prior to this change the puppet agent module has a note that it's to be
used with PE < 2015.3. This Commit updates the metadata.json to note
PE Ankeny versions.