### PR TITLE
(PE-12001) Add Solaris 10 sparc to supported arch

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,7 +21,7 @@ class puppet_agent (
   $source        = $::puppet_agent::params::_source,
 ) inherits ::puppet_agent::params {
 
-  validate_re($arch, ['^x86$','^x64$','^i386$','^i86pc$','^amd64$','^x86_64$','^power$'])
+  validate_re($arch, ['^x86$','^x64$','^i386$','^i86pc$','^amd64$','^x86_64$','^power$', '^sun4[uv]$'])
 
   if versioncmp("${::clientversion}", '3.8.0') < 0 {
     fail('upgrading requires Puppet 3.8')
@@ -42,7 +42,11 @@ class puppet_agent (
       if $::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '10' {
         $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.sles10.${::architecture}.rpm"
       } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '10' {
-        $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.i386.pkg.gz"
+        if $arch =~ '^sun4[uv]$' {
+          $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.sparc.pkg.gz"
+        } else {
+          $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.i386.pkg.gz"
+        }
       }
 
       class { '::puppet_agent::prepare':

--- a/spec/classes/puppet_agent_osfamily_solaris_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_solaris_spec.rb
@@ -48,7 +48,7 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
   end
 
   describe 'supported environment' do
-    context "when Solaris 10" do
+    context "when Solaris 10 i386" do
       let(:facts) do
         facts.merge({
           :is_pe                     => true,
@@ -99,6 +99,61 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
       it do
         is_expected.to contain_package('puppet-agent').with_adminfile('/opt/puppetlabs/packages/solaris-noask')
         is_expected.to contain_package('puppet-agent').with_source('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.i386.pkg')
+      end
+    end
+
+    context "when Solaris 10 sparc sun4u" do
+      let(:facts) do
+        facts.merge({
+          :is_pe                     => true,
+          :platform_tag              => "solaris-10-sparc",
+          :operatingsystemmajrelease => '10',
+          :architecture              => 'sun4u',
+        })
+      end
+
+      it { should compile.with_all_deps }
+      it { is_expected.to contain_file('/opt/puppetlabs') }
+      it { is_expected.to contain_file('/opt/puppetlabs/packages') }
+      it do
+        is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.sparc.pkg.gz').with_ensure('present')
+        is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.sparc.pkg.gz').with_source('puppet:///pe_packages/4.0.0/solaris-10-sparc/puppet-agent-1.2.5-1.sparc.pkg.gz')
+      end
+
+      it { is_expected.to contain_file('/opt/puppetlabs/packages/solaris-noask').with_source('puppet:///pe_packages/4.0.0/solaris-10-sparc/solaris-noask') }
+      it do
+        is_expected.to contain_exec('unzip puppet-agent-1.2.5-1.sparc.pkg.gz').with_command('gzip -d /opt/puppetlabs/packages/puppet-agent-1.2.5-1.sparc.pkg.gz')
+        is_expected.to contain_exec('unzip puppet-agent-1.2.5-1.sparc.pkg.gz').with_creates('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.sparc.pkg')
+      end
+
+      it { is_expected.to contain_service('pe-puppet').with_ensure('stopped') }
+      it { is_expected.to contain_service('pe-mcollective').with_ensure('stopped') }
+
+      [
+        'PUPpuppet',
+        'PUPaugeas',
+        'PUPdeep-merge',
+        'PUPfacter',
+        'PUPhiera',
+        'PUPlibyaml',
+        'PUPmcollective',
+        'PUPopenssl',
+        'PUPpuppet-enterprise-release',
+        'PUPruby',
+        'PUPruby-augeas',
+        'PUPruby-rgen',
+        'PUPruby-shadow',
+        'PUPstomp',
+      ].each do |package|
+        it do
+          is_expected.to contain_package(package).with_ensure('absent')
+          is_expected.to contain_package(package).with_adminfile('/opt/puppetlabs/packages/solaris-noask')
+        end
+      end
+
+      it do
+        is_expected.to contain_package('puppet-agent').with_adminfile('/opt/puppetlabs/packages/solaris-noask')
+        is_expected.to contain_package('puppet-agent').with_source('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.sparc.pkg')
       end
     end
   end


### PR DESCRIPTION
Prior to this commit the puppet_agent module did not accept
the sparc (sun4u/v) arch on Solaris 10.
This commit adds that arch to the accepted architectures, as well
as add special handling on Solaris 10 to use the "sparc" packages
on those arches.