### PR TITLE
(PE-12299) Add Solaris 11 Support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :test do
   gem 'rspec-puppet', '~> 2.2'
   gem 'puppetlabs_spec_helper', '~> 0.10'
   gem 'metadata-json-lint', '~> 0.0'
-  gem 'rspec-puppet-facts', '~> 0.10'
+  gem 'rspec-puppet-facts', '~> 1.3'
 end
 
 group :system_tests do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,8 @@ class puppet_agent (
       } else {
         $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.i386.pkg.gz"
       }
+      } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '11' {
+        $_package_file_name = "${puppet_agent::package_name}@${puppet_agent::params::master_agent_version},5.11-1.i386.p5p"
     } elsif $::operatingsystem == 'Darwin' and $::macosx_productversion_major =~ '10\.[9,10,11]' {
       $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.osx${$::macosx_productversion_major}.dmg"
     } elsif $::operatingsystem == 'aix' and $::architecture =~ 'PowerPC_POWER[5,6,7]' {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,13 +41,17 @@ class puppet_agent (
         if $::operatingsystemmajrelease == '10' {
           $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.sparc.pkg.gz"
         } elsif $::operatingsystemmajrelease == '11' {
-          $_package_file_name = "${puppet_agent::package_name}@${puppet_agent::params::master_agent_version},5.11-1.sparc.p5p"
+          $_version_without_letters = regsubst($puppet_agent::params::master_agent_version, /[a-zA-Z]/, '', 'G')
+          $_solaris_version = regsubst($_version_without_letters, /(^-|-$)/, '', 'G')
+          $_package_file_name = "${puppet_agent::package_name}@${_solaris_version},5.11-1.sparc.p5p"
         }
       } else {
         if $::operatingsystemmajrelease == '10' {
-      $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.i386.pkg.gz"
+          $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.i386.pkg.gz"
         } elsif $::operatingsystemmajrelease == '11' {
-          $_package_file_name = "${puppet_agent::package_name}@${puppet_agent::params::master_agent_version},5.11-1.i386.p5p"
+          $_version_without_letters = regsubst($puppet_agent::params::master_agent_version, /[a-zA-Z]/, '', 'G')
+          $_solaris_version = regsubst($_version_without_letters, /(^-|-$)/, '', 'G')
+          $_package_file_name = "${puppet_agent::package_name}@${_solaris_version},5.11-1.i386.p5p"
         }
       }
     } elsif $::operatingsystem == 'Darwin' and $::macosx_productversion_major =~ '10\.[9,10,11]' {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,14 +36,20 @@ class puppet_agent (
 
     if $::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '10' {
       $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.sles10.${::architecture}.rpm"
-    } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '10' {
+    } elsif $::operatingsystem == 'Solaris' {
       if $arch =~ '^sun4[uv]$' {
-        $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.sparc.pkg.gz"
+        if $::operatingsystemmajrelease == '10' {
+          $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.sparc.pkg.gz"
+        } elsif $::operatingsystemmajrelease == '11' {
+          $_package_file_name = "${puppet_agent::package_name}@${puppet_agent::params::master_agent_version},5.11-1.sparc.p5p"
+        }
       } else {
-        $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.i386.pkg.gz"
+        if $::operatingsystemmajrelease == '10' {
+      $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.i386.pkg.gz"
+        } elsif $::operatingsystemmajrelease == '11' {
+          $_package_file_name = "${puppet_agent::package_name}@${puppet_agent::params::master_agent_version},5.11-1.i386.p5p"
+        }
       }
-      } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '11' {
-        $_package_file_name = "${puppet_agent::package_name}@${puppet_agent::params::master_agent_version},5.11-1.i386.p5p"
     } elsif $::operatingsystem == 'Darwin' and $::macosx_productversion_major =~ '10\.[9,10,11]' {
       $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.osx${$::macosx_productversion_major}.dmg"
     } elsif $::operatingsystem == 'aix' and $::architecture =~ 'PowerPC_POWER[5,6,7]' {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -42,9 +42,9 @@ class puppet_agent::install(
     contain puppet_agent::install::remove_packages
 
     exec { 'puppet_agent restore /etc/puppetlabs':
-      command   => 'cp -r /tmp/puppet_agent/puppetlabs /etc',
-      path      => '/bin:/usr/bin:/sbin:/usr/sbin',
-      require   => Class['puppet_agent::install::remove_packages'],
+      command => 'cp -r /tmp/puppet_agent/puppetlabs /etc',
+      path    => '/bin:/usr/bin:/sbin:/usr/sbin',
+      require => Class['puppet_agent::install::remove_packages'],
     }
 
     exec { 'puppet_agent post-install restore /etc/puppetlabs':

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -38,6 +38,25 @@ class puppet_agent::install(
       source    => "/opt/puppetlabs/packages/${_unzipped_package_name}",
       require   => Class['puppet_agent::install::remove_packages'],
     }
+  } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '11' {
+    contain puppet_agent::install::remove_packages
+
+    exec { 'puppet_agent restore /etc/puppetlabs':
+      command   => 'cp -r /tmp/puppet_agent/puppetlabs /etc',
+      path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+      require   => Class['puppet_agent::install::remove_packages'],
+    }
+
+    exec { 'puppet_agent post-install restore /etc/puppetlabs':
+      command     => 'cp -r /tmp/puppet_agent/puppetlabs /etc',
+      path        => '/bin:/usr/bin:/sbin:/usr/sbin',
+      refreshonly => true,
+    }
+
+    $_package_options = {
+      require => Exec['puppet_agent restore /etc/puppetlabs'],
+      notify  => Exec['puppet_agent post-install restore /etc/puppetlabs'],
+    }
   } elsif $::operatingsystem == 'Darwin' and $::macosx_productversion_major =~ '10\.[9,10,11]' {
     contain puppet_agent::install::remove_packages
 

--- a/manifests/install/remove_packages.pp
+++ b/manifests/install/remove_packages.pp
@@ -51,7 +51,6 @@ class puppet_agent::install::remove_packages {
           'PUPstomp',
         ]
       } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '11' {
-        # This order matters since solaris 11 won't uninstall packages that have dependencies installed
         $packages = [
           'pe-mcollective',
           'pe-mcollective-common',
@@ -60,18 +59,58 @@ class puppet_agent::install::remove_packages {
           'pe-deep-merge',
           'pe-ruby-ldap',
           'pe-ruby-augeas',
-          'pe-augeas',
           'pe-ruby-shadow',
-          'pe-stomp',
           'pe-puppet',
           'pe-facter',
-          'pe-hiera',
-          'pe-ruby-rgen',
-          'pe-ruby',
-          'pe-openssl',
-          'pe-libyaml',
-          'pe-puppet-enterprise-release',
         ]
+        package { 'pe-augeas':
+          ensure => absent,
+          require => Package['pe-ruby-augeas'],
+        }
+        package { 'pe-stomp':
+          ensure => absent,
+          require => Package['pe-mcollective'],
+        }
+        package { ['pe-hiera', 'pe-ruby-rgen']:
+          ensure => absent,
+          require => Package['pe-puppet'],
+        }
+        package { 'pe-ruby':
+          ensure => absent,
+          require => Package[
+            'pe-hiera',
+            'pe-deep-merge',
+            'pe-ruby-rgen',
+            'pe-stomp',
+            'pe-ruby-shadow',
+            'pe-puppet',
+            'pe-mcollective',
+            'pe-facter',
+            'pe-facter',
+            'pe-ruby-augeas',
+          ]
+        }
+        package { ['pe-openssl', 'pe-libyaml']:
+          ensure => absent,
+          require => Package['pe-ruby'],
+        }
+        package { 'pe-puppet-enterprise-release':
+          ensure => absent,
+          require => Package[
+            'pe-hiera',
+            'pe-stomp',
+            'pe-deep-merge',
+            'pe-libyaml',
+            'pe-ruby',
+            'pe-ruby-shadow',
+            'pe-augeas',
+            'pe-puppet',
+            'pe-ruby-rgen',
+            'pe-facter',
+            'pe-mcollective',
+            'pe-ruby-augeas',
+          ],
+        }
       } else {
         $packages = [
           'pe-augeas',

--- a/manifests/install/remove_packages.pp
+++ b/manifests/install/remove_packages.pp
@@ -15,24 +15,26 @@ class puppet_agent::install::remove_packages {
 
     } else {
 
-      $package_options = $::operatingsystem ? {
-        'SLES'  => {
+      if $::operatingsystem == 'SLES' {
+        $package_options = {
           uninstall_options => '--nodeps',
           provider          => 'rpm',
-        },
-        'AIX'  => {
-          uninstall_options => '--nodeps',
-          provider          => 'rpm',
-        },
-        'Solaris' => {
-          adminfile => '/opt/puppetlabs/packages/solaris-noask',
-        },
-        default => {
         }
+      } elsif $::operatingsystem == 'AIX' {
+        $package_options = {
+          uninstall_options => '--nodeps',
+          provider          => 'rpm',
+        }
+      } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '10' {
+        $package_options = {
+          adminfile => '/opt/puppetlabs/packages/solaris-noask',
+        }
+      } else {
+        $package_options = {}
       }
 
-      $packages = $::operatingsystem ? {
-        'Solaris' => [
+      if $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '10' {
+        $packages = [
           'PUPpuppet',
           'PUPaugeas',
           'PUPdeep-merge',
@@ -47,8 +49,31 @@ class puppet_agent::install::remove_packages {
           'PUPruby-rgen',
           'PUPruby-shadow',
           'PUPstomp',
-        ],
-        default => [
+        ]
+      } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '11' {
+        # This order matters since solaris 11 won't uninstall packages that have dependencies installed
+        $packages = [
+          'pe-mcollective',
+          'pe-mcollective-common',
+          'pe-virt-what',
+          'pe-libldap',
+          'pe-deep-merge',
+          'pe-ruby-ldap',
+          'pe-ruby-augeas',
+          'pe-augeas',
+          'pe-ruby-shadow',
+          'pe-stomp',
+          'pe-puppet',
+          'pe-facter',
+          'pe-hiera',
+          'pe-ruby-rgen',
+          'pe-ruby',
+          'pe-openssl',
+          'pe-libyaml',
+          'pe-puppet-enterprise-release',
+        ]
+      } else {
+        $packages = [
           'pe-augeas',
           'pe-mcollective-common',
           'pe-rubygem-deep-merge',

--- a/manifests/install/remove_packages.pp
+++ b/manifests/install/remove_packages.pp
@@ -64,19 +64,19 @@ class puppet_agent::install::remove_packages {
           'pe-facter',
         ]
         package { 'pe-augeas':
-          ensure => absent,
+          ensure  => absent,
           require => Package['pe-ruby-augeas'],
         }
         package { 'pe-stomp':
-          ensure => absent,
+          ensure  => absent,
           require => Package['pe-mcollective'],
         }
         package { ['pe-hiera', 'pe-ruby-rgen']:
-          ensure => absent,
+          ensure  => absent,
           require => Package['pe-puppet'],
         }
         package { 'pe-ruby':
-          ensure => absent,
+          ensure  => absent,
           require => Package[
             'pe-hiera',
             'pe-deep-merge',
@@ -87,15 +87,15 @@ class puppet_agent::install::remove_packages {
             'pe-mcollective',
             'pe-facter',
             'pe-facter',
-            'pe-ruby-augeas',
+            'pe-ruby-augeas'
           ]
         }
         package { ['pe-openssl', 'pe-libyaml']:
-          ensure => absent,
+          ensure  => absent,
           require => Package['pe-ruby'],
         }
         package { 'pe-puppet-enterprise-release':
-          ensure => absent,
+          ensure  => absent,
           require => Package[
             'pe-hiera',
             'pe-stomp',
@@ -108,7 +108,7 @@ class puppet_agent::install::remove_packages {
             'pe-ruby-rgen',
             'pe-facter',
             'pe-mcollective',
-            'pe-ruby-augeas',
+            'pe-ruby-augeas'
           ],
         }
       } else {

--- a/manifests/osfamily/solaris.pp
+++ b/manifests/osfamily/solaris.pp
@@ -44,9 +44,9 @@ class puppet_agent::osfamily::solaris(
         ensure => directory,
       }
       exec { 'puppet_agent backup /etc/puppetlabs/':
-        command  => 'cp -r /etc/puppetlabs/ /tmp/puppet_agent/',
-        require  => [Exec['puppet_agent copy packages'], File['/tmp/puppet_agent/']],
-        path     => '/bin:/usr/bin:/sbin:/usr/sbin',
+        command => 'cp -r /etc/puppetlabs/ /tmp/puppet_agent/',
+        require => [Exec['puppet_agent copy packages'], File['/tmp/puppet_agent/']],
+        path    => '/bin:/usr/bin:/sbin:/usr/sbin',
       }
 
       $pkgrepo_dir = '/etc/puppetlabs/installer/solaris.repo'

--- a/manifests/osfamily/solaris.pp
+++ b/manifests/osfamily/solaris.pp
@@ -32,6 +32,57 @@ class puppet_agent::osfamily::solaris(
         source => "puppet:///pe_packages/${pe_server_version}/${::platform_tag}/solaris-noask",
       }
     }
+    '11': {
+      class { 'puppet_agent::prepare::package':
+        package_file_name => $package_file_name,
+      }
+      contain puppet_agent::prepare::package
+
+      # Backup user configuration because solaris 11 will blow away
+      # /etc/puppetlabs/ when uninstalling the pe-* modules.
+      file { '/tmp/puppet_agent/':
+        ensure => directory,
+      }
+      exec { 'puppet_agent backup /etc/puppetlabs/':
+        command  => 'cp -r /etc/puppetlabs/ /tmp/puppet_agent/',
+        require  => [Exec['puppet_agent copy packages'], File['/tmp/puppet_agent/']],
+        path     => '/bin:/usr/bin:/sbin:/usr/sbin',
+      }
+
+      $pkgrepo_dir = '/etc/puppetlabs/installer/solaris.repo'
+
+      exec { 'puppet_agent remove existing repo':
+        command   => "pkgrepo remove -s '${pkgrepo_dir}' '*'",
+        path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+        onlyif    => "test -f ${pkgrepo_dir}/pkg5.repository",
+        logoutput => 'on_failure',
+        notify    => Exec['puppet_agent create repo'],
+      }
+
+      exec { 'puppet_agent create repo':
+        command     => "pkgrepo create ${pkgrepo_dir}",
+        path        => '/bin:/usr/bin:/sbin:/usr/sbin',
+        unless      => "test -f ${pkgrepo_dir}/pkg5.repository",
+        logoutput   => 'on_failure',
+        notify      => Exec['puppet_agent set publisher'],
+        refreshonly => true,
+      }
+
+      exec { 'puppet_agent set publisher':
+        command     => "pkgrepo set -s ${pkgrepo_dir} publisher/prefix=puppetlabs.com",
+        path        => '/bin:/usr/bin:/sbin:/usr/sbin',
+        logoutput   => 'on_failure',
+        refreshonly => true,
+      }
+
+      exec { 'puppet_agent copy packages':
+        command   => "pkgrecv -s file:///opt/puppetlabs/packages/${package_file_name} -d ${pkgrepo_dir} '*'",
+        path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+        require   => Exec['puppet_agent set publisher'],
+        logoutput => 'on_failure',
+      }
+
+    }
     default: {
       fail("${::operatingsystem} ${::operatingsystemmajrelease} not supported")
     }

--- a/manifests/osfamily/solaris.pp
+++ b/manifests/osfamily/solaris.pp
@@ -47,6 +47,7 @@ class puppet_agent::osfamily::solaris(
         command => 'cp -r /etc/puppetlabs/ /tmp/puppet_agent/',
         require => [Exec['puppet_agent copy packages'], File['/tmp/puppet_agent/']],
         path    => '/bin:/usr/bin:/sbin:/usr/sbin',
+        onlyif  => 'test "$(ls -A /tmp/puppet_agent 2>/dev/null)"',
       }
 
       $pkgrepo_dir = '/etc/puppetlabs/installer/solaris.repo'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,7 +24,9 @@ class puppet_agent::params {
   case $::osfamily {
     'RedHat', 'Amazon', 'Debian', 'Suse', 'Solaris', 'Darwin', 'AIX': {
       $package_name = 'puppet-agent'
-      $service_names = ['puppet', 'mcollective']
+      if !($::osfamily == 'Solaris' and $::operatingsystemmajrelease == '11') {
+        $service_names = ['puppet', 'mcollective']
+      }
 
       $local_puppet_dir = '/opt/puppetlabs'
       $local_packages_dir = "${local_puppet_dir}/packages"

--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -59,7 +59,7 @@ class puppet_agent::prepare(
       $_osfamily_class = downcase("::puppet_agent::osfamily::${::osfamily}")
       class { $_osfamily_class:
         package_file_name => $package_file_name,
-        require => Class['puppet_agent::prepare::puppet_config'],
+        require           => Class['puppet_agent::prepare::puppet_config'],
       }
       contain $_osfamily_class
     }

--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -58,7 +58,8 @@ class puppet_agent::prepare(
     'redhat', 'debian', 'windows', 'solaris', 'aix', 'suse', 'darwin': {
       $_osfamily_class = downcase("::puppet_agent::osfamily::${::osfamily}")
       class { $_osfamily_class:
-        package_file_name => $package_file_name
+        package_file_name => $package_file_name,
+        require => Class['puppet_agent::prepare::puppet_config'],
       }
       contain $_osfamily_class
     }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,17 +6,25 @@
 class puppet_agent::service {
   assert_private()
 
-  $::puppet_agent::service_names.each |$service| {
-    service { $service:
-      ensure     => running,
-      enable     => true,
-      hasstatus  => true,
-      hasrestart => true,
+
+  if $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '11' {
+    contain '::puppet_agent::service::solaris'
+  } else {
+
+    $::puppet_agent::service_names.each |$service| {
+      service { $service:
+        ensure     => running,
+        enable     => true,
+        hasstatus  => true,
+        hasrestart => true,
+      }
     }
+
+    if $::operatingsystem == 'Solaris' {
+      contain '::puppet_agent::service::solaris'
+      Service[$::puppet_agent::service_names] -> Class['::puppet_agent::service::solaris']
+    }
+
   }
 
-  if $::operatingsystem == 'Solaris' {
-    contain '::puppet_agent::service::solaris'
-    Service[$::puppet_agent::service_names] -> Class['::puppet_agent::service::solaris']
-  }
 }

--- a/manifests/service/solaris.pp
+++ b/manifests/service/solaris.pp
@@ -18,10 +18,13 @@ class puppet_agent::service::solaris {
       ensure  => file,
       content => template('puppet_agent/solaris_start_puppet.sh.erb'),
       mode    => '755',
-    }->
+    } ->
     exec { 'solaris_start_puppet.sh':
       command => "/tmp/solaris_start_puppet.sh &",
       path    => '/usr/bin:/bin:/usr/sbin',
+    }
+    file { ['/var/opt/lib', '/var/opt/lib/pe-puppet', '/var/opt/lib/pe-puppet/state']:
+      ensure => directory,
     }
   }
 }

--- a/manifests/service/solaris.pp
+++ b/manifests/service/solaris.pp
@@ -14,13 +14,13 @@ class puppet_agent::service::solaris {
       ensure => stopped,
     }
   } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '11' {
-    file { "/tmp/solaris_start_puppet.sh":
+    file { '/tmp/solaris_start_puppet.sh':
       ensure  => file,
       content => template('puppet_agent/solaris_start_puppet.sh.erb'),
-      mode    => '755',
+      mode    => '0755',
     } ->
     exec { 'solaris_start_puppet.sh':
-      command => "/tmp/solaris_start_puppet.sh &",
+      command => '/tmp/solaris_start_puppet.sh &',
       path    => '/usr/bin:/bin:/usr/sbin',
     }
     file { ['/var/opt/lib', '/var/opt/lib/pe-puppet', '/var/opt/lib/pe-puppet/state']:

--- a/manifests/service/solaris.pp
+++ b/manifests/service/solaris.pp
@@ -13,5 +13,15 @@ class puppet_agent::service::solaris {
     service { 'pe-puppet':
       ensure => stopped,
     }
+  } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '11' {
+    file { "/tmp/solaris_start_puppet.sh":
+      ensure  => file,
+      content => template('puppet_agent/solaris_start_puppet.sh.erb'),
+      mode    => '755',
+    }->
+    exec { 'solaris_start_puppet.sh':
+      command => "/tmp/solaris_start_puppet.sh &",
+      path    => '/usr/bin:/bin:/usr/sbin',
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -57,7 +57,8 @@
     {
       "operatingsystem": "Solaris",
       "operatingsystemrelease": [
-        "10"
+        "10",
+        "11"
       ]
     },
     {

--- a/spec/classes/puppet_agent_osfamily_solaris_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_solaris_spec.rb
@@ -34,20 +34,129 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
     end
   end
 
-  describe 'not yet supported releases' do
-    context 'when Solaris 11' do
+  describe 'supported environment' do
+
+    context "when Solaris 11 i386" do
       let(:facts) do
         facts.merge({
-          :is_pe => true,
+          :is_pe                     => true,
+          :platform_tag              => "solaris-11-i386",
           :operatingsystemmajrelease => '11',
         })
       end
 
-      it { expect { catalogue }.to raise_error(/Solaris 11 not supported/) }
-    end
-  end
+      it { should compile.with_all_deps }
+      it { is_expected.to contain_file('/opt/puppetlabs') }
+      it { is_expected.to contain_file('/opt/puppetlabs/packages') }
+      it do
+        is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent@1.2.5,5.11-1.i386.p5p').with_ensure('present')
+        is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent@1.2.5,5.11-1.i386.p5p').with({
+          'source' => 'puppet:///pe_packages/4.0.0/solaris-11-i386/puppet-agent@1.2.5,5.11-1.i386.p5p',
+        })
+      end
 
-  describe 'supported environment' do
+      it do
+        is_expected.to contain_exec('puppet_agent backup /etc/puppetlabs/').with({
+          'command' => 'cp -r /etc/puppetlabs/ /tmp/puppet_agent/',
+        })
+        is_expected.to contain_exec('puppet_agent remove existing repo').with_command("pkgrepo remove -s '/etc/puppetlabs/installer/solaris.repo' '*'")
+        is_expected.to contain_exec('puppet_agent create repo').with_command('pkgrepo create /etc/puppetlabs/installer/solaris.repo')
+        is_expected.to contain_exec('puppet_agent set publisher').with_command('pkgrepo set -s /etc/puppetlabs/installer/solaris.repo publisher/prefix=puppetlabs.com')
+        is_expected.to contain_exec('puppet_agent copy packages').with_command("pkgrecv -s file:///opt/puppetlabs/packages/puppet-agent@1.2.5,5.11-1.i386.p5p -d /etc/puppetlabs/installer/solaris.repo '*'")
+
+      end
+
+      [
+          'pe-augeas',
+          'pe-deep-merge',
+          'pe-facter',
+          'pe-hiera',
+          'pe-libldap',
+          'pe-libyaml',
+          'pe-mcollective',
+          'pe-mcollective-common',
+          'pe-openssl',
+          'pe-puppet',
+          'pe-puppet-enterprise-release',
+          'pe-ruby',
+          'pe-ruby-augeas',
+          'pe-ruby-ldap',
+          'pe-ruby-rgen',
+          'pe-ruby-shadow',
+          'pe-stomp',
+          'pe-virt-what',
+      ].each do |package|
+        it do
+          is_expected.to contain_package(package).with_ensure('absent')
+        end
+      end
+
+      it do
+        is_expected.to contain_package('puppet-agent').with_ensure('present')
+      end
+    end
+
+    context "when Solaris 11 sparc sun4u" do
+      let(:facts) do
+        facts.merge({
+          :is_pe                     => true,
+          :platform_tag              => "solaris-11-sparc",
+          :operatingsystemmajrelease => '11',
+          :architecture              => 'sun4u',
+        })
+      end
+
+      it { should compile.with_all_deps }
+      it { is_expected.to contain_file('/opt/puppetlabs') }
+      it { is_expected.to contain_file('/opt/puppetlabs/packages') }
+      it do
+        is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent@1.2.5,5.11-1.sparc.p5p').with_ensure('present')
+        is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent@1.2.5,5.11-1.sparc.p5p').with({
+          'source' => 'puppet:///pe_packages/4.0.0/solaris-11-sparc/puppet-agent@1.2.5,5.11-1.sparc.p5p',
+        })
+      end
+
+      it do
+        is_expected.to contain_exec('puppet_agent backup /etc/puppetlabs/').with({
+          'command' => 'cp -r /etc/puppetlabs/ /tmp/puppet_agent/',
+        })
+        is_expected.to contain_exec('puppet_agent remove existing repo').with_command("pkgrepo remove -s '/etc/puppetlabs/installer/solaris.repo' '*'")
+        is_expected.to contain_exec('puppet_agent create repo').with_command('pkgrepo create /etc/puppetlabs/installer/solaris.repo')
+        is_expected.to contain_exec('puppet_agent set publisher').with_command('pkgrepo set -s /etc/puppetlabs/installer/solaris.repo publisher/prefix=puppetlabs.com')
+        is_expected.to contain_exec('puppet_agent copy packages').with_command("pkgrecv -s file:///opt/puppetlabs/packages/puppet-agent@1.2.5,5.11-1.sparc.p5p -d /etc/puppetlabs/installer/solaris.repo '*'")
+
+      end
+
+      [
+          'pe-augeas',
+          'pe-deep-merge',
+          'pe-facter',
+          'pe-hiera',
+          'pe-libldap',
+          'pe-libyaml',
+          'pe-mcollective',
+          'pe-mcollective-common',
+          'pe-openssl',
+          'pe-puppet',
+          'pe-puppet-enterprise-release',
+          'pe-ruby',
+          'pe-ruby-augeas',
+          'pe-ruby-ldap',
+          'pe-ruby-rgen',
+          'pe-ruby-shadow',
+          'pe-stomp',
+          'pe-virt-what',
+      ].each do |package|
+        it do
+          is_expected.to contain_package(package).with_ensure('absent')
+        end
+      end
+
+      it do
+        is_expected.to contain_package('puppet-agent').with_ensure('present')
+      end
+    end
+
     context "when Solaris 10 i386" do
       let(:facts) do
         facts.merge({

--- a/spec/classes/puppet_agent_osfamily_solaris_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_solaris_spec.rb
@@ -59,7 +59,7 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
         is_expected.to contain_exec('puppet_agent backup /etc/puppetlabs/').with({
           'command' => 'cp -r /etc/puppetlabs/ /tmp/puppet_agent/',
         })
-        is_expected.to contain_exec('puppet_agent remove existing repo').with_command("pkgrepo remove -s '/etc/puppetlabs/installer/solaris.repo' '*'")
+        is_expected.to contain_exec('puppet_agent remove existing repo').with_command("rm -rf '/etc/puppetlabs/installer/solaris.repo'")
         is_expected.to contain_exec('puppet_agent create repo').with_command('pkgrepo create /etc/puppetlabs/installer/solaris.repo')
         is_expected.to contain_exec('puppet_agent set publisher').with_command('pkgrepo set -s /etc/puppetlabs/installer/solaris.repo publisher/prefix=puppetlabs.com')
         is_expected.to contain_exec('puppet_agent copy packages').with_command("pkgrecv -s file:///opt/puppetlabs/packages/puppet-agent@1.2.5,5.11-1.i386.p5p -d /etc/puppetlabs/installer/solaris.repo '*'")
@@ -120,7 +120,7 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
         is_expected.to contain_exec('puppet_agent backup /etc/puppetlabs/').with({
           'command' => 'cp -r /etc/puppetlabs/ /tmp/puppet_agent/',
         })
-        is_expected.to contain_exec('puppet_agent remove existing repo').with_command("pkgrepo remove -s '/etc/puppetlabs/installer/solaris.repo' '*'")
+        is_expected.to contain_exec('puppet_agent remove existing repo').with_command("rm -rf '/etc/puppetlabs/installer/solaris.repo'")
         is_expected.to contain_exec('puppet_agent create repo').with_command('pkgrepo create /etc/puppetlabs/installer/solaris.repo')
         is_expected.to contain_exec('puppet_agent set publisher').with_command('pkgrepo set -s /etc/puppetlabs/installer/solaris.repo publisher/prefix=puppetlabs.com')
         is_expected.to contain_exec('puppet_agent copy packages').with_command("pkgrecv -s file:///opt/puppetlabs/packages/puppet-agent@1.2.5,5.11-1.sparc.p5p -d /etc/puppetlabs/installer/solaris.repo '*'")

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -13,7 +13,6 @@ describe 'puppet_agent' do
           elsif os =~ /solaris/
             facts.merge({
               :is_pe => true,
-              :operatingsystemmajrelease => facts[:operatingsystemrelease].split('.')[1],
             })
           else
             facts
@@ -51,12 +50,18 @@ describe 'puppet_agent' do
                 it { is_expected.to contain_class('puppet_agent::service') }
 
                 if params[:service_names].nil?
-                  it { is_expected.to contain_service('puppet') }
-                  it { is_expected.to contain_service('mcollective') }
+                  if (facts[:osfamily] == 'Solaris' and facts[:operatingsystemmajrelease] == '11') || facts[:osfamily] == 'Sles'
+                    it { is_expected.to_not contain_service('puppet') }
+                    it { is_expected.to_not contain_service('mcollective') }
+                  else
+                    it { is_expected.to contain_service('puppet') }
+                    it { is_expected.to contain_service('mcollective') }
+                  end
                 else
                   it { is_expected.to_not contain_service('puppet') }
                   it { is_expected.to_not contain_service('mcollective') }
                 end
+
                 it { is_expected.to contain_package('puppet-agent').with_ensure('present') }
               else
                 it { is_expected.to_not contain_service('puppet') }

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -10,13 +10,18 @@ describe 'puppet_agent' do
               :is_pe => true,
               :operatingsystemmajrelease => facts[:operatingsystemrelease].split('.')[0],
             })
+          elsif os =~ /solaris/
+            facts.merge({
+              :is_pe => true,
+              :operatingsystemmajrelease => facts[:operatingsystemrelease].split('.')[1],
+            })
           else
             facts
           end
         end
 
         before(:each) do
-          if os =~ /sles/
+          if os =~ /sles/ || os =~ /solaris/
             # Need to mock the PE functions
 
             Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|

--- a/templates/solaris_start_puppet.sh.erb
+++ b/templates/solaris_start_puppet.sh.erb
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+puppet_pid="<%= @puppet_agent_pid %>"
+while $(kill -0 ${puppet_pid:?}); do
+  sleep 5
+done
+
+function start_service() {
+  service="${1:?}"
+  /opt/puppetlabs/bin/puppet resource service "${service:?}" ensure=running enable=true
+}
+
+start_service puppet
+start_service mcollective


### PR DESCRIPTION
This PR consists of everything needed to get puppet agents on Solaris 11 to upgrade from puppet 3.x to puppet 4.x in a PE environment.

This PR is ready for review, and potentially even a merge.