### PR TITLE
(PE-12002) Add AIX support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,7 +21,7 @@ class puppet_agent (
   $source        = $::puppet_agent::params::_source,
 ) inherits ::puppet_agent::params {
 
-  validate_re($arch, ['^x86$','^x64$','^i386$','^i86pc$','^amd64$','^x86_64$','^power$', '^sun4[uv]$'])
+  validate_re($arch, ['^x86$','^x64$','^i386$','^i86pc$','^amd64$','^x86_64$','^power$','^sun4[uv]$','PowerPC_POWER'])
 
   if versioncmp("${::clientversion}", '3.8.0') < 0 {
     fail('upgrading requires Puppet 3.8')
@@ -49,6 +49,9 @@ class puppet_agent (
         }
       } elsif $::operatingsystem == 'Darwin' and $::macosx_productversion_major =~ '10\.[9,10,11]' {
         $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.osx${$::macosx_productversion_major}.dmg"
+      } elsif $::operatingsystem == 'aix' and $::architecture =~ 'PowerPC_POWER[5,6,7]' {
+        $aix_ver_number = regsubst($::platform_tag,'aix-(\d+\.\d+)-power','\1')
+        $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.aix${aix_ver_number}.ppc.rpm"
       } else {
         $_package_file_name = undef
       }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,7 +13,7 @@ class puppet_agent::install(
 ) {
   assert_private()
 
-  if $::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '10' {
+  if ($::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '10') or ($::operatingsystem == 'AIX' and  $::architecture =~ 'PowerPC_POWER[5,6,7]') {
     contain puppet_agent::install::remove_packages
 
     exec { 'replace puppet.conf removed by package removal':

--- a/manifests/install/remove_packages.pp
+++ b/manifests/install/remove_packages.pp
@@ -20,6 +20,10 @@ class puppet_agent::install::remove_packages {
           uninstall_options => '--nodeps',
           provider          => 'rpm',
         },
+        'AIX'  => {
+          uninstall_options => '--nodeps',
+          provider          => 'rpm',
+        },
         'Solaris' => {
           adminfile => '/opt/puppetlabs/packages/solaris-noask',
         },

--- a/manifests/osfamily/aix.pp
+++ b/manifests/osfamily/aix.pp
@@ -1,0 +1,16 @@
+class puppet_agent::osfamily::aix(
+  $package_file_name = undef,
+) {
+  assert_private()
+
+  class { 'puppet_agent::prepare::package':
+    package_file_name => $package_file_name,
+  }
+
+  contain puppet_agent::prepare::package
+
+  file { '/usr/local/bin/puppet':
+    ensure => 'link',
+    target => '/opt/puppetlabs/bin/puppet',
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class puppet_agent::params {
   }
 
   case $::osfamily {
-    'RedHat', 'Amazon', 'Debian', 'Suse', 'Solaris', 'Darwin': {
+    'RedHat', 'Amazon', 'Debian', 'Suse', 'Solaris', 'Darwin', 'AIX': {
       $package_name = 'puppet-agent'
       $service_names = ['puppet', 'mcollective']
 

--- a/spec/classes/puppet_agent_osfamily_aix_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_aix_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+
+
+describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >= "4.0.0" do
+  before(:each) do
+    Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
+      "4.0.0"
+    end
+
+    Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
+      '1.2.5'
+    end
+  end
+
+  facts = {
+    :is_pe           => true,
+    :osfamily        => 'AIX',
+    :operatingsystem => 'AIX',
+    :servername      => 'master.example.vm',
+    :clientcert      => 'foo.example.vm',
+  }
+
+  ['7', '6', '5'].each do |aixver|
+    context "aix #{aixver}" do
+
+      let(:facts) do
+        facts.merge({
+          :architecture    => "PowerPC_POWER#{aixver}",
+          :platform_tag    => "aix-#{aixver}.1-power"
+        })
+      end
+
+      rpmname = "puppet-agent-1.2.5-1.aix#{aixver}.1.ppc.rpm"
+
+      it { is_expected.to contain_file('/etc/puppetlabs/puppet') }
+
+      it { is_expected.to contain_file('/etc/puppetlabs/puppet/puppet.conf') }
+
+      it { is_expected.to contain_file("/opt/puppetlabs/packages/#{rpmname}")}
+
+      it { is_expected.to contain_class('Puppet_agent::Install').with({
+           'package_file_name'     => rpmname,
+         })
+      }
+
+      it {
+        is_expected.to contain_package('puppet-agent').with({
+            'source'    => "/opt/puppetlabs/packages/#{rpmname}",
+            'ensure'    => 'present',
+            'provider'  => 'rpm'
+          })
+      }
+
+      [
+       'pe-augeas',
+       'pe-mcollective-common',
+       'pe-rubygem-deep-merge',
+       'pe-mcollective',
+       'pe-puppet-enterprise-release',
+       'pe-libldap',
+       'pe-libyaml',
+       'pe-ruby-stomp',
+       'pe-ruby-augeas',
+       'pe-ruby-shadow',
+       'pe-hiera',
+       'pe-facter',
+       'pe-puppet',
+       'pe-openssl',
+       'pe-ruby',
+       'pe-ruby-rgen',
+       'pe-virt-what',
+       'pe-ruby-ldap',
+      ].each do |package|
+        it do
+          is_expected.to contain_package(package).with_ensure('absent')
+          is_expected.to contain_package(package).with_uninstall_options('--nodeps')
+          is_expected.to contain_package(package).with_provider('rpm')
+        end
+      end
+    end
+  end
+
+  ['4', '8'].each do |aixver|
+    context "aix #{aixver}" do
+      let(:facts) do
+        facts.merge({
+          :architecture    => "PowerPC_POWER#{aixver}",
+          :platform_tag    => "aix-#{aixver}.1-power"
+        })
+      end
+
+      rpmname = "puppet-agent-1.2.5-1.aix#{aixver}.1.ppc.rpm"
+
+      it {
+        is_expected.to_not contain_file("/opt/puppetlabs/packages/#{rpmname}") }
+    end
+  end
+end
+


### PR DESCRIPTION
This change adds puppet agent support for AIX.

Support is gated by the 'aix' operatingsystem fact
and an architecture fact matching 'PowerPC_POWER[5,6,7]'.

This change uses the same strategy as osx for removing
unused packages as aix doesn't have fully fledged package
management for rpms.