### PR TITLE
(PE-13608) puppet_agent windows spec tests failing on posix systems

### DIFF
--- a/manifests/windows/install.pp
+++ b/manifests/windows/install.pp
@@ -28,14 +28,14 @@ class puppet_agent::windows::install {
   }
 
   $_msi_location = $_source ? {
-    /^puppet:/ => "${::env_temp_variable}\\puppet-agent.msi",
+    /^puppet:/ => "${::env_temp_variable}/puppet-agent.msi",
     default    => $_source,
   }
 
   if $_source =~ /^puppet:/ {
     file{ $_msi_location:
       source => $_source,
-      before => File["${::env_temp_variable}\\install_puppet.bat"],
+      before => File["${::env_temp_variable}/install_puppet.bat"],
     }
   }
 
@@ -48,7 +48,7 @@ class puppet_agent::windows::install {
   $_logfile = "${::env_temp_variable}\\puppet-${_timestamp}-installer.log"
   notice ("Puppet upgrade log file at ${_logfile}")
   debug ("Installing puppet from ${_msi_location}")
-  file { "${::env_temp_variable}\\install_puppet.bat":
+  file { "${::env_temp_variable}/install_puppet.bat":
     ensure  => file,
     content => template('puppet_agent/install_puppet.bat.erb')
   }->

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+
 RSpec.describe 'puppet_agent', :unless => Puppet.version =~ /^(3\.7|4.\d+)\.\d+/ do
 
   if Puppet.version >= "4.0.0"
@@ -12,7 +13,7 @@ RSpec.describe 'puppet_agent', :unless => Puppet.version =~ /^(3\.7|4.\d+)\.\d+/
       context "Windows Kernelmajversion #{kernelmajversion}" do
         facts = {
           :architecture => 'x64',
-          :env_temp_variable => 'C:\tmp',
+          :env_temp_variable => 'C:/tmp',
           :kernelmajversion => kernelmajversion,
           :osfamily => 'windows',
           :puppetversion => '3.8.0',
@@ -40,7 +41,7 @@ RSpec.describe 'puppet_agent', :unless => Puppet.version =~ /^(3\.7|4.\d+)\.\d+/
           let(:facts) { facts.merge({:is_pe => true}) }
 
           it {
-            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+            is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(
               %r[#{Regexp.escape("msiexec.exe /qn /norestart /i \"https://pm.puppetlabs.com/puppet-agent/4.0.0/1.2.1.1/repos/windows/puppet-agent-#{values[:expect_arch]}.msi\"")}])
           }
         end
@@ -50,10 +51,10 @@ RSpec.describe 'puppet_agent', :unless => Puppet.version =~ /^(3\.7|4.\d+)\.\d+/
               :source => 'https://alternate.com/puppet-agent.msi',
             } }
             it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+              is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(
                                /msiexec.exe \/qn \/norestart \/i "https:\/\/alternate.com\/puppet-agent.msi"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/PID eq 42/)
+              is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+              is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(/PID eq 42/)
             }
           end
           describe 'C:/tmp/puppet-agent-x64.msi' do
@@ -61,10 +62,10 @@ RSpec.describe 'puppet_agent', :unless => Puppet.version =~ /^(3\.7|4.\d+)\.\d+/
               :source => 'C:/tmp/puppet-agent-x64.msi',
             } }
             it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "C:\\tmp\\puppet-agent-x64\.msi"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/PID eq 42/)
+              is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(
+                               /msiexec.exe \/qn \/norestart \/i "C:\\tmp\\puppet-agent-x64.msi"/)
+              is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+              is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(/PID eq 42/)
             }
           end
           describe 'C:\Temp/ Folder\puppet-agent-x64.msi' do
@@ -72,10 +73,10 @@ RSpec.describe 'puppet_agent', :unless => Puppet.version =~ /^(3\.7|4.\d+)\.\d+/
               :source => 'C:\Temp/ Folder\puppet-agent-x64.msi',
             } }
             it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "C:\\Temp Folder\\puppet-agent-x64\.msi"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/PID eq 42/)
+              is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(
+                               /msiexec.exe \/qn \/norestart \/i "C:\\Temp Folder\\puppet-agent-x64.msi"/)
+              is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+              is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(/PID eq 42/)
             }
           end
           describe 'C:/Temp/ Folder/puppet-agent-x64.msi' do
@@ -83,10 +84,10 @@ RSpec.describe 'puppet_agent', :unless => Puppet.version =~ /^(3\.7|4.\d+)\.\d+/
               :source => 'C:/Temp/ Folder/puppet-agent-x64.msi',
             } }
             it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "C:\\Temp Folder\\puppet-agent-x64\.msi"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/PID eq 42/)
+              is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(
+                               /msiexec.exe \/qn \/norestart \/i "C:\\Temp Folder\\puppet-agent-x64.msi"/)
+              is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+              is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(/PID eq 42/)
             }
           end
           describe '\\\\garded\c$\puppet-agent-x64.msi' do
@@ -94,36 +95,38 @@ RSpec.describe 'puppet_agent', :unless => Puppet.version =~ /^(3\.7|4.\d+)\.\d+/
               :source => "\\\\garded\\c$\\puppet-agent-x64.msi",
             } }
             it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+              is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(
                                /msiexec.exe \/qn \/norestart \/i "\\\\garded\\c\$\\puppet-agent-x64\.msi"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/PID eq 42/)
+              is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+              is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(/PID eq 42/)
             }
           end
           describe 'default source' do
             let(:params) { {} }
             it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+              is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(
                                /msiexec.exe \/qn \/norestart \/i "https:\/\/downloads.puppetlabs.com\/windows\/puppet-agent-#{values[:expect_arch]}-latest\.msi"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer\.log"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/PID eq 42/)
+              is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer\.log"/)
+              is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(/PID eq 42/)
             }
             it {
               should contain_exec('install_puppet.bat').with { {
-                       'command' => 'C:\windows\sysnative\cmd.exe /c start /b "C:\tmp\install_puppet.bat"',
+                       'command' => 'C:\windows\sysnative\cmd.exe /c start /b "C:/tmp/install_puppet.bat"',
                      } }
             }
             it {
-              is_expected.to_not contain_file('C:\tmp\puppet-agent.msi')
+              is_expected.to_not contain_file('C:/tmp/puppet-agent.msi')
             }
           end
           describe 'puppet:///puppet_agent/puppet-agent-1.1.0-x86.msi' do
             let(:params) { {:source => 'puppet:///puppet_agent/puppet-agent-1.1.0-x86.msi'} }
             it {
-              is_expected.to contain_file('C:\tmp\puppet-agent.msi').that_comes_before('File[C:\tmp\install_puppet.bat]')
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "C:\\tmp\\puppet-agent.msi"/
-                             )
+              if ! File.expand_path('').match('^/')
+                require 'pry'; binding.pry
+                is_expected.to contain_file('C:/tmp/puppet-agent.msi').that_comes_before('File[C:/tmp/install_puppet.bat]')
+                is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(
+                                 /msiexec.exe \/qn \/norestart \/i "C:\tmp\puppet-agent.msi"/)
+              end
             }
           end
         end
@@ -131,7 +134,7 @@ RSpec.describe 'puppet_agent', :unless => Puppet.version =~ /^(3\.7|4.\d+)\.\d+/
           describe 'specify x86' do
             let(:params) { {:arch => 'x86'} }
             it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+              is_expected.to contain_file('C:/tmp/install_puppet.bat').with_content(
                                /msiexec.exe \/qn \/norestart \/i "https:\/\/downloads.puppetlabs.com\/windows\/puppet-agent-x86-latest\.msi"/
                              )
             }
@@ -169,7 +172,7 @@ RSpec.describe 'puppet_agent', :unless => Puppet.version =~ /^(3\.7|4.\d+)\.\d+/
           let(:facts) { facts.merge({:rubyplatform => 'i386-ming32'}) }
           it {
             is_expected.to contain_exec('install_puppet.bat').with { {
-                             'command' => 'C:\windows\sysnative\cmd.exe /c start /b C:\windows\system32\cmd.exe /c "C:\tmp\install_puppet.bat"',
+                             'command' => 'C:\windows\sysnative\cmd.exe /c start /b C:\windows\system32\cmd.exe /c "C:/tmp/install_puppet.bat"',
                            } }
 
           }
@@ -178,7 +181,7 @@ RSpec.describe 'puppet_agent', :unless => Puppet.version =~ /^(3\.7|4.\d+)\.\d+/
           let(:facts) { facts.merge({:rubyplatform => 'x86_64'}) }
           it {
             is_expected.to contain_exec('install_puppet.bat').with { {
-                             'command' => 'C:\windows\sysnative\cmd.exe /c start /b C:\windows\sysnative\cmd.exe /c "C:\tmp\install_puppet.bat"',
+                             'command' => 'C:\windows\sysnative\cmd.exe /c start /b C:\windows\sysnative\cmd.exe /c "C:/tmp/install_puppet.bat"',
                            } }
 
           }

--- a/templates/install_puppet.bat.erb
+++ b/templates/install_puppet.bat.erb
@@ -5,7 +5,7 @@ echo %_task% | findstr "No tasks are running" >nul
 IF NOT %errorlevel% == 0 ( GOTO wait_for_pid )
 
 
-msiexec.exe /qn /norestart /i "<%= @_msi_location %>" /l*v "<%= @_logfile %>"
+msiexec.exe /qn /norestart /i "<%= if (!@_msi_location.include?("http")); @_msi_location.gsub(/\//, '\\'); else @_msi_location; end %>" /l*v "<%= @_logfile.gsub(/\//, '\\') %>"
 
 :End
 ENDLOCAL


### PR DESCRIPTION
Prior to this commit there were several pathing issues that were preventing
puppet_agent spec tests for windows from running on posix systems
like Travis.

This commit switches some /'s with \'s as MSI cannot accept / and gates
the windows specific file resource ordering tests on being run against
a windows system.