### PR TITLE
(PE-13608) Do not convert windows file resource to RAL catalog

### DIFF
--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe 'puppet_agent', :unless => Puppet.version =~ /^(3\.7|4.\d+)\.\d+/
           describe 'puppet:///puppet_agent/puppet-agent-1.1.0-x86.msi' do
             let(:params) { {:source => 'puppet:///puppet_agent/puppet-agent-1.1.0-x86.msi'} }
             it {
-              is_expected.to contain_file('C:\tmp\puppet-agent.msi').that_comes_before('File[C:\tmp\install_puppet.bat]')
+              is_expected.to contain_file('C:\tmp\puppet-agent.msi').with_before('File[C:\tmp\install_puppet.bat]')
               is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
                                /msiexec.exe \/qn \/norestart \/i "C:\\tmp\\puppet-agent.msi"/
                              )


### PR DESCRIPTION
Before this commit when rspec-puppet would attempt to use the
'that_comes_before' matcher on a POSIX system with the file resource
when the file resource contained a windows path the test would fail.
This is because when puppet converts the catalog to the RAL catalog type
it pokes around in the actual types themselves. Since this is done on a
POSIX based system puppet attempts to validate the absolute path in the
file resource as a POSIX file path and fails since it is not a valid
absolute path.

This commit replaces the call to create the relationship graph to
determine where the windows file resource is at with a more basic test
to assert that the 'before' parameter is filled out on the resource
instead.