### PR TITLE
Remove legacy pe-mcollective-metadata cronjob

### DIFF
--- a/manifests/prepare/mco_client_config.pp
+++ b/manifests/prepare/mco_client_config.pp
@@ -52,4 +52,8 @@ class puppet_agent::prepare::mco_client_config {
     value   => $::puppet_agent::params::mco_log,
     require => File[$mco_client],
   }
+
+  cron { 'pe-mcollective-metadata':
+    ensure => absent,
+  }
 }


### PR DESCRIPTION
After using the puppet_agent module to [upgrade Puppet Enterprise](http://docs.puppetlabs.com/pe/latest/install_upgrading_agents.html#upgrade-agents-to-pe-201531-from-38x), the following mail started going to root every 15 minutes:
```
/bin/sh: /opt/puppet/sbin/refresh-mcollective-metadata: /opt/puppet/bin/ruby: bad interpreter: No such file or directory
```
There is no `refresh-mcollective-metadata` script anywhere in `/opt/puppetlabs`, so this cron job is useless.

This PR removes the cron job that invokes the old script.  For open source Puppet users, this is a null operation, since the cron job won't exist.