### PR TITLE
(PE-11531/PUP-5222) Allow puppet_agent to upgrade versions > 3.8

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,11 +7,17 @@
 #
 # === Parameters
 #
+# [arch]
+#   The package architecture.
+# [is_pe]
+#   Install from Puppet Enterprise repos.
 # [package_name]
 #   The package to upgrade to, i.e. `puppet-agent`.
 # [service_names]
 #   An array of services to start, normally `puppet` and `mcollective`.
 #   None will be started if the array is empty.
+# [source]
+#   The location to find packages.
 #
 class puppet_agent (
   $arch          = $::architecture,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,16 +1,20 @@
 # == Class: puppet_agent
 #
-# Upgrades Puppet 3.8 to Puppet 4+ (Puppet-Agent from Puppet Collection 1).
-# Makes the upgrade easier by migrating SSL certs and config files to the new
-# Puppet-Agent paths and removing deprecated settings that are no longer
+# Upgrades Puppet 3.8 and newer to the requested version.
+# Makes Puppet 4 upgrades easier by migrating SSL certs and config files to the
+# new Puppet-Agent paths and removing deprecated settings that are no longer
 # supported by Puppet 4.
 #
 # === Parameters
 #
+# [version]
+#   The package version to upgrade to. Defaults to undef, meaning only upgrade from Puppet < 4.0.
 # [arch]
-#   The package architecture.
+#   The package architecture. Defaults to the architecture fact.
+# [collection]
+#   The Puppet Collection to track. Defaults to 'PC1'.
 # [is_pe]
-#   Install from Puppet Enterprise repos.
+#   Install from Puppet Enterprise repos. Enabled if communicating with a PE master.
 # [package_name]
 #   The package to upgrade to, i.e. `puppet-agent`.
 # [service_names]
@@ -20,6 +24,8 @@
 #   The location to find packages.
 #
 class puppet_agent (
+  $version       = $::puppet_agent::params::version,
+  $collection    = $::puppet_agent::params::collection,
   $arch          = $::architecture,
   $is_pe         = $::puppet_agent::params::_is_pe,
   $package_name  = $::puppet_agent::params::package_name,
@@ -32,46 +38,47 @@ class puppet_agent (
   if versioncmp("${::clientversion}", '3.8.0') < 0 {
     fail('upgrading requires Puppet 3.8')
   }
-  elsif versioncmp("${::clientversion}", '4.0.0') >= 0 {
-    info('puppet_agent performs no actions on Puppet 4+')
+  elsif $::architecture == 'x86' and $arch == 'x64' {
+    fail('unable to install x64 on a x86 system')
+  }
+  elsif $version != undef and $version !~ /^\d+\.\d+\.\d+$/ {
+    fail("invalid version ${version} requested")
   }
   else {
-    if $::architecture == 'x86' and $arch == 'x64' {
-      fail('Unable to install x64 on a x86 system')
-    }
-    if $::osfamily == 'windows' {
-      class { '::puppet_agent::prepare': } ->
-      class { '::puppet_agent::windows::install': }
-    }
-    else {
-
-      if $::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '10' {
-        $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.sles10.${::architecture}.rpm"
-      } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '10' {
-        if $arch =~ '^sun4[uv]$' {
-          $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.sparc.pkg.gz"
-        } else {
-          $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.i386.pkg.gz"
-        }
-      } elsif $::operatingsystem == 'Darwin' and $::macosx_productversion_major =~ '10\.[9,10,11]' {
-        $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.osx${$::macosx_productversion_major}.dmg"
-      } elsif $::operatingsystem == 'aix' and $::architecture =~ 'PowerPC_POWER[5,6,7]' {
-        $aix_ver_number = regsubst($::platform_tag,'aix-(\d+\.\d+)-power','\1')
-        $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.aix${aix_ver_number}.ppc.rpm"
+    if $::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '10' {
+      $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.sles10.${::architecture}.rpm"
+    } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '10' {
+      if $arch =~ '^sun4[uv]$' {
+        $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.sparc.pkg.gz"
       } else {
-        $_package_file_name = undef
+        $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.i386.pkg.gz"
       }
+    } elsif $::operatingsystem == 'Darwin' and $::macosx_productversion_major =~ '10\.[9,10,11]' {
+      $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.osx${$::macosx_productversion_major}.dmg"
+    } elsif $::operatingsystem == 'aix' and $::architecture =~ 'PowerPC_POWER[5,6,7]' {
+      $aix_ver_number = regsubst($::platform_tag,'aix-(\d+\.\d+)-power','\1')
+      $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.aix${aix_ver_number}.ppc.rpm"
+    } else {
+      $_package_file_name = undef
+    }
 
-      class { '::puppet_agent::prepare':
-        package_file_name => $_package_file_name,
-      } ->
-      class { '::puppet_agent::install':
-        package_file_name => $_package_file_name,
-      } ->
-      class { '::puppet_agent::service': }
+    class { '::puppet_agent::prepare':
+      package_file_name => $_package_file_name,
+    } ->
+    class { '::puppet_agent::install':
+      package_file_name => $_package_file_name,
+      version => $version,
+    }
+    
+    contain '::puppet_agent::prepare'
+    contain '::puppet_agent::install'
 
-      contain '::puppet_agent::prepare'
-      contain '::puppet_agent::install'
+    if !$::puppet_agent::params::_windows_client {
+      # Starting services doesn't work with Windows, as the install must
+      # happen after Puppet has completed its run.
+      class { '::puppet_agent::service':
+        require => Class['::puppet_agent::install']
+      }
       contain '::puppet_agent::service'
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,8 +7,6 @@
 #
 # === Parameters
 #
-# [version]
-#   The package version to upgrade to. Defaults to undef, meaning only upgrade from Puppet < 4.0.
 # [arch]
 #   The package architecture. Defaults to the architecture fact.
 # [collection]
@@ -17,6 +15,8 @@
 #   Install from Puppet Enterprise repos. Enabled if communicating with a PE master.
 # [package_name]
 #   The package to upgrade to, i.e. `puppet-agent`.
+# [package_version]
+#   The package version to upgrade to. Defaults to undef, meaning only upgrade from Puppet < 4.0.
 # [service_names]
 #   An array of services to start, normally `puppet` and `mcollective`.
 #   None will be started if the array is empty.
@@ -24,13 +24,13 @@
 #   The location to find packages.
 #
 class puppet_agent (
-  $version       = $::puppet_agent::params::version,
-  $collection    = $::puppet_agent::params::collection,
-  $arch          = $::architecture,
-  $is_pe         = $::puppet_agent::params::_is_pe,
-  $package_name  = $::puppet_agent::params::package_name,
-  $service_names = $::puppet_agent::params::service_names,
-  $source        = $::puppet_agent::params::_source,
+  $collection      = $::puppet_agent::params::collection,
+  $arch            = $::architecture,
+  $is_pe           = $::puppet_agent::params::_is_pe,
+  $package_name    = $::puppet_agent::params::package_name,
+  $package_version = $::puppet_agent::params::package_version,
+  $service_names   = $::puppet_agent::params::service_names,
+  $source          = $::puppet_agent::params::_source,
 ) inherits ::puppet_agent::params {
 
   validate_re($arch, ['^x86$','^x64$','^i386$','^i86pc$','^amd64$','^x86_64$','^power$','^sun4[uv]$','PowerPC_POWER'])
@@ -41,8 +41,8 @@ class puppet_agent (
   elsif $::architecture == 'x86' and $arch == 'x64' {
     fail('unable to install x64 on a x86 system')
   }
-  elsif $version != undef and $version !~ /^\d+\.\d+\.\d+$/ {
-    fail("invalid version ${version} requested")
+  elsif $package_version != undef and $package_version !~ /^\d+\.\d+\.\d+[.-]?\d*$/ {
+    fail("invalid version ${package_version} requested")
   }
   else {
     if $::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '10' {
@@ -67,9 +67,9 @@ class puppet_agent (
     } ->
     class { '::puppet_agent::install':
       package_file_name => $_package_file_name,
-      version => $version,
+      package_version   => $package_version,
     }
-    
+
     contain '::puppet_agent::prepare'
     contain '::puppet_agent::install'
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,49 +8,23 @@
 #   The puppet-agent package file name.
 #   (see puppet_agent::prepare::package_file_name)
 #
+# [version]
+#   The puppet-agent version to install.
 class puppet_agent::install(
   $package_file_name = undef,
+  $version
 ) {
   assert_private()
 
-  if ($::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '10') or ($::operatingsystem == 'AIX' and  $::architecture =~ 'PowerPC_POWER[5,6,7]') {
-    contain puppet_agent::install::remove_packages
-
-    exec { 'replace puppet.conf removed by package removal':
-      path      => '/bin:/usr/bin:/sbin:/usr/sbin',
-      command   => "cp ${puppet_agent::params::confdir}/puppet.conf.rpmsave ${puppet_agent::params::config}",
-      creates   => $puppet_agent::params::config,
-      require   => Class['puppet_agent::install::remove_packages'],
-      before    => Package[$puppet_agent::package_name],
-      logoutput => 'on_failure',
+  if $::puppet_agent::params::_windows_client {
+    class { '::puppet_agent::install::windows':
+      version => $version,
     }
-
-    $_package_options = {
-      provider        => 'rpm',
-      source          => "/opt/puppetlabs/packages/${package_file_name}",
-    }
-  } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '10' {
-    contain puppet_agent::install::remove_packages
-
-    $_unzipped_package_name = regsubst($package_file_name, '\.gz$', '')
-    $_package_options = {
-      adminfile => '/opt/puppetlabs/packages/solaris-noask',
-      source    => "/opt/puppetlabs/packages/${_unzipped_package_name}",
-      require   => Class['puppet_agent::install::remove_packages'],
-    }
-  } elsif $::operatingsystem == 'Darwin' and $::macosx_productversion_major =~ '10\.[9,10,11]' {
-    contain puppet_agent::install::remove_packages
-
-    $_package_options = {
-      source    => "/opt/puppetlabs/packages/${package_file_name}",
-      require   => Class['puppet_agent::install::remove_packages'],
-    }
+    contain '::puppet_agent::install::windows'
   } else {
-    $_package_options = {}
-  }
-
-  package { $::puppet_agent::package_name:
-    ensure => present,
-    *      => $_package_options,
+    class { '::puppet_agent::install::default':
+      version => $version,
+    }
+    contain '::puppet_agent::install::default'
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,18 +12,19 @@
 #   The puppet-agent version to install.
 class puppet_agent::install(
   $package_file_name = undef,
-  $version
+  $package_version
 ) {
   assert_private()
 
   if $::puppet_agent::params::_windows_client {
-    class { '::puppet_agent::install::windows':
-      version => $version,
+    class { '::puppet_agent::windows::install':
+      package_version    => $package_version,
     }
-    contain '::puppet_agent::install::windows'
+    contain '::puppet_agent::windows::install'
   } else {
     class { '::puppet_agent::install::default':
-      version => $version,
+      package_file_name => $package_file_name,
+      package_version   => $package_version,
     }
     contain '::puppet_agent::install::default'
   }

--- a/manifests/install/default.pp
+++ b/manifests/install/default.pp
@@ -1,0 +1,57 @@
+# == Class puppet_agent::install::default
+#
+# Private class called from puppet_agent::install class
+#
+# Manage the install process for systems using their default package provider
+#
+class puppet_agent::install::default (
+  $package_file_name = undef,
+  $version
+) {
+  assert_private()
+
+  if $version == undef {
+    $version = 'present'
+  }
+
+  if ($::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '10') or ($::operatingsystem == 'AIX' and  $::architecture =~ 'PowerPC_POWER[5,6,7]') {
+    contain puppet_agent::install::remove_packages
+
+    exec { 'replace puppet.conf removed by package removal':
+      path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+      command   => "cp ${puppet_agent::params::confdir}/puppet.conf.rpmsave ${puppet_agent::params::config}",
+      creates   => $puppet_agent::params::config,
+      require   => Class['puppet_agent::install::remove_packages'],
+      before    => Package[$puppet_agent::package_name],
+      logoutput => 'on_failure',
+    }
+
+    $_package_options = {
+      provider        => 'rpm',
+      source          => "/opt/puppetlabs/packages/${package_file_name}",
+    }
+  } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '10' {
+    contain puppet_agent::install::remove_packages
+
+    $_unzipped_package_name = regsubst($package_file_name, '\.gz$', '')
+    $_package_options = {
+      adminfile => '/opt/puppetlabs/packages/solaris-noask',
+      source    => "/opt/puppetlabs/packages/${_unzipped_package_name}",
+      require   => Class['puppet_agent::install::remove_packages'],
+    }
+  } elsif $::operatingsystem == 'Darwin' and $::macosx_productversion_major =~ '10\.[9,10,11]' {
+    contain puppet_agent::install::remove_packages
+
+    $_package_options = {
+      source    => "/opt/puppetlabs/packages/${package_file_name}",
+      require   => Class['puppet_agent::install::remove_packages'],
+    }
+  } else {
+    $_package_options = {}
+  }
+
+  package { $::puppet_agent::package_name:
+    ensure => $version,
+    *      => $_package_options,
+  }
+}

--- a/manifests/install/default.pp
+++ b/manifests/install/default.pp
@@ -6,12 +6,12 @@
 #
 class puppet_agent::install::default (
   $package_file_name = undef,
-  $version
+  $package_version
 ) {
   assert_private()
 
-  if $version == undef {
-    $version = 'present'
+  if $package_version == undef {
+    $package_version = 'present'
   }
 
   if ($::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '10') or ($::operatingsystem == 'AIX' and  $::architecture =~ 'PowerPC_POWER[5,6,7]') {
@@ -51,7 +51,7 @@ class puppet_agent::install::default (
   }
 
   package { $::puppet_agent::package_name:
-    ensure => $version,
+    ensure => $package_version,
     *      => $_package_options,
   }
 }

--- a/manifests/osfamily/debian.pp
+++ b/manifests/osfamily/debian.pp
@@ -30,7 +30,7 @@ class puppet_agent::osfamily::debian(
       "Acquire::http:::proxy::${source_host} DIRECT;",
     ]
 
-    apt::setting { 'conf-pc1_repo':
+    apt::setting { 'conf-pc_repo':
       content  => $_apt_settings.join(''),
       priority => 90,
     }
@@ -59,20 +59,20 @@ class puppet_agent::osfamily::debian(
   }
 
 
-  apt::source { 'pc1_repo':
+  apt::source { 'pc_repo':
     location => $source,
-    repos    => 'PC1',
+    repos    => $::puppet_agent::collection,
     key      => {
       'id'     => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
       'server' => 'pgp.mit.edu',
     },
-    notify   => Notify['pc1_repo_force'],
+    notify   => Notify['pc_repo_force'],
   }
 
   # apt_update doesn't inherit the future class dependency, so it
   # can wait until the end of the run to exec. Force it to happen now.
-  notify { 'pc1_repo_force':
-      message => 'forcing apt update for pc1_repo',
+  notify { 'pc_repo_force':
+      message => 'forcing apt update for pc_repo',
       require => Exec['apt_update'],
   }
 }

--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -35,7 +35,7 @@ class puppet_agent::osfamily::redhat(
   }
   else {
     $source = $::puppet_agent::source ? {
-      undef   => "https://yum.puppetlabs.com/${urlbit}/PC1/${::architecture}",
+      undef   => "https://yum.puppetlabs.com/${urlbit}/${::puppet_agent::collection}/${::architecture}",
       default => $::puppet_agent::source,
     }
   }
@@ -64,9 +64,9 @@ class puppet_agent::osfamily::redhat(
     logoutput => 'on_failure',
   }
 
-  yumrepo { 'pc1_repo':
+  yumrepo { 'pc_repo':
     baseurl       => $source,
-    descr         => 'Puppet Labs PC1 Repository',
+    descr         => "Puppet Labs ${::puppet_agent::collection} Repository",
     enabled       => true,
     gpgcheck      => '1',
     gpgkey        => "file://${gpg_path}",

--- a/manifests/osfamily/suse.pp
+++ b/manifests/osfamily/suse.pp
@@ -45,8 +45,8 @@ class puppet_agent::osfamily::suse(
       $pe_server_version = pe_build_version()
       $source = "${::puppet_agent::source}/${pe_server_version}/${::platform_tag}"
 
-      $repo_file = '/etc/zypp/repos.d/pc1_repo.repo'
-      $repo_name = 'pc1_repo'
+      $repo_file = '/etc/zypp/repos.d/pc_repo.repo'
+      $repo_name = 'pc_repo'
 
       # In Puppet Enterprise, agent packages are served by the same server
       # as the master, which can be using either a self signed CA, or an external CA.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,9 @@ class puppet_agent::params {
   # function is available
   $_is_pe = ($::is_pe or is_function_available('pe_compiling_server_version'))
 
+  $version = undef
+  $collection = 'PC1'
+
   # In Puppet Enterprise, agent packages are provided by the master
   # with a default prefix of `/packages`.
   if $::osfamily != 'windows' {
@@ -46,6 +49,7 @@ class puppet_agent::params {
       $mcodirs = [$mco_dir] # Directories should already exists as they have not changed
       $puppetdirs = [regsubst($confdir,'\/etc\/','/code/')]
       $path_separator = ';'
+      $_windows_client = true
     }
     default: {
       fail("${::operatingsystem} not supported")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,7 +12,7 @@ class puppet_agent::params {
   # function is available
   $_is_pe = ($::is_pe or is_function_available('pe_compiling_server_version'))
 
-  $version = undef
+  $package_version = undef
   $collection = 'PC1'
 
   # In Puppet Enterprise, agent packages are provided by the master

--- a/manifests/windows/install.pp
+++ b/manifests/windows/install.pp
@@ -4,8 +4,8 @@
 #
 # Manage the install process for windows specifically
 #
-class puppet_agent::install::windows (
-  $version
+class puppet_agent::windows::install (
+  $package_version
 ) {
   assert_private()
 
@@ -16,17 +16,17 @@ class puppet_agent::install::windows (
 
   # If version is undefined and not at Puppet 4, upgrade to latest.
   # Otherwise only perform an upgrade if version declares a version different from the current one.
-  if ($version == undef and versioncmp("${::clientversion}", '4.0.0') < 0) or ($version != undef and versioncmp("${::clientversion}", $version) != 0) {
+  if ($package_version == undef and versioncmp("${::clientversion}", '4.0.0') < 0) or ($package_version != undef and versioncmp("${::clientversion}", $package_version) != 0) {
     if $::puppet_agent::is_pe {
       $_agent_version = chomp(file('/opt/puppetlabs/puppet/VERSION'))
       $_pe_server_version = pe_build_version()
       $_https_source = "https://pm.puppetlabs.com/puppet-agent/${_pe_server_version}/${_agent_version}/repos/windows/puppet-agent-${_arch}.msi"
     }
-    elsif $version == undef {
+    elsif $package_version == undef {
       $_https_source = "https://downloads.puppetlabs.com/windows/puppet-agent-${_arch}-latest.msi"
     }
     else {
-      $_https_source = "https://downloads.puppetlabs.com/windows/puppet-agent-${version}-${_arch}.msi"
+      $_https_source = "https://downloads.puppetlabs.com/windows/puppet-agent-${package_version}-${_arch}.msi"
     }
 
     $_source = $::puppet_agent::source ? {

--- a/manifests/windows/install.pp
+++ b/manifests/windows/install.pp
@@ -1,10 +1,12 @@
-# == Class puppet_agent::windows::install
+# == Class puppet_agent::install::windows
 #
-# Private class called from puppet_agent class
+# Private class called from puppet_agent::install class
 #
 # Manage the install process for windows specifically
 #
-class puppet_agent::windows::install {
+class puppet_agent::install::windows (
+  $version
+) {
   assert_private()
 
   $_arch = $::kernelmajversion ?{
@@ -12,48 +14,55 @@ class puppet_agent::windows::install {
     default   => $::puppet_agent::arch
   }
 
-  if $::puppet_agent::is_pe {
-    $_agent_version = $puppet_agent::params::master_agent_version
-    $_pe_server_version = pe_build_version()
-    $_https_source = "https://pm.puppetlabs.com/puppet-agent/${_pe_server_version}/${_agent_version}/repos/windows/puppet-agent-${_arch}.msi"
-  }
-  else {
-    $_https_source = "https://downloads.puppetlabs.com/windows/puppet-agent-${_arch}-latest.msi"
-  }
-
-  $_source = $::puppet_agent::source ? {
-    undef          => $_https_source,
-    /^[a-zA-Z]:/ => windows_native_path($::puppet_agent::source),
-    default        => $::puppet_agent::source,
-  }
-
-  $_msi_location = $_source ? {
-    /^puppet:/ => "${::env_temp_variable}\\puppet-agent.msi",
-    default    => $_source,
-  }
-
-  if $_source =~ /^puppet:/ {
-    file{ $_msi_location:
-      source => $_source,
-      before => File["${::env_temp_variable}\\install_puppet.bat"],
+  # If version is undefined and not at Puppet 4, upgrade to latest.
+  # Otherwise only perform an upgrade if version declares a version different from the current one.
+  if ($version == undef and versioncmp("${::clientversion}", '4.0.0') < 0) or ($version != undef and versioncmp("${::clientversion}", $version) != 0) {
+    if $::puppet_agent::is_pe {
+      $_agent_version = chomp(file('/opt/puppetlabs/puppet/VERSION'))
+      $_pe_server_version = pe_build_version()
+      $_https_source = "https://pm.puppetlabs.com/puppet-agent/${_pe_server_version}/${_agent_version}/repos/windows/puppet-agent-${_arch}.msi"
     }
-  }
+    elsif $version == undef {
+      $_https_source = "https://downloads.puppetlabs.com/windows/puppet-agent-${_arch}-latest.msi"
+    }
+    else {
+      $_https_source = "https://downloads.puppetlabs.com/windows/puppet-agent-${version}-${_arch}.msi"
+    }
 
-  $_cmd_location = $::rubyplatform ? {
-    /i386/  => 'C:\\Windows\\system32\\cmd.exe',
-    default => "${::system32}\\cmd.exe"
-  }
+    $_source = $::puppet_agent::source ? {
+      undef          => $_https_source,
+      /^[a-zA-Z]:/ => windows_native_path($::puppet_agent::source),
+      default        => $::puppet_agent::source,
+    }
 
-  $_timestamp = strftime('%Y_%m_%d-%H_%M')
-  $_logfile = "${::env_temp_variable}\\puppet-${_timestamp}-installer.log"
-  notice ("Puppet upgrade log file at ${_logfile}")
-  debug ("Installing puppet from ${_msi_location}")
-  file { "${::env_temp_variable}\\install_puppet.bat":
-    ensure  => file,
-    content => template('puppet_agent/install_puppet.bat.erb')
-  }->
-  exec { 'install_puppet.bat':
-    command => "${::system32}\\cmd.exe /c start /b ${_cmd_location} /c \"${::env_temp_variable}\\install_puppet.bat\"",
-    path    => $::path,
+    $_msi_location = $_source ? {
+      /^puppet:/ => "${::env_temp_variable}\\puppet-agent.msi",
+      default    => $_source,
+    }
+
+    if $_source =~ /^puppet:/ {
+      file{ $_msi_location:
+        source => $_source,
+        before => File["${::env_temp_variable}\\install_puppet.bat"],
+      }
+    }
+
+    $_cmd_location = $::rubyplatform ? {
+      /i386/  => 'C:\\Windows\\system32\\cmd.exe',
+      default => "${::system32}\\cmd.exe"
+    }
+
+    $_timestamp = strftime('%Y_%m_%d-%H_%M')
+    $_logfile = "${::env_temp_variable}\\puppet-${_timestamp}-installer.log"
+    notice ("Puppet upgrade log file at ${_logfile}")
+    debug ("Installing puppet from ${_msi_location}")
+    file { "${::env_temp_variable}\\install_puppet.bat":
+      ensure  => file,
+      content => template('puppet_agent/install_puppet.bat.erb')
+    }->
+    exec { 'install_puppet.bat':
+      command => "${::system32}\\cmd.exe /c start /b ${_cmd_location} /c \"${::env_temp_variable}\\install_puppet.bat\"",
+      path    => $::path,
+    }
   }
 }

--- a/spec/classes/puppet_agent_install_default_spec.rb
+++ b/spec/classes/puppet_agent_install_default_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+describe 'puppet_agent', :if => Puppet.version >= '3.8.0' do
+  context 'version is undefined' do
+    let(:facts) { {
+      :architecture => 'x86',
+      :osfamily => 'RedHat',
+    } }
+    it { is_expected.to contain_package('puppet-agent').with_ensure('present') }
+  end
+
+  context 'version is 1.0.0' do
+    let(:facts) { {
+      :architecture => 'x86',
+      :osfamily => 'RedHat',
+    } }
+    let(:params) { {:version => '1.0.0'} }
+    it { is_expected.to contain_package('puppet-agent').with_ensure('1.0.0') }
+  end
+
+  context 'version is foo' do
+    let(:facts) { {
+      :architecture => 'x86',
+      :osfamily => 'RedHat',
+    } }
+    let(:params) { {:version => 'foo'} }
+    it { expect {is_expected.to contain_package('puppet_agent') }.to raise_error(Puppet::Error, /invalid version foo requested/) }
+  end
+end

--- a/spec/classes/puppet_agent_install_default_spec.rb
+++ b/spec/classes/puppet_agent_install_default_spec.rb
@@ -9,13 +9,15 @@ describe 'puppet_agent', :if => Puppet.version >= '3.8.0' do
     it { is_expected.to contain_package('puppet-agent').with_ensure('present') }
   end
 
-  context 'version is 1.0.0' do
-    let(:facts) { {
-      :architecture => 'x86',
-      :osfamily => 'RedHat',
-    } }
-    let(:params) { {:version => '1.0.0'} }
-    it { is_expected.to contain_package('puppet-agent').with_ensure('1.0.0') }
+  ['1.0.0', '1.0.0-1', '1.0.0.1'].each do |version|
+    context "version is #{version}" do
+      let(:facts) { {
+        :architecture => 'x86',
+        :osfamily => 'RedHat',
+      } }
+      let(:params) { {:package_version => version} }
+      it { is_expected.to contain_package('puppet-agent').with_ensure(version) }
+    end
   end
 
   context 'version is foo' do
@@ -23,7 +25,7 @@ describe 'puppet_agent', :if => Puppet.version >= '3.8.0' do
       :architecture => 'x86',
       :osfamily => 'RedHat',
     } }
-    let(:params) { {:version => 'foo'} }
+    let(:params) { {:package_version => 'foo'} }
     it { expect {is_expected.to contain_package('puppet_agent') }.to raise_error(Puppet::Error, /invalid version foo requested/) }
   end
 end

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
-describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >= "4.0.0" do
+describe 'puppet_agent', :if => Puppet.version >= '3.8.0' do
+
   facts = {
     :lsbdistid => 'Debian',
     :osfamily => 'Debian',
@@ -52,12 +53,12 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
       "Acquire::https::master.example.vm::SslKey \"/etc/puppetlabs/puppet/ssl/private_keys/foo.example.vm.pem\";",
       "Acquire::http:::proxy::master.example.vm DIRECT;",
     ]
-    it { is_expected.to contain_apt__setting('conf-pc1_repo').with({
+    it { is_expected.to contain_apt__setting('conf-pc_repo').with({
       'priority' => 90,
       'content'  => apt_settings.join(''),
     }) }
 
-    it { is_expected.to contain_apt__source('pc1_repo').with({
+    it { is_expected.to contain_apt__source('pc_repo').with({
       'location' => 'https://master.example.vm:8140/packages/4.0.0/debian-7-x86_64',
       'repos'    => 'PC1',
       'key'      => {
@@ -72,7 +73,7 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
     it { is_expected.not_to contain_apt__setting('conf-pe-repo') }
     it { is_expected.not_to contain_apt__setting('list-puppet-enterprise-installer') }
 
-    it { is_expected.to contain_apt__source('pc1_repo').with({
+    it { is_expected.to contain_apt__source('pc_repo').with({
       'location' => 'http://apt.puppetlabs.com',
       'repos'    => 'PC1',
       'key'      => {

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
-describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >= "4.0.0" do
+describe 'puppet_agent', :if => Puppet.version >= '3.8.0' do
+
   [['Fedora', 'fedora/f$releasever'], ['CentOS', 'el/$releasever']].each do |os, urlbit|
     context "with #{os} and #{urlbit}" do
       facts = {
@@ -37,7 +38,7 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
 
       context 'when FOSS' do
         it { is_expected.not_to contain_yumrepo('puppetlabs-pepackages').with_ensure('absent') }
-        it { is_expected.to contain_yumrepo('pc1_repo').with({
+        it { is_expected.to contain_yumrepo('pc_repo').with({
           'baseurl' => "https://yum.puppetlabs.com/#{urlbit}/PC1/x64",
           'enabled' => 'true',
             'gpgcheck' => '1',
@@ -67,7 +68,7 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
 
         it { is_expected.to contain_yumrepo('puppetlabs-pepackages').with_ensure('absent') }
 
-        it { is_expected.to contain_yumrepo('pc1_repo').with({
+        it { is_expected.to contain_yumrepo('pc_repo').with({
           'baseurl' => "https://master.example.vm:8140/packages/4.0.0/el-7-x86_64",
           'enabled' => 'true',
           'gpgcheck' => '1',

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
-describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >= "4.0.0" do
+describe 'puppet_agent', :if => Puppet.version >= '3.8.0' do
+
   before(:each) do
     # Need to mock the PE functions
     Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
@@ -134,15 +135,15 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
           }) }
 
           {
-            'name'        => 'pc1_repo',
+            'name'        => 'pc_repo',
             'enabled'      => '1',
             'autorefresh' => '0',
             'baseurl'     => "https://master.example.vm:8140/packages/4.0.0/sles-#{os_version}-x86_64?ssl_verify=no",
             'type'        => 'rpm-md',
           }.each do |setting, value|
-              it { is_expected.to contain_ini_setting("zypper pc1_repo #{setting}").with({
-                'path'    => '/etc/zypp/repos.d/pc1_repo.repo',
-                'section' => 'pc1_repo',
+              it { is_expected.to contain_ini_setting("zypper pc_repo #{setting}").with({
+                'path'    => '/etc/zypp/repos.d/pc_repo.repo',
+                'section' => 'pc_repo',
                 'setting' => setting,
                 'value'   => value,
               }) }

--- a/spec/classes/puppet_agent_prepare_spec.rb
+++ b/spec/classes/puppet_agent_prepare_spec.rb
@@ -5,12 +5,13 @@ MCO_LIBDIR = '/opt/puppetlabs/mcollective/plugins'
 MCO_PLUGIN_YAML = '/etc/puppetlabs/mcollective/facts.yaml'
 MCO_LOGFILE = '/var/log/puppetlabs/mcollective.log'
 
-describe 'puppet_agent::prepare' do
+describe 'puppet_agent', :if => (Puppet.version >= '3.8.0' and Puppet.version < '4.0.0') do
+
   context 'supported operating system families' do
     ['Debian', 'RedHat'].each do |osfamily|
       facts = {
         :operatingsystem => 'foo',
-        :architecture => 'bar',
+        :architecture => 'x86_64',
         :osfamily => osfamily,
         :lsbdistid => osfamily,
         :lsbdistcodename => 'baz',
@@ -122,9 +123,9 @@ describe 'puppet_agent::prepare' do
         ['certificate_requests', 'certs', 'private', 'private_keys', 'public_keys'].each do |dir|
           it { is_expected.to contain_file("/etc/puppetlabs/puppet/ssl/#{dir}").with({
             'ensure'  => 'directory',
-            'source'  => "/dev/null/ssl/#{dir}",
+              'source'  => "/dev/null/ssl/#{dir}",
             'backup'  => 'false',
-            'recurse' => 'true',
+              'recurse' => 'true',
           }) }
         end
 
@@ -199,6 +200,26 @@ describe 'puppet_agent::prepare' do
              it { is_expected.to contain_ini_setting("#{section}/#{setting}").with_ensure('absent') }
            end
         end
+      end
+    end
+  end
+end
+
+describe 'puppet_agent', :if => Puppet.version >= '3.8.0' do
+  context 'supported operating system families' do
+    ['Debian', 'RedHat'].each do |osfamily|
+      facts = {
+        :operatingsystem => 'foo',
+        :architecture => 'x86_64',
+        :osfamily => osfamily,
+        :lsbdistid => osfamily,
+        :lsbdistcodename => 'baz',
+        :mco_server_config => nil,
+        :mco_client_config => nil,
+      }
+
+      context "on #{osfamily}" do
+        let(:facts) { facts }
 
         it { is_expected.to contain_class("puppet_agent::osfamily::#{facts[:osfamily]}") }
       end

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -1,188 +1,180 @@
 require 'spec_helper'
 
-RSpec.describe 'puppet_agent', :unless => Puppet.version =~ /^(3\.7|4.\d+)\.\d+/ do
+describe 'puppet_agent', :if => (Puppet.version >= '3.8.0' and Puppet.version < '4.0.0') do
+  {'5.1' => {:expect_arch => 'x86', :appdata => 'C:/Document and Settings/All Users/Application Data/Puppetlabs'},
+   '6.1' => {:expect_arch => 'x64', :appdata => 'C:/ProgramData/Puppetlabs'}}.each do |kernelmajversion, values|
+    context "Windows Kernelmajversion #{kernelmajversion}" do
+      let(:facts) { {
+        :architecture => 'x64',
+        :env_temp_variable => 'C:\tmp',
+        :kernelmajversion => kernelmajversion,
+        :osfamily => 'windows',
+        :puppet_confdir => "#{values[:appdata]}/puppet/etc",
+        :mco_confdir => "#{values[:appdata]}/mcollective/etc",
+        :puppet_agent_pid => 42,
+        :system32 => 'C:\windows\sysnative',
+      } }
+      context 'is_pe' do
+        before(:each) do
+          # Need to mock the function pe_build_version
+          pe_build_version = {}
+          file = {}
 
-  if Puppet.version >= "4.0.0"
-    it {
-      is_expected.to_not contain_class('::puppet_agent::windows::install')
-    }
-  elsif Puppet.version >= "3.8.0"
-    {'5.1' => {:expect_arch => 'x86', :appdata => 'C:/Document and Settings/All Users/Application Data/Puppetlabs'},
-     '6.1' => {:expect_arch => 'x64', :appdata => 'C:/ProgramData/Puppetlabs'}}.each do |kernelmajversion, values|
-      context "Windows Kernelmajversion #{kernelmajversion}" do
-        facts = {
-          :architecture => 'x64',
-          :env_temp_variable => 'C:\tmp',
-          :kernelmajversion => kernelmajversion,
-          :osfamily => 'windows',
-          :puppetversion => '3.8.0',
-          :puppet_confdir => "#{values[:appdata]}/puppet/etc",
-          :mco_confdir => "#{values[:appdata]}/mcollective/etc",
-          :puppet_agent_pid => 42,
-          :system32 => 'C:\windows\sysnative',
+          Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) {
+            |args| pe_build_version.call()
+          }
+          Puppet::Parser::Functions.newfunction(:file, :type => :rvalue) {
+            |args| file.call(args[0])
+          }
+
+          pe_build_version.stubs(:call).returns('4.0.0')
+          file.stubs(:call).with('/opt/puppetlabs/puppet/VERSION').returns('1.2.1.1')
+        end
+        let(:params) {{ :is_pe => true }}
+        it {
+          is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+            %r[#{Regexp.escape("msiexec.exe /qn /norestart /i \"https://pm.puppetlabs.com/puppet-agent/4.0.0/1.2.1.1/repos/windows/puppet-agent-#{values[:expect_arch]}.msi\"")}])
         }
+      end
 
-        let(:facts) { facts }
-
-        context 'is_pe' do
-          before(:each) do
-            # Need to mock the PE functions
-
-            Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
-              '4.0.0'
-            end
-
-            Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
-              '1.2.1.1'
-            end
-          end
-
-          let(:facts) { facts.merge({:is_pe => true}) }
-
+      context 'source =>' do
+        describe 'https://alterernate.com/puppet-agent.msi' do
+          let(:params) { {
+            :source => 'https://alternate.com/puppet-agent.msi',
+          } }
           it {
             is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-              %r[#{Regexp.escape("msiexec.exe /qn /norestart /i \"https://pm.puppetlabs.com/puppet-agent/4.0.0/1.2.1.1/repos/windows/puppet-agent-#{values[:expect_arch]}.msi\"")}])
+              /msiexec.exe \/qn \/norestart \/i "https:\/\/alternate.com\/puppet-agent.msi"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/PID eq 42/)
           }
         end
-        context 'source =>' do
-          describe 'https://alterernate.com/puppet-agent.msi' do
-            let(:params) { {
-              :source => 'https://alternate.com/puppet-agent.msi',
-            } }
-            it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "https:\/\/alternate.com\/puppet-agent.msi"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/PID eq 42/)
-            }
-          end
-          describe 'C:/tmp/puppet-agent-x64.msi' do
-            let(:params) { {
-              :source => 'C:/tmp/puppet-agent-x64.msi',
-            } }
-            it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "C:\\tmp\\puppet-agent-x64\.msi"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/PID eq 42/)
-            }
-          end
-          describe 'C:\Temp/ Folder\puppet-agent-x64.msi' do
-            let(:params) { {
-              :source => 'C:\Temp/ Folder\puppet-agent-x64.msi',
-            } }
-            it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "C:\\Temp Folder\\puppet-agent-x64\.msi"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/PID eq 42/)
-            }
-          end
-          describe 'C:/Temp/ Folder/puppet-agent-x64.msi' do
-            let(:params) { {
-              :source => 'C:/Temp/ Folder/puppet-agent-x64.msi',
-            } }
-            it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "C:\\Temp Folder\\puppet-agent-x64\.msi"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/PID eq 42/)
-            }
-          end
-          describe '\\\\garded\c$\puppet-agent-x64.msi' do
-            let(:params) { {
-              :source => "\\\\garded\\c$\\puppet-agent-x64.msi",
-            } }
-            it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "\\\\garded\\c\$\\puppet-agent-x64\.msi"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/PID eq 42/)
-            }
-          end
-          describe 'default source' do
-            let(:params) { {} }
-            it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "https:\/\/downloads.puppetlabs.com\/windows\/puppet-agent-#{values[:expect_arch]}-latest\.msi"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer\.log"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/PID eq 42/)
-            }
-            it {
-              should contain_exec('install_puppet.bat').with { {
-                       'command' => 'C:\windows\sysnative\cmd.exe /c start /b "C:\tmp\install_puppet.bat"',
-                     } }
-            }
-            it {
-              is_expected.to_not contain_file('C:\tmp\puppet-agent.msi')
-            }
-          end
-          describe 'puppet:///puppet_agent/puppet-agent-1.1.0-x86.msi' do
-            let(:params) { {:source => 'puppet:///puppet_agent/puppet-agent-1.1.0-x86.msi'} }
-            it {
-              is_expected.to contain_file('C:\tmp\puppet-agent.msi').with_before('File[C:\tmp\install_puppet.bat]')
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "C:\\tmp\\puppet-agent.msi"/
-                             )
-            }
-          end
+        describe 'C:/tmp/puppet-agent-x64.msi' do
+          let(:params) { {
+            :source => 'C:/tmp/puppet-agent-x64.msi',
+          } }
+          it {
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+              /msiexec.exe \/qn \/norestart \/i "C:\\tmp\\puppet-agent-x64\.msi"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/PID eq 42/)
+          }
         end
-        context 'arch =>' do
-          describe 'specify x86' do
-            let(:params) { {:arch => 'x86'} }
-            it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "https:\/\/downloads.puppetlabs.com\/windows\/puppet-agent-x86-latest\.msi"/
-                             )
-            }
-          end
-
-          describe 'try x64 on x86 system' do
-            let(:facts) { {
-              :osfamily => 'windows',
-              :puppetversion => '3.8.0',
-              :tmpdir => 'C:\tmp',
-              :architecture => 'x86',
-              :system32 => 'C:\windows\sysnative'
+        describe 'C:\Temp/ Folder\puppet-agent-x64.msi' do
+          let(:params) { {
+            :source => 'C:\Temp/ Folder\puppet-agent-x64.msi',
+          } }
+          it {
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+              /msiexec.exe \/qn \/norestart \/i "C:\\Temp Folder\\puppet-agent-x64\.msi"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/PID eq 42/)
+          }
+        end
+        describe 'C:/Temp/ Folder/puppet-agent-x64.msi' do
+          let(:params) { {
+            :source => 'C:/Temp/ Folder/puppet-agent-x64.msi',
+          } }
+          it {
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+              /msiexec.exe \/qn \/norestart \/i "C:\\Temp Folder\\puppet-agent-x64\.msi"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/PID eq 42/)
+          }
+        end
+        describe '\\\\garded\c$\puppet-agent-x64.msi' do
+          let(:params) { {
+            :source => "\\\\garded\\c$\\puppet-agent-x64.msi",
+          } }
+          it {
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+              /msiexec.exe \/qn \/norestart \/i "\\\\garded\\c\$\\puppet-agent-x64\.msi"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/PID eq 42/)
+          }
+        end
+        describe 'default source' do
+          it {
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+              /msiexec.exe \/qn \/norestart \/i "https:\/\/downloads.puppetlabs.com\/windows\/puppet-agent-#{values[:expect_arch]}-latest\.msi"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer\.log"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/PID eq 42/)
+          }
+          it {
+            should contain_exec('install_puppet.bat').with { {
+              'command' => 'C:\windows\sysnative\cmd.exe /c start /b "C:\tmp\install_puppet.bat"',
             } }
-            let(:params) { {:arch => 'x64'} }
-            it {
-              expect { catalogue }.to raise_error(Puppet::Error, /Unable to install x64 on a x86 system/)
-            }
-          end
+          }
+          it {
+            is_expected.to_not contain_file('C:\tmp\puppet-agent.msi')
+          }
+        end
+        describe 'puppet:///puppet_agent/puppet-agent-1.1.0-x86.msi' do
+          let(:params) { {:source => 'puppet:///puppet_agent/puppet-agent-1.1.0-x86.msi'} }
+          it {
+            is_expected.to contain_file('C:\tmp\puppet-agent.msi').that_comes_before('File[C:\tmp\install_puppet.bat]')
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+              /msiexec.exe \/qn \/norestart \/i "C:\\tmp\\puppet-agent.msi"/
+            )
+          }
         end
       end
-      context 'rubyplatform' do
-        facts = {
-          :architecture => 'x64',
-          :env_temp_variable => 'C:\tmp',
-          :kernelmajversion => kernelmajversion,
-          :osfamily => 'windows',
-          :puppetversion => '3.8.0',
-          :puppet_confdir => "#{values[:appdata]}/puppet/etc",
-          :mco_confdir => "#{values[:appdata]}/mcollective/etc",
-          :puppet_agent_pid => 42,
-          :system32 => 'C:\windows\sysnative',
-          :tmpdir => 'C:\tmp',
+
+      context 'arch =>' do
+        describe 'specify x86' do
+          let(:params) { {:arch => 'x86'} }
+          it {
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+              /msiexec.exe \/qn \/norestart \/i "https:\/\/downloads.puppetlabs.com\/windows\/puppet-agent-x86-latest\.msi"/
+            )
+          }
+        end
+
+        describe 'try x64 on x86 system' do
+          let(:facts) { {
+            :osfamily => 'windows',
+            :tmpdir => 'C:\tmp',
+            :architecture => 'x86',
+            :puppet_confdir => "#{values[:appdata]}/puppet/etc",
+            :system32 => 'C:\windows\sysnative'
+          } }
+          let(:params) { {:arch => 'x64'} }
+          it {
+            expect { catalogue }.to raise_error(Puppet::Error, /unable to install x64 on a x86 system/)
+          }
+        end
+      end
+    end
+
+    context 'rubyplatform' do
+      facts = {
+        :architecture => 'x64',
+        :env_temp_variable => 'C:\tmp',
+        :kernelmajversion => kernelmajversion,
+        :osfamily => 'windows',
+        :puppet_confdir => "#{values[:appdata]}/puppet/etc",
+        :mco_confdir => "#{values[:appdata]}/mcollective/etc",
+        :puppet_agent_pid => 42,
+        :system32 => 'C:\windows\sysnative',
+        :tmpdir => 'C:\tmp',
+      }
+      describe 'i386-ming32' do
+        let(:facts) { facts.merge({:rubyplatform => 'i386-ming32'}) }
+        it {
+          is_expected.to contain_exec('install_puppet.bat').with { {
+            'command' => 'C:\windows\sysnative\cmd.exe /c start /b C:\windows\system32\cmd.exe /c "C:\tmp\install_puppet.bat"',
+          } }
+
         }
-        describe 'i386-ming32' do
-          let(:facts) { facts.merge({:rubyplatform => 'i386-ming32'}) }
-          it {
-            is_expected.to contain_exec('install_puppet.bat').with { {
-                             'command' => 'C:\windows\sysnative\cmd.exe /c start /b C:\windows\system32\cmd.exe /c "C:\tmp\install_puppet.bat"',
-                           } }
+      end
+      describe 'x86' do
+        let(:facts) { facts.merge({:rubyplatform => 'x86_64'}) }
+        it {
+          is_expected.to contain_exec('install_puppet.bat').with { {
+            'command' => 'C:\windows\sysnative\cmd.exe /c start /b C:\windows\sysnative\cmd.exe /c "C:\tmp\install_puppet.bat"',
+          } }
 
-          }
-        end
-        describe 'x86' do
-          let(:facts) { facts.merge({:rubyplatform => 'x86_64'}) }
-          it {
-            is_expected.to contain_exec('install_puppet.bat').with { {
-                             'command' => 'C:\windows\sysnative\cmd.exe /c start /b C:\windows\sysnative\cmd.exe /c "C:\tmp\install_puppet.bat"',
-                           } }
-
-          }
-        end
+        }
       end
     end
   end


### PR DESCRIPTION
This PR is a rebase/modification of https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/62 to add a `package_version` parameter to `puppet_agent`, which will allow a user to upgrade to/install a specific version of the puppet-agent package, including versions > 3.8, even when already upgraded to > 3.8. I un-did a slight refactor where `manifests/windows/install.pp` was rename `manifests/install/windows.pp` for easier tracking of changes and so it doesn't break the windows PR that we also need to merge. We can always do this refactor later with no other changes.

Tested it out with centos-7 by installing 2015.2.0 on a mono/agent, upgrading mono, then installing puppet_agent and setting the version to the current one. Upgrade went fine (the package was upgraded and none of the pre 3.8 changes occured).