### PR TITLE
(MODULES-3015) Fix SLES11 GPG key import issue

### DIFF
--- a/manifests/osfamily/suse.pp
+++ b/manifests/osfamily/suse.pp
@@ -16,8 +16,9 @@ class puppet_agent::osfamily::suse(
     }
     '11', '12': {
       # Import the GPG key
-      $keyname = 'RPM-GPG-KEY-puppetlabs'
-      $gpg_path = "/etc/pki/rpm-gpg/${keyname}"
+      $keyname     = 'RPM-GPG-KEY-puppetlabs'
+      $gpg_path    = "/etc/pki/rpm-gpg/${keyname}"
+      $gpg_homedir = '/root/.gnupg'
 
       file { ['/etc/pki', '/etc/pki/rpm-gpg']:
         ensure => directory,
@@ -35,7 +36,7 @@ class puppet_agent::osfamily::suse(
       exec {  "import-${keyname}":
         path      => '/bin:/usr/bin:/sbin:/usr/sbin',
         command   => "rpm --import ${gpg_path}",
-        unless    => "rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < ${gpg_path}) | cut --characters=11-18 | tr [A-Z] [a-z]`",
+        unless    => "rpm -q gpg-pubkey-$(echo $(gpg --homedir ${gpg_homedir} --throw-keyids < ${gpg_path}) | cut --characters=11-18 | tr [A-Z] [a-z])",
         require   => File[$gpg_path],
         logoutput => 'on_failure',
       }

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -114,7 +114,7 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
           it { is_expected.to contain_exec('import-RPM-GPG-KEY-puppetlabs').with({
             'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
             'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
-            'unless'    => 'rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs) | cut --characters=11-18 | tr [A-Z] [a-z]`',
+            'unless'    => 'rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs) | cut --characters=11-18 | tr [A-Z] [a-z])',
             'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs]',
             'logoutput' => 'on_failure',
           }) }


### PR DESCRIPTION
Previously, the exec to import the Puppetlabs GPG key made a call out to the
gpg binary to gather the hex value of the Puppetlabs GPG key. This call works
from the console with an ENV, but it doesn't work when automated because it
cannot find the relative homedir (~/.gnupg). To work around this, explicitly
set the value for root's .gnupg homedir in the unless command and expose it as
a variable should we need to deal with it later.