### PR TITLE
(PE-13179) remove lower version requirement in code

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,10 +23,7 @@ class puppet_agent (
 
   validate_re($arch, ['^x86$','^x64$','^i386$','^i86pc$','^amd64$','^x86_64$','^power$','^sun4[uv]$','PowerPC_POWER'])
 
-  if versioncmp("${::clientversion}", '3.8.0') < 0 {
-    fail('upgrading requires Puppet 3.8')
-  }
-  elsif versioncmp("${::clientversion}", '4.0.0') >= 0 {
+  if versioncmp("${::clientversion}", '4.0.0') >= 0 {
     info('puppet_agent performs no actions on Puppet 4+')
   }
   else {

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -29,35 +29,31 @@ describe 'puppet_agent' do
           end
         end
 
-        if Puppet.version < "3.8.0"
-          it { expect { is_expected.to contain_package('puppet_agent') }.to raise_error(Puppet::Error, /upgrading requires Puppet 3.8/) }
-        else
-          [{}, {:service_names => []}].each do |params|
-            context "puppet_agent class without any parameters" do
-              let(:params) { params }
+        [{}, {:service_names => []}].each do |params|
+          context "puppet_agent class without any parameters" do
+            let(:params) { params }
 
-              it { is_expected.to compile.with_all_deps }
+            it { is_expected.to compile.with_all_deps }
 
-              it { is_expected.to contain_class('puppet_agent') }
-              it { is_expected.to contain_class('puppet_agent::params') }
-              if Puppet.version < "4.0.0"
-                it { is_expected.to contain_class('puppet_agent::prepare') }
-                it { is_expected.to contain_class('puppet_agent::install').that_comes_before('puppet_agent::service') }
-                it { is_expected.to contain_class('puppet_agent::service') }
+            it { is_expected.to contain_class('puppet_agent') }
+            it { is_expected.to contain_class('puppet_agent::params') }
+            if Puppet.version < "4.0.0"
+              it { is_expected.to contain_class('puppet_agent::prepare') }
+              it { is_expected.to contain_class('puppet_agent::install').that_comes_before('puppet_agent::service') }
+              it { is_expected.to contain_class('puppet_agent::service') }
 
-                if params[:service_names].nil?
-                  it { is_expected.to contain_service('puppet') }
-                  it { is_expected.to contain_service('mcollective') }
-                else
-                  it { is_expected.to_not contain_service('puppet') }
-                  it { is_expected.to_not contain_service('mcollective') }
-                end
-                it { is_expected.to contain_package('puppet-agent').with_ensure('present') }
+              if params[:service_names].nil?
+                it { is_expected.to contain_service('puppet') }
+                it { is_expected.to contain_service('mcollective') }
               else
                 it { is_expected.to_not contain_service('puppet') }
                 it { is_expected.to_not contain_service('mcollective') }
-                it { is_expected.to_not contain_package('puppet-agent') }
               end
+              it { is_expected.to contain_package('puppet-agent').with_ensure('present') }
+            else
+              it { is_expected.to_not contain_service('puppet') }
+              it { is_expected.to_not contain_service('mcollective') }
+              it { is_expected.to_not contain_package('puppet-agent') }
             end
           end
         end


### PR DESCRIPTION
Prior to this commit there was a lower bound on what versions of
puppet could be upgraded by the agent module. This has caused
users to rely on supplemental tools in some cases to facilitate
upgrades. In order to encourage upgrades and make the process
easier, we're removing the lower bound.