### PR TITLE
(PE-10956) Manage /opt/puppetlabs

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,12 +26,13 @@ class puppet_agent::params {
       $package_name = 'puppet-agent'
       $service_names = ['puppet', 'mcollective']
 
-      $local_packages_dir = '/opt/puppetlabs/packages'
+      $local_puppet_dir = '/opt/puppetlabs'
+      $local_packages_dir = "${local_puppet_dir}/packages"
 
       $confdir = '/etc/puppetlabs/puppet'
       $mco_dir = '/etc/puppetlabs/mcollective'
 
-      $mco_install = '/opt/puppetlabs/mcollective'
+      $mco_install = "${local_puppet_dir}/mcollective"
       $logdir = '/var/log/puppetlabs'
 
       # A list of dirs that need to be created. Mainly done this way because
@@ -48,7 +49,8 @@ class puppet_agent::params {
       $package_name = 'puppet-agent'
       $service_names = ['puppet', 'mcollective']
 
-      $local_packages_dir = windows_native_path("${::common_appdata}/Puppetlabs/packages")
+      $local_puppet_dir = windows_native_path("${::common_appdata}/Puppetlabs")
+      $local_packages_dir = windows_native_path("${local_puppet_dir}/packages")
 
       $confdir = $::puppet_confdir
       $mco_dir = $::mco_confdir

--- a/manifests/prepare/package.pp
+++ b/manifests/prepare/package.pp
@@ -26,6 +26,13 @@ class puppet_agent::prepare::package(
       $source = "puppet:///pe_packages/${pe_server_version}/${::platform_tag}/${package_file_name}"
     }
 
+    # Manage /opt/puppetlabs for platforms
+    if !defined(File[$::puppet_agent::params::local_puppet_dir]) {
+      file { $::puppet_agent::params::local_puppet_dir:
+        ensure => directory,
+      }
+    }
+
     file { $::puppet_agent::params::local_packages_dir:
       ensure => directory,
     }


### PR DESCRIPTION
Prior to this commit we removed management of `/opt/puppetlabs`.
This resulted in platforms that need to create
`/opt/puppetlabs/packages` before installation failing to work
because the parent directory was not present (because packaging
didn't create it yet)

This commit adds `/opt/puppetlabs` to the managed directories.