### PR TITLE
add support for Amazon Linux to puppet_agent::osfamily::redhat

### DIFF
--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -23,8 +23,15 @@ class puppet_agent::osfamily::redhat(
     $_sslclientcert_path = "${_ssl_dir}/certs/${::clientcert}.pem"
     $_sslclientkey_path = "${_ssl_dir}/private_keys/${::clientcert}.pem"
 
+    # Treat Amazon Linux just like Enterprise Linux 6
+    if $::operatingsystem == 'Amazon' {
+      $_repo_dir = "el-6-${::architecture}"
+    }
+    else {
+      $_repo_dir = $::platform_tag
+    }
     $pe_server_version = pe_build_version()
-    $source = "${::puppet_agent::source}/${pe_server_version}/${::platform_tag}"
+    $source = "${::puppet_agent::source}/${pe_server_version}/${_repo_dir}"
 
     # Due to the file paths changing on the PE Master, the 3.8 repository is no longer valid.
     # On upgrade, remove the repo file so that a dangling reference is not left behind returning


### PR DESCRIPTION
Amazon Linux looks enough like CentOS 6 that we can treat it that way for purposes of upgrading the puppet agent RPM. The end result of the change is that on Amazon Linux releases, the module configures the yum "pc1_repo" baseurl to the "el-6-${::architecture}" subdirectory instead of something
like "el-2015-x86_64" or "el-2014-x86_64".

This was tested on Amazon Linux 2015.03 and 2014.09.