### PR TITLE
(PE-11531) Allow upgrades from Puppet 4+

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,7 @@
 fixtures:
   repositories:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+    transition: "https://github.com/puppetlabs/puppetlabs-transition.git"
     inifile: "https://github.com/puppetlabs/puppetlabs-inifile.git"
     apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
   symlinks:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,49 +1,70 @@
 # == Class: puppet_agent
 #
-# Upgrades Puppet 3.8 to Puppet 4+ (Puppet-Agent from Puppet Collection 1).
-# Makes the upgrade easier by migrating SSL certs and config files to the new
-# Puppet-Agent paths and removing deprecated settings that are no longer
+# Upgrades Puppet 3.8 and newer to the requested version.
+# Makes Puppet 4 upgrades easier by migrating SSL certs and config files to the
+# new Puppet-Agent paths and removing deprecated settings that are no longer
 # supported by Puppet 4.
 #
 # === Parameters
 #
+# [arch]
+#   The package architecture. Defaults to the architecture fact.
+# [collection]
+#   The Puppet Collection to track. Defaults to 'PC1'.
+# [is_pe]
+#   Install from Puppet Enterprise repos. Enabled if communicating with a PE master.
 # [package_name]
 #   The package to upgrade to, i.e. `puppet-agent`.
+# [package_version]
+#   The package version to upgrade to. Defaults to undef, meaning only upgrade from Puppet < 4.0.
 # [service_names]
 #   An array of services to start, normally `puppet` and `mcollective`.
 #   None will be started if the array is empty.
+# [source]
+#   The location to find packages.
 #
 class puppet_agent (
-  $arch          = $::architecture,
-  $is_pe         = $::puppet_agent::params::_is_pe,
-  $package_name  = $::puppet_agent::params::package_name,
-  $service_names = $::puppet_agent::params::service_names,
-  $source        = $::puppet_agent::params::_source,
+  $arch            = $::architecture,
+  $collection      = 'PC1',
+  $is_pe           = $::puppet_agent::params::_is_pe,
+  $package_name    = $::puppet_agent::params::package_name,
+  $package_version = undef,
+  $service_names   = $::puppet_agent::params::service_names,
+  $source          = $::puppet_agent::params::_source,
 ) inherits ::puppet_agent::params {
 
   validate_re($arch, ['^x86$','^x64$','^i386$','^i86pc$','^amd64$','^x86_64$','^power$','^sun4[uv]$','PowerPC_POWER'])
 
-  if versioncmp("${::clientversion}", '4.0.0') >= 0 {
-    info('puppet_agent performs no actions on Puppet 4+')
+  if ($package_version == undef and $puppet_agent::params::master_agent_version != undef and versioncmp("${::clientversion}", '4.0.0') < 0) {
+    $_package_version = $puppet_agent::params::master_agent_version
+  } elsif $package_version != undef {
+    $_package_version = $package_version
   }
-  else {
+
+  if $_package_version == undef  {
+    info("puppet_agent performs no actions if a package_version is not specified on Puppet 4, or if the master's agent version cannot be determined on Puppet 3.8")
+  } else {
+    if $package_version != undef and $package_version !~ /^\d+\.\d+\.\d+([.-]?\d*|\.\d+\.g[0-9a-f]+)$/ {
+      fail("invalid version ${package_version} requested")
+    }
+
     if $::architecture == 'x86' and $arch == 'x64' {
       fail('Unable to install x64 on a x86 system')
     }
 
     if $::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '10' {
-      $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.sles10.${::architecture}.rpm"
+      $_package_file_name = "${puppet_agent::package_name}-${_package_version}-1.sles10.${::architecture}.rpm"
     } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '10' {
       if $arch =~ /^sun4[uv]$/ {
-        $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.sparc.pkg.gz"
+        $_package_file_name = "${puppet_agent::package_name}-${_package_version}-1.sparc.pkg.gz"
       } else {
-        $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.i386.pkg.gz"
+        $_package_file_name = "${puppet_agent::package_name}-${_package_version}-1.i386.pkg.gz"
       }
     } elsif $::operatingsystem == 'Darwin' and $::macosx_productversion_major =~ /10\.[9,10,11]/ {
-      $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.osx${$::macosx_productversion_major}.dmg"
+      $_package_file_name = "${puppet_agent::package_name}-${_package_version}-1.osx${$::macosx_productversion_major}.dmg"
     } elsif $::operatingsystem == 'aix' and $::architecture =~ /PowerPC_POWER[5,6,7]/ {
       $aix_ver_number = regsubst($::platform_tag,'aix-(\d+\.\d+)-power','\1')
-      $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.aix${aix_ver_number}.ppc.rpm"
+      $_package_file_name = "${puppet_agent::package_name}-${_package_version}-1.aix${aix_ver_number}.ppc.rpm"
     } elsif $::osfamily == 'windows' {
       $_arch = $::kernelmajversion ?{
         /^5\.\d+/ => 'x86', # x64 is never allowed on windows 2003
@@ -52,6 +73,8 @@ class puppet_agent (
 
       if $is_pe {
         $_package_file_name = "${package_name}-${_arch}.msi"
+      } elsif $_package_version != undef {
+        $_package_file_name = "${package_name}-${_arch}-${_package_version}.msi"
       } else {
         $_package_file_name = "${package_name}-${_arch}-latest.msi"
       }
@@ -61,16 +84,19 @@ class puppet_agent (
 
     class { '::puppet_agent::prepare':
       package_file_name => $_package_file_name,
+      package_version   => $_package_version,
     } ->
     class { '::puppet_agent::install':
       package_file_name => $_package_file_name,
+      package_version   => $_package_version,
     }
 
     contain '::puppet_agent::prepare'
     contain '::puppet_agent::install'
 
     # On windows, our MSI handles the services
-    if $::osfamily != 'windows' {
+    # On PE AIO nodes, PE Agent nodegroup is managing the services
+    if $::osfamily != 'windows' and (!is_pe or versioncmp($::clientversion, '4.0.0') < 0) {
       class { '::puppet_agent::service':
         require => Class['::puppet_agent::install'],
       }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,9 +7,12 @@
 # [package_file_name]
 #   The puppet-agent package file name.
 #   (see puppet_agent::prepare::package_file_name)
+# [version]
+#   The puppet-agent version to install.
 #
 class puppet_agent::install(
   $package_file_name = undef,
+  $package_version   = 'present',
 ) {
   assert_private()
 
@@ -50,20 +53,36 @@ class puppet_agent::install(
   }
 
   if $::osfamily == 'windows' {
-    if $::puppet_agent::is_pe == true and empty($::puppet_agent::source) and defined(File["${::puppet_agent::params::local_packages_dir}/${package_file_name}"]) {
-      class { 'puppet_agent::windows::install':
-        package_file_name => $package_file_name,
-        source            => windows_native_path("${::puppet_agent::params::local_packages_dir}/${package_file_name}"),
+    # Prevent re-running the batch install
+    if versioncmp("${::aio_agent_version}", "${package_version}") < 0 {
+      if $::puppet_agent::is_pe == true and empty($::puppet_agent::source) and defined(File["${::puppet_agent::params::local_packages_dir}/${package_file_name}"]) {
+        class { 'puppet_agent::windows::install':
+          package_file_name => $package_file_name,
+          source            => windows_native_path("${::puppet_agent::params::local_packages_dir}/${package_file_name}"),
+        }
+      } else {
+        class { 'puppet_agent::windows::install':
+          package_file_name => $package_file_name,
+          source            => $::puppet_agent::source,
+        }
       }
-    } else {
-      class { 'puppet_agent::windows::install':
-        package_file_name => $package_file_name,
-        source            => $::puppet_agent::source,
-      }
+    }
+  } elsif ($::osfamily == 'Solaris' and $::operatingsystemmajrelease == '10') or $::osfamily == 'Darwin' or $::osfamily == 'AIX' or ($::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '10') {
+    # Solaris 10/OSX/AIX/SLES 10 package provider does not provide 'versionable'
+    # Package is removed above, then re-added as the new version here.
+    package { $::puppet_agent::package_name:
+      ensure => 'present',
+      *      => $_package_options,
+    }
+  } elsif ($::osfamily == 'RedHat') and ($package_version != 'present') {
+    # Workaround PUP-5802/PUP-5025
+    package { $::puppet_agent::package_name:
+      ensure => "${package_version}-1.el${::operatingsystemmajrelease}",
+      *      => $_package_options,
     }
   } else {
     package { $::puppet_agent::package_name:
-      ensure => present,
+      ensure => $package_version,
       *      => $_package_options,
     }
   }

--- a/manifests/install/remove_packages.pp
+++ b/manifests/install/remove_packages.pp
@@ -4,33 +4,37 @@
 # manager, where we are required to manually remove the old pe-* packages prior
 # to installing puppet-agent.
 #
-class puppet_agent::install::remove_packages {
+class puppet_agent::install::remove_packages(
+  $package_version = undef
+  ) {
   assert_private()
 
-  if versioncmp("${::clientversion}", '4.0.0') < 0 {
-
-    if $::operatingsystem == 'Darwin' {
-
-      contain '::puppet_agent::install::remove_packages_osx'
-
-    } else {
-
-      $package_options = $::operatingsystem ? {
-        'SLES'  => {
-          uninstall_options => '--nodeps',
-          provider          => 'rpm',
-        },
-        'AIX'  => {
-          uninstall_options => '--nodeps',
-          provider          => 'rpm',
-        },
-        'Solaris' => {
-          adminfile => '/opt/puppetlabs/packages/solaris-noask',
-        },
-        default => {
-        }
+  if $::operatingsystem == 'Darwin' {
+    contain '::puppet_agent::install::remove_packages_osx'
+  } else {
+    $package_options = $::operatingsystem ? {
+      'SLES'  => {
+        ensure            => 'absent',
+        uninstall_options => '--nodeps',
+        provider          => 'rpm',
+      },
+      'AIX'  => {
+        ensure            => 'absent',
+        uninstall_options => '--nodeps',
+        provider          => 'rpm',
+      },
+      'Solaris' => {
+        ensure            => 'absent',
+        adminfile => '/opt/puppetlabs/packages/solaris-noask',
+      },
+      default => {
+        ensure            => 'absent',
       }
+    }
 
+    if versioncmp("${::clientversion}", '4.0.0') < 0 {
+      # We only need to remove these packages if we are transitioning from PE
+      # versions that are pre AIO.
       $packages = $::operatingsystem ? {
         'Solaris' => [
           'PUPpuppet',
@@ -69,13 +73,24 @@ class puppet_agent::install::remove_packages {
           'pe-ruby-ldap',
         ]
       }
-
-      # We only need to remove these packages if we are transitioning from PE
-      # versions that are pre AIO.
-      $packages.each |$old_package| {
+    } elsif versioncmp("${::aio_agent_version}", "${::puppet_agent::package_version}") < 0 {
+      $packages = [ 'puppet-agent' ]
+    } else {
+      $packages = []
+    }
+    $packages.each |$old_package| {
+      if (versioncmp("${::clientversion}", '4.0.0') < 0) {
         package { $old_package:
-          ensure => absent,
-          *      => $package_options,
+          * => $package_options,
+        }
+      } else {
+        # We must use transition here because we would have a duplicate package
+        # declaration if we used a Package.
+        notify { "using puppetlabs-transition to remove ${old_package}: ${::operatingsystem} does not support versionable": }
+        transition { "remove ${old_package}":
+          resource   => Package[$old_package],
+          attributes => $package_options,
+          prior_to   => Notify["using puppetlabs-transition to remove ${old_package}: ${::operatingsystem} does not support versionable"],
         }
       }
     }

--- a/manifests/install/remove_packages_osx.pp
+++ b/manifests/install/remove_packages_osx.pp
@@ -7,53 +7,59 @@ class puppet_agent::install::remove_packages_osx {
   assert_private()
 
   if $::puppet_agent::is_pe {
-    # shutdown services
-    service { 'pe-puppet':
-      ensure => stopped,
-    }->
-    service { 'pe-mcollective':
-      ensure => stopped,
-    }->
+    if versioncmp("${::clientversion}", '4.0.0') < 0 {
+      # shutdown services
+      service { 'pe-puppet':
+        ensure => stopped,
+      }->
+      service { 'pe-mcollective':
+        ensure => stopped,
+      }->
 
-    # remove old users and groups
-    user { 'pe-puppet':
-      ensure => absent,
-    }->
-    user { 'pe-mcollective':
-      ensure => absent,
-    }->
+      # remove old users and groups
+      user { 'pe-puppet':
+        ensure => absent,
+      }->
+      user { 'pe-mcollective':
+        ensure => absent,
+      }->
 
-    # remove old /opt/puppet files
-    file { '/opt/puppet':
-      ensure => absent,
-      force  => true,
-      backup => false,
-    }
-    # Can't delete /var/opt/lib/pe-puppet or we get errors because
-    # /var/opt/lib/pe-puppet/state is missing when puppet run tries to save
-    # report
+      # remove old /opt/puppet files
+      file { '/opt/puppet':
+        ensure => absent,
+        force  => true,
+        backup => false,
+      }
+      # Can't delete /var/opt/lib/pe-puppet or we get errors because
+      # /var/opt/lib/pe-puppet/state is missing when puppet run tries to save
+      # report
 
-    # forget packages
-    [
-      'pe-augeas',
-      'pe-ruby-augeas',
-      'pe-openssl',
-      'pe-ruby',
-      'pe-cfpropertylist',
-      'pe-facter',
-      'pe-puppet',
-      'pe-mcollective',
-      'pe-hiera',
-      'pe-puppet-enterprise-release',
-      'pe-stomp',
-      'pe-libyaml',
-      'pe-ruby-rgen',
-      'pe-deep-merge',
-      'pe-ruby-shadow',
-    ].each |$package| {
-      exec { "forget ${package}":
-        command => "/usr/sbin/pkgutil --forget com.puppetlabs.${package}",
-        require => File['/opt/puppet'],
+      # forget packages
+      [
+        'pe-augeas',
+        'pe-ruby-augeas',
+        'pe-openssl',
+        'pe-ruby',
+        'pe-cfpropertylist',
+        'pe-facter',
+        'pe-puppet',
+        'pe-mcollective',
+        'pe-hiera',
+        'pe-puppet-enterprise-release',
+        'pe-stomp',
+        'pe-libyaml',
+        'pe-ruby-rgen',
+        'pe-deep-merge',
+        'pe-ruby-shadow',
+      ].each |$package| {
+        exec { "forget ${package}":
+          command => "/usr/sbin/pkgutil --forget com.puppetlabs.${package}",
+          require => File['/opt/puppet'],
+        }
+      }
+    } elsif versioncmp("${::aio_agent_version}", "${puppet_agent::package_version}") < 0 {
+      exec { 'forget puppet-agent':
+        command => '/usr/sbin/pkgutil --forget com.puppetlabs.puppet-agent',
       }
     }
   }

--- a/manifests/osfamily/debian.pp
+++ b/manifests/osfamily/debian.pp
@@ -30,7 +30,7 @@ class puppet_agent::osfamily::debian(
       "Acquire::http::proxy::${source_host} DIRECT;",
     ]
 
-    apt::setting { 'conf-pc1_repo':
+    apt::setting { 'conf-pc_repo':
       content  => $_apt_settings.join(''),
       priority => 90,
     }
@@ -59,20 +59,20 @@ class puppet_agent::osfamily::debian(
   }
 
 
-  apt::source { 'pc1_repo':
+  apt::source { 'pc_repo':
     location => $source,
-    repos    => 'PC1',
+    repos    => $::puppet_agent::collection,
     key      => {
       'id'     => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
       'server' => 'pgp.mit.edu',
     },
-    notify   => Notify['pc1_repo_force'],
+    notify   => Notify['pc_repo_force'],
   }
 
   # apt_update doesn't inherit the future class dependency, so it
   # can wait until the end of the run to exec. Force it to happen now.
-  notify { 'pc1_repo_force':
-      message => 'forcing apt update for pc1_repo',
+  notify { 'pc_repo_force':
+      message => "forcing apt update for pc_repo ${::puppet_agent::collection}",
       require => Exec['apt_update'],
   }
 }

--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -38,7 +38,7 @@ class puppet_agent::osfamily::redhat(
   }
   else {
     $source = $::puppet_agent::source ? {
-      undef   => "https://yum.puppetlabs.com/${urlbit}/PC1/${::architecture}",
+      undef   => "https://yum.puppetlabs.com/${urlbit}/${::puppet_agent::collection}/${::architecture}",
       default => $::puppet_agent::source,
     }
   }
@@ -67,9 +67,9 @@ class puppet_agent::osfamily::redhat(
     logoutput => 'on_failure',
   }
 
-  yumrepo { 'pc1_repo':
+  yumrepo { 'pc_repo':
     baseurl       => $source,
-    descr         => 'Puppet Labs PC1 Repository',
+    descr         => "Puppet Labs ${::puppet_agent::collection} Repository",
     enabled       => true,
     gpgcheck      => '1',
     gpgkey        => "file://${gpg_path}",
@@ -78,4 +78,3 @@ class puppet_agent::osfamily::redhat(
     sslclientkey  => $_sslclientkey_path,
   }
 }
-

--- a/manifests/osfamily/solaris.pp
+++ b/manifests/osfamily/solaris.pp
@@ -3,8 +3,12 @@ class puppet_agent::osfamily::solaris(
 ) {
   assert_private()
 
-  if $::operatingsystem != 'Solaris' or $::puppet_agent::is_pe == false {
+  if $::operatingsystem != 'Solaris' {
     fail("${::operatingsystem} not supported")
+  }
+
+  if $::puppet_agent::is_pe == false {
+    fail('Solaris upgrades are only supported on Puppet Enterprise')
   }
 
   case $::operatingsystemmajrelease {

--- a/manifests/osfamily/suse.pp
+++ b/manifests/osfamily/suse.pp
@@ -46,8 +46,8 @@ class puppet_agent::osfamily::suse(
       $pe_server_version = pe_build_version()
       $source = "${::puppet_agent::source}/${pe_server_version}/${::platform_tag}"
 
-      $repo_file = '/etc/zypp/repos.d/pc1_repo.repo'
-      $repo_name = 'pc1_repo'
+      $repo_file = '/etc/zypp/repos.d/pc_repo.repo'
+      $repo_name = 'pc_repo'
 
       # In Puppet Enterprise, agent packages are served by the same server
       # as the master, which can be using either a self signed CA, or an external CA.

--- a/metadata.json
+++ b/metadata.json
@@ -124,6 +124,7 @@
   ],
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
+    {"name":"puppetlabs-transition","version_requirement":">= 0.1.0 < 0.2.0"},
     {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0 < 2.0.0"},
     {"name":"puppetlabs-apt","version_requirement":">= 2.0.1 < 3.0.0"}
   ]

--- a/spec/classes/puppet_agent_osfamily_aix_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_aix_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 
-describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >= "4.0.0" do
+describe 'puppet_agent' do
   before(:each) do
     Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
       "4.0.0"
@@ -10,6 +10,14 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
     Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
       '1.2.5'
     end
+  end
+
+  package_version = '1.2.5'
+  package_ensure = 'present'
+  let(:params) do
+    {
+      :package_version => package_version
+    }
   end
 
   facts = {
@@ -30,15 +38,23 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
         })
       end
 
-      rpmname = "puppet-agent-1.2.5-1.aix#{aixver}.1.ppc.rpm"
+      rpmname = "puppet-agent-#{package_version}-1.aix#{aixver}.1.ppc.rpm"
 
-      it { is_expected.to contain_file('/etc/puppetlabs/puppet') }
+      if Puppet.version < "4.0.0"
+        it { is_expected.to contain_file('/etc/puppetlabs/puppet') }
+        it { is_expected.to contain_file('/etc/puppetlabs/puppet/puppet.conf') }
+      end
 
-      it { is_expected.to contain_file('/etc/puppetlabs/puppet/puppet.conf') }
+      it do
+        is_expected.to contain_exec('replace puppet.conf removed by package removal').with_command('cp /etc/puppetlabs/puppet/puppet.conf.rpmsave /etc/puppetlabs/puppet/puppet.conf')
+        is_expected.to contain_exec('replace puppet.conf removed by package removal').with_creates('/etc/puppetlabs/puppet/puppet.conf')
+      end
 
       it { is_expected.to contain_file('/opt/puppetlabs') }
       it { is_expected.to contain_file('/opt/puppetlabs/packages') }
       it { is_expected.to contain_file("/opt/puppetlabs/packages/#{rpmname}")}
+
+      it { is_expected.to contain_class("puppet_agent::osfamily::aix") }
 
       it { is_expected.to contain_class('Puppet_agent::Install').with({
            'package_file_name'     => rpmname,
@@ -48,35 +64,43 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
       it {
         is_expected.to contain_package('puppet-agent').with({
             'source'    => "/opt/puppetlabs/packages/#{rpmname}",
-            'ensure'    => 'present',
+            'ensure'    => package_ensure,
             'provider'  => 'rpm'
           })
       }
 
-      [
-       'pe-augeas',
-       'pe-mcollective-common',
-       'pe-rubygem-deep-merge',
-       'pe-mcollective',
-       'pe-puppet-enterprise-release',
-       'pe-libldap',
-       'pe-libyaml',
-       'pe-ruby-stomp',
-       'pe-ruby-augeas',
-       'pe-ruby-shadow',
-       'pe-hiera',
-       'pe-facter',
-       'pe-puppet',
-       'pe-openssl',
-       'pe-ruby',
-       'pe-ruby-rgen',
-       'pe-virt-what',
-       'pe-ruby-ldap',
-      ].each do |package|
-        it do
-          is_expected.to contain_package(package).with_ensure('absent')
-          is_expected.to contain_package(package).with_uninstall_options('--nodeps')
-          is_expected.to contain_package(package).with_provider('rpm')
+      if Puppet.version < "4.0.0"
+        [
+         'pe-augeas',
+         'pe-mcollective-common',
+         'pe-rubygem-deep-merge',
+         'pe-mcollective',
+         'pe-puppet-enterprise-release',
+         'pe-libldap',
+         'pe-libyaml',
+         'pe-ruby-stomp',
+         'pe-ruby-augeas',
+         'pe-ruby-shadow',
+         'pe-hiera',
+         'pe-facter',
+         'pe-puppet',
+         'pe-openssl',
+         'pe-ruby',
+         'pe-ruby-rgen',
+         'pe-virt-what',
+         'pe-ruby-ldap',
+        ].each do |package|
+          it do
+            if Puppet.version < "4.0.0"
+            else
+              is_expected.to contain_transition("remove #{package}").with(
+                :attributes => {
+                  'ensure' => 'absent',
+                  'uninstall_options' => '--nodeps',
+                  'provider' => 'rpm',
+                })
+            end
+          end
         end
       end
     end
@@ -91,11 +115,10 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
         })
       end
 
-      rpmname = "puppet-agent-1.2.5-1.aix#{aixver}.1.ppc.rpm"
+      rpmname = "puppet-agent-#{package_version}-1.aix#{aixver}.1.ppc.rpm"
 
       it {
         is_expected.to_not contain_file("/opt/puppetlabs/packages/#{rpmname}") }
     end
   end
 end
-

--- a/spec/classes/puppet_agent_osfamily_darwin_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_darwin_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
-describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >= "4.0.0" do
+describe 'puppet_agent' do
+  master_package_version = '1.3.5'
   before(:each) do
     # Need to mock the PE functions
     Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
@@ -8,8 +9,20 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
     end
 
     Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
-      '1.2.5'
+      master_package_version
     end
+  end
+
+  if Puppet.version >= "4.0.0"
+    package_version = '1.2.5'
+    let(:params) do
+      {
+        :package_version => package_version
+      }
+    end
+  else
+    # Default to PE master package version in 3.8
+    package_version = master_package_version
   end
 
   facts = {
@@ -36,46 +49,55 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
   end
 
   describe 'supported environment' do
-    context "when OSX 10.9" do
-      let(:facts) do
-        facts.merge({
-          :is_pe                       => true,
-          :platform_tag                => "osx-10.9-x86_64",
-          :macosx_productversion_major => '10.9',
-        })
+    context "when running a supported OSX" do
+      ["osx-10.9-x86_64", "osx-10.10-x86_64", "osx-10.11-x86_64"].each do |tag|
+        context "on #{tag} with no aio_version" do
+          let(:osmajor) { tag.split('-')[1] }
+
+          let(:facts) do
+            facts.merge({
+              :is_pe                       => true,
+              :platform_tag                => tag,
+              :macosx_productversion_major => osmajor,
+            })
+          end
+
+          it { should compile.with_all_deps }
+          it { is_expected.to contain_file('/opt/puppetlabs') }
+          it { is_expected.to contain_file('/opt/puppetlabs/packages') }
+          it { is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.osx#{osmajor}.dmg") }
+          it { is_expected.to contain_package('puppet-agent').with_ensure('present') }
+          it { is_expected.to contain_package('puppet-agent').with_source("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.osx#{osmajor}.dmg") }
+          it { is_expected.to contain_class('puppet_agent::install::remove_packages') }
+          it { is_expected.to contain_class('puppet_agent::install::remove_packages_osx') }
+          it { is_expected.to contain_class("puppet_agent::osfamily::darwin") }
+
+          if Puppet.version < "4.0.0"
+            [
+              'pe-augeas',
+              'pe-ruby-augeas',
+              'pe-openssl',
+              'pe-ruby',
+              'pe-cfpropertylist',
+              'pe-facter',
+              'pe-puppet',
+              'pe-mcollective',
+              'pe-hiera',
+              'pe-puppet-enterprise-release',
+              'pe-stomp',
+              'pe-libyaml',
+              'pe-ruby-rgen',
+              'pe-deep-merge',
+              'pe-ruby-shadow',
+            ].each do |package|
+              it { is_expected.to contain_exec("forget #{package}").with_command("/usr/sbin/pkgutil --forget com.puppetlabs.#{package}") }
+              it { is_expected.to contain_exec("forget #{package}").with_require('File[/opt/puppet]') }
+            end
+          else
+            it { is_expected.to contain_exec('forget puppet-agent').with_command("/usr/sbin/pkgutil --forget com.puppetlabs.puppet-agent") }
+          end
+        end
       end
-
-      it { should compile.with_all_deps }
-      it { is_expected.to contain_file('/opt/puppetlabs') }
-      it { is_expected.to contain_package('puppet-agent').with_source('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.osx10.9.dmg') }
-    end
-
-    context "when OSX 10.10" do
-      let(:facts) do
-        facts.merge({
-          :is_pe                       => true,
-          :platform_tag                => "osx-10.10-x86_64",
-          :macosx_productversion_major => '10.10',
-        })
-      end
-
-      it { should compile.with_all_deps }
-      it { is_expected.to contain_file('/opt/puppetlabs') }
-      it { is_expected.to contain_package('puppet-agent').with_source('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.osx10.10.dmg') }
-    end
-
-    context "when OSX 10.11" do
-      let(:facts) do
-        facts.merge({
-          :is_pe                       => true,
-          :platform_tag                => "osx-10.11-x86_64",
-          :macosx_productversion_major => '10.11',
-        })
-      end
-
-      it { should compile.with_all_deps }
-      it { is_expected.to contain_file('/opt/puppetlabs') }
-      it { is_expected.to contain_package('puppet-agent').with_source('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.osx10.11.dmg') }
     end
   end
 end

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -1,14 +1,23 @@
 require 'spec_helper'
 
-describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >= "4.0.0" do
-  [['Fedora', 'fedora/f$releasever'], ['CentOS', 'el/$releasever'], ['Amazon', 'el/6']].each do |os, urlbit|
+describe 'puppet_agent' do
+  # All FOSS and all Puppet 4+ upgrades require the package_version
+  package_version = '1.2.5'
+  let(:params) {
+    {
+      :package_version => package_version
+    }
+  }
+
+  [['Fedora', 'fedora/f$releasever', 7], ['CentOS', 'el/$releasever', 7], ['Amazon', 'el/6', 6]].each do |os, urlbit, osmajor|
     context "with #{os} and #{urlbit}" do
       let(:facts) {{
-        :osfamily => 'RedHat',
-        :operatingsystem => os,
-        :architecture => 'x64',
-        :servername   => 'master.example.vm',
-        :clientcert   => 'foo.example.vm',
+        :osfamily                  => 'RedHat',
+        :operatingsystem           => os,
+        :architecture              => 'x64',
+        :servername                => 'master.example.vm',
+        :clientcert                => 'foo.example.vm',
+        :operatingsystemmajrelease => osmajor,
       }}
 
       it { is_expected.to contain_exec('import-RPM-GPG-KEY-puppetlabs').with({
@@ -35,17 +44,19 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
 
       context 'when FOSS' do
         it { is_expected.not_to contain_yumrepo('puppetlabs-pepackages').with_ensure('absent') }
-        it { is_expected.to contain_yumrepo('pc1_repo').with({
+        it { is_expected.to contain_yumrepo('pc_repo').with({
           'baseurl' => "https://yum.puppetlabs.com/#{urlbit}/PC1/x64",
           'enabled' => 'true',
             'gpgcheck' => '1',
             'gpgkey' => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
         }) }
+
+        it { is_expected.to contain_class("puppet_agent::osfamily::redhat") }
       end
     end
   end
 
-  [['RedHat', 'el-7-x86_64', 'el-7-x86_64'], ['Amazon', '', 'el-6-x64']].each do |os, tag, repodir|
+  [['RedHat', 'el-7-x86_64', 'el-7-x86_64', 7], ['Amazon', '', 'el-6-x64', 6]].each do |os, tag, repodir, osmajor|
     context "when PE on #{os}" do
       before(:each) do
         # Need to mock the PE functions
@@ -60,18 +71,19 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
       end
 
       let(:facts) {{
-        :osfamily => 'RedHat',
-        :operatingsystem => os,
-        :architecture => 'x64',
-        :servername   => 'master.example.vm',
-        :clientcert   => 'foo.example.vm',
-        :is_pe        => true,
-        :platform_tag => tag,
+        :osfamily                  => 'RedHat',
+        :operatingsystem           => os,
+        :architecture              => 'x64',
+        :servername                => 'master.example.vm',
+        :clientcert                => 'foo.example.vm',
+        :is_pe                     => true,
+        :platform_tag              => tag,
+        :operatingsystemmajrelease => osmajor,
       }}
 
       it { is_expected.to contain_yumrepo('puppetlabs-pepackages').with_ensure('absent') }
 
-      it { is_expected.to contain_yumrepo('pc1_repo').with({
+      it { is_expected.to contain_yumrepo('pc_repo').with({
         'baseurl' => "https://master.example.vm:8140/packages/4.0.0/#{repodir}",
         'enabled' => 'true',
         'gpgcheck' => '1',
@@ -80,6 +92,8 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
         'sslclientcert' => '/etc/puppetlabs/puppet/ssl/certs/foo.example.vm.pem',
         'sslclientkey' => '/etc/puppetlabs/puppet/ssl/private_keys/foo.example.vm.pem',
       }) }
+
+      it { is_expected.to contain_class("puppet_agent::osfamily::redhat") }
     end
   end
 end

--- a/spec/classes/puppet_agent_osfamily_solaris_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_solaris_spec.rb
@@ -1,19 +1,7 @@
 require 'spec_helper'
 
-describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >= "4.0.0" do
-  before(:each) do
-    # Need to mock the PE functions
-    Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
-      "4.0.0"
-    end
-
-    Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
-      '1.2.5'
-    end
-  end
-
+describe 'puppet_agent' do
   facts = {
-    :is_pe                     => true,
     :osfamily                  => 'Solaris',
     :operatingsystem           => 'Solaris',
     :operatingsystemmajrelease => '10',
@@ -21,6 +9,15 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
     :servername                => 'master.example.vm',
     :clientcert                => 'foo.example.vm',
   }
+
+  package_version = '1.2.5'
+  if Puppet.version >= "4.0.0"
+    let(:params) do
+      {
+        :package_version => package_version
+      }
+    end
+  end
 
   describe 'unsupported environment' do
     context 'when not PE' do
@@ -30,11 +27,30 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
         })
       end
 
-      it { expect { catalogue }.to raise_error(/Solaris not supported/) }
+      # FOSS requires the package_version because the pe_compiling_server_version
+      # fact isn't available.
+      let(:params) do
+        {
+          :package_version => package_version
+        }
+      end
+
+      it { expect { catalogue }.to raise_error(/only supported on Puppet Enterprise/) }
     end
   end
 
   describe 'not yet supported releases' do
+    before(:each) do
+      # Need to mock the PE functions
+      Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
+        "4.0.0"
+      end
+
+      Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
+        package_version
+      end
+    end
+
     context 'when Solaris 11' do
       let(:facts) do
         facts.merge({
@@ -48,6 +64,17 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
   end
 
   describe 'supported environment' do
+    before(:each) do
+      # Need to mock the PE functions
+      Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
+        "4.0.0"
+      end
+
+      Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
+        package_version
+      end
+    end
+
     context "when Solaris 10 i386" do
       let(:facts) do
         facts.merge({
@@ -56,53 +83,78 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
           :operatingsystemmajrelease => '10',
         })
       end
-
       it { should compile.with_all_deps }
+
       it { is_expected.to contain_file('/opt/puppetlabs') }
       it { is_expected.to contain_file('/opt/puppetlabs/packages') }
       it do
-        is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.i386.pkg.gz').with_ensure('present')
-        is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.i386.pkg.gz').with_source('puppet:///pe_packages/4.0.0/solaris-10-i386/puppet-agent-1.2.5-1.i386.pkg.gz')
+        is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.i386.pkg.gz").with_ensure('present')
+        is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.i386.pkg.gz").with_source("puppet:///pe_packages/4.0.0/solaris-10-i386/puppet-agent-#{package_version}-1.i386.pkg.gz")
       end
 
       it { is_expected.to contain_file('/opt/puppetlabs/packages/solaris-noask').with_source('puppet:///pe_packages/4.0.0/solaris-10-i386/solaris-noask') }
       it do
-        is_expected.to contain_exec('unzip puppet-agent-1.2.5-1.i386.pkg.gz').with_command('gzip -d /opt/puppetlabs/packages/puppet-agent-1.2.5-1.i386.pkg.gz')
-        is_expected.to contain_exec('unzip puppet-agent-1.2.5-1.i386.pkg.gz').with_creates('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.i386.pkg')
+        is_expected.to contain_exec("unzip puppet-agent-#{package_version}-1.i386.pkg.gz").with_command("gzip -d /opt/puppetlabs/packages/puppet-agent-#{package_version}-1.i386.pkg.gz")
+        is_expected.to contain_exec("unzip puppet-agent-#{package_version}-1.i386.pkg.gz").with_creates("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.i386.pkg")
       end
 
-      it { is_expected.to contain_service('pe-puppet').with_ensure('stopped') }
-      it { is_expected.to contain_service('pe-mcollective').with_ensure('stopped') }
+      it { is_expected.to contain_class('puppet_agent::install::remove_packages') }
+      it { is_expected.to contain_class("puppet_agent::osfamily::solaris") }
 
-      [
-        'PUPpuppet',
-        'PUPaugeas',
-        'PUPdeep-merge',
-        'PUPfacter',
-        'PUPhiera',
-        'PUPlibyaml',
-        'PUPmcollective',
-        'PUPopenssl',
-        'PUPpuppet-enterprise-release',
-        'PUPruby',
-        'PUPruby-augeas',
-        'PUPruby-rgen',
-        'PUPruby-shadow',
-        'PUPstomp',
-      ].each do |package|
+      if Puppet.version < "4.0.0"
+        it { is_expected.to contain_service('pe-puppet').with_ensure('stopped') }
+        it { is_expected.to contain_service('pe-mcollective').with_ensure('stopped') }
+
+        [
+          'PUPpuppet',
+          'PUPaugeas',
+          'PUPdeep-merge',
+          'PUPfacter',
+          'PUPhiera',
+          'PUPlibyaml',
+          'PUPmcollective',
+          'PUPopenssl',
+          'PUPpuppet-enterprise-release',
+          'PUPruby',
+          'PUPruby-augeas',
+          'PUPruby-rgen',
+          'PUPruby-shadow',
+          'PUPstomp',
+        ].each do |package|
+          it do
+            is_expected.to contain_package(package).with_ensure('absent')
+            is_expected.to contain_package(package).with_adminfile('/opt/puppetlabs/packages/solaris-noask')
+          end
+        end
+      else
         it do
-          is_expected.to contain_package(package).with_ensure('absent')
-          is_expected.to contain_package(package).with_adminfile('/opt/puppetlabs/packages/solaris-noask')
+          is_expected.to contain_transition("remove puppet-agent").with(
+            :attributes => {
+              'ensure' => 'absent',
+              'adminfile' => '/opt/puppetlabs/packages/solaris-noask',
+            })
         end
       end
 
       it do
         is_expected.to contain_package('puppet-agent').with_adminfile('/opt/puppetlabs/packages/solaris-noask')
-        is_expected.to contain_package('puppet-agent').with_source('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.i386.pkg')
+        is_expected.to contain_package('puppet-agent').with_ensure('present')
+        is_expected.to contain_package('puppet-agent').with_source("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.i386.pkg")
       end
     end
 
     context "when Solaris 10 sparc sun4u" do
+      before(:each) do
+        # Need to mock the PE functions
+        Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
+          "4.0.0"
+        end
+
+        Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
+          package_version
+        end
+      end
+
       let(:facts) do
         facts.merge({
           :is_pe                     => true,
@@ -113,46 +165,61 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
       end
 
       it { should compile.with_all_deps }
+
       it { is_expected.to contain_file('/opt/puppetlabs/packages') }
       it do
-        is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.sparc.pkg.gz').with_ensure('present')
-        is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.sparc.pkg.gz').with_source('puppet:///pe_packages/4.0.0/solaris-10-sparc/puppet-agent-1.2.5-1.sparc.pkg.gz')
+        is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.sparc.pkg.gz").with_ensure('present')
+        is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.sparc.pkg.gz").with_source("puppet:///pe_packages/4.0.0/solaris-10-sparc/puppet-agent-#{package_version}-1.sparc.pkg.gz")
       end
 
       it { is_expected.to contain_file('/opt/puppetlabs/packages/solaris-noask').with_source('puppet:///pe_packages/4.0.0/solaris-10-sparc/solaris-noask') }
       it do
-        is_expected.to contain_exec('unzip puppet-agent-1.2.5-1.sparc.pkg.gz').with_command('gzip -d /opt/puppetlabs/packages/puppet-agent-1.2.5-1.sparc.pkg.gz')
-        is_expected.to contain_exec('unzip puppet-agent-1.2.5-1.sparc.pkg.gz').with_creates('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.sparc.pkg')
+        is_expected.to contain_exec("unzip puppet-agent-#{package_version}-1.sparc.pkg.gz").with_command("gzip -d /opt/puppetlabs/packages/puppet-agent-#{package_version}-1.sparc.pkg.gz")
+        is_expected.to contain_exec("unzip puppet-agent-#{package_version}-1.sparc.pkg.gz").with_creates("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.sparc.pkg")
       end
 
-      it { is_expected.to contain_service('pe-puppet').with_ensure('stopped') }
-      it { is_expected.to contain_service('pe-mcollective').with_ensure('stopped') }
+      it { is_expected.to contain_class('puppet_agent::install::remove_packages') }
+      it { is_expected.to contain_class("puppet_agent::osfamily::solaris") }
 
-      [
-        'PUPpuppet',
-        'PUPaugeas',
-        'PUPdeep-merge',
-        'PUPfacter',
-        'PUPhiera',
-        'PUPlibyaml',
-        'PUPmcollective',
-        'PUPopenssl',
-        'PUPpuppet-enterprise-release',
-        'PUPruby',
-        'PUPruby-augeas',
-        'PUPruby-rgen',
-        'PUPruby-shadow',
-        'PUPstomp',
-      ].each do |package|
+      if Puppet.version < "4.0.0"
+        it { is_expected.to contain_service('pe-puppet').with_ensure('stopped') }
+        it { is_expected.to contain_service('pe-mcollective').with_ensure('stopped') }
+
+        [
+          'PUPpuppet',
+          'PUPaugeas',
+          'PUPdeep-merge',
+          'PUPfacter',
+          'PUPhiera',
+          'PUPlibyaml',
+          'PUPmcollective',
+          'PUPopenssl',
+          'PUPpuppet-enterprise-release',
+          'PUPruby',
+          'PUPruby-augeas',
+          'PUPruby-rgen',
+          'PUPruby-shadow',
+          'PUPstomp',
+        ].each do |package|
+          it do
+            is_expected.to contain_package(package).with_ensure('absent')
+            is_expected.to contain_package(package).with_adminfile('/opt/puppetlabs/packages/solaris-noask')
+          end
+        end
+      else
         it do
-          is_expected.to contain_package(package).with_ensure('absent')
-          is_expected.to contain_package(package).with_adminfile('/opt/puppetlabs/packages/solaris-noask')
+          is_expected.to contain_transition("remove puppet-agent").with(
+            :attributes => {
+              'ensure' => 'absent',
+              'adminfile' => '/opt/puppetlabs/packages/solaris-noask',
+            })
         end
       end
 
       it do
         is_expected.to contain_package('puppet-agent').with_adminfile('/opt/puppetlabs/packages/solaris-noask')
-        is_expected.to contain_package('puppet-agent').with_source('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.sparc.pkg')
+        is_expected.to contain_package('puppet-agent').with_ensure('present')
+        is_expected.to contain_package('puppet-agent').with_source("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.sparc.pkg")
       end
     end
   end

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
-describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >= "4.0.0" do
+describe 'puppet_agent' do
+  package_version = '1.2.5'
   before(:each) do
     # Need to mock the PE functions
     Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
@@ -21,6 +22,12 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
     :servername                => 'master.example.vm',
     :clientcert                => 'foo.example.vm',
   }
+
+  let(:params) do
+    {
+      :package_version => package_version
+    }
+  end
 
   describe 'unsupported environment' do
     context 'when not PE' do
@@ -55,6 +62,13 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
         })
       end
 
+      it { is_expected.to contain_class("puppet_agent::prepare::package") }
+
+      it do
+        is_expected.to contain_exec('replace puppet.conf removed by package removal').with_command('cp /etc/puppetlabs/puppet/puppet.conf.rpmsave /etc/puppetlabs/puppet/puppet.conf')
+        is_expected.to contain_exec('replace puppet.conf removed by package removal').with_creates('/etc/puppetlabs/puppet/puppet.conf')
+      end
+
       it { is_expected.to contain_file('/opt/puppetlabs') }
       it { is_expected.to contain_file('/opt/puppetlabs/packages') }
       it do
@@ -62,36 +76,43 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
         is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.sles10.x86_64.rpm').with_source('puppet:///pe_packages/4.0.0/sles-10-x86_64/puppet-agent-1.2.5-1.sles10.x86_64.rpm')
       end
 
-      [
-        'pe-augeas',
-        'pe-mcollective-common',
-        'pe-rubygem-deep-merge',
-        'pe-mcollective',
-        'pe-puppet-enterprise-release',
-        'pe-libldap',
-        'pe-libyaml',
-        'pe-ruby-stomp',
-        'pe-ruby-augeas',
-        'pe-ruby-shadow',
-        'pe-hiera',
-        'pe-facter',
-        'pe-puppet',
-        'pe-openssl',
-        'pe-ruby',
-        'pe-ruby-rgen',
-        'pe-virt-what',
-        'pe-ruby-ldap',
-      ].each do |package|
-        it do
-          is_expected.to contain_package(package).with_ensure('absent')
-          is_expected.to contain_package(package).with_uninstall_options('--nodeps')
-          is_expected.to contain_package(package).with_provider('rpm')
-        end
-      end
+      it { is_expected.to contain_class("puppet_agent::osfamily::suse") }
 
-      it do
-        is_expected.to contain_exec('replace puppet.conf removed by package removal').with_command('cp /etc/puppetlabs/puppet/puppet.conf.rpmsave /etc/puppetlabs/puppet/puppet.conf')
-        is_expected.to contain_exec('replace puppet.conf removed by package removal').with_creates('/etc/puppetlabs/puppet/puppet.conf')
+      if Puppet.version < "4.0.0"
+
+        [
+          'pe-augeas',
+          'pe-mcollective-common',
+          'pe-rubygem-deep-merge',
+          'pe-mcollective',
+          'pe-puppet-enterprise-release',
+          'pe-libldap',
+          'pe-libyaml',
+          'pe-ruby-stomp',
+          'pe-ruby-augeas',
+          'pe-ruby-shadow',
+          'pe-hiera',
+          'pe-facter',
+          'pe-puppet',
+          'pe-openssl',
+          'pe-ruby',
+          'pe-ruby-rgen',
+          'pe-virt-what',
+          'pe-ruby-ldap',
+        ].each do |package|
+          it do
+            is_expected.to contain_package(package).with_ensure('absent')
+            is_expected.to contain_package(package).with_uninstall_options('--nodeps')
+            is_expected.to contain_package(package).with_provider('rpm')
+          end
+        end
+      else
+        it do
+          is_expected.to contain_transition('remove puppet-agent').with_attributes(
+            'ensure' => 'absent',
+            'uninstall_options' => '--nodeps',
+            'provider' => 'rpm')
+        end
       end
 
       it do
@@ -125,6 +146,8 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
             }) }
           end
 
+          it { is_expected.to contain_class("puppet_agent::osfamily::suse") }
+
           it { is_expected.to contain_file('/etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs').with({
             'ensure' => 'present',
             'owner'  => '0',
@@ -134,15 +157,15 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
           }) }
 
           {
-            'name'        => 'pc1_repo',
+            'name'        => 'pc_repo',
             'enabled'      => '1',
             'autorefresh' => '0',
             'baseurl'     => "https://master.example.vm:8140/packages/4.0.0/sles-#{os_version}-x86_64?ssl_verify=no",
             'type'        => 'rpm-md',
           }.each do |setting, value|
-              it { is_expected.to contain_ini_setting("zypper pc1_repo #{setting}").with({
-                'path'    => '/etc/zypp/repos.d/pc1_repo.repo',
-                'section' => 'pc1_repo',
+              it { is_expected.to contain_ini_setting("zypper pc_repo #{setting}").with({
+                'path'    => '/etc/zypp/repos.d/pc_repo.repo',
+                'section' => 'pc_repo',
                 'setting' => setting,
                 'value'   => value,
               }) }

--- a/spec/classes/puppet_agent_prepare_spec.rb
+++ b/spec/classes/puppet_agent_prepare_spec.rb
@@ -6,10 +6,24 @@ MCO_PLUGIN_YAML = '/etc/puppetlabs/mcollective/facts.yaml'
 MCO_LOGFILE = '/var/log/puppetlabs/mcollective.log'
 
 describe 'puppet_agent::prepare' do
+  let(:params) { {
+    :package_version => '4.0.0',
+  } }
   context 'supported operating system families' do
-    ['Debian', 'RedHat'].each do |osfamily|
+    ['Debian', 'RedHat', 'SuSE'].each do |osfamily|
+      case osfamily
+      when 'SuSE'
+        os = 'SLES'
+        osmajor = '10'
+      else
+        os = 'foo'
+        osmajor = '42'
+      end
+
+
       facts = {
-        :operatingsystem => 'foo',
+        :operatingsystem => os,
+        :operatingsystemmajrelease => osmajor,
         :architecture => 'bar',
         :osfamily => osfamily,
         :lsbdistid => osfamily,
@@ -32,8 +46,11 @@ describe 'puppet_agent::prepare' do
               'hostcrl' => { 'path_exists' => false }
             }})
           }
-          ['certificate_requests', 'certs', 'private', 'private_keys', 'public_keys', 'crl.pem'].each do |path|
-            it { is_expected.to_not contain_file("/etc/puppetlabs/puppet/ssl/#{path}") }
+          # We don't perform SSL migration post-4 upgrade
+          if Puppet.version < "4.0.0"
+            ['certificate_requests', 'certs', 'private', 'private_keys', 'public_keys', 'crl.pem'].each do |path|
+              it { is_expected.to_not contain_file("/etc/puppetlabs/puppet/ssl/#{path}") }
+            end
           end
         end
 
@@ -58,146 +75,158 @@ describe 'puppet_agent::prepare' do
                 })
               }
 
-              it { is_expected.to contain_file('/etc/puppetlabs/mcollective').with_ensure('directory') }
+              # We don't perform MCO migration post-4 upgrade
+              if Puppet.version < "4.0.0"
+                it { is_expected.to contain_file('/etc/puppetlabs/mcollective').with_ensure('directory') }
 
-              mco_config.each do |node, cfg|
-                if cfg
-                  it { is_expected.to contain_file(MCO_CFG[node]).with({
-                    'ensure' => 'file',
-                    'source' => cfg,
-                  }) }
+                mco_config.each do |node, cfg|
+                  if cfg
+                    it { is_expected.to contain_file(MCO_CFG[node]).with({
+                      'ensure' => 'file',
+                      'source' => cfg,
+                    }) }
 
-                  if mco_settings && mco_settings['libdir'] && !mco_settings['libdir'].include?(MCO_LIBDIR)
-                    it { is_expected.to contain_ini_setting("#{node}/libdir").with({
+                    if mco_settings && mco_settings['libdir'] && !mco_settings['libdir'].include?(MCO_LIBDIR)
+                      it { is_expected.to contain_ini_setting("#{node}/libdir").with({
+                        'section' => '',
+                        'setting' => 'libdir',
+                        'path'    => MCO_CFG[node],
+                        'value'   => "#{MCO_LIBDIR}:#{mco_settings['libdir']}",
+                      }).that_requires("File[#{MCO_CFG[node]}]") }
+                    else
+                      it { is_expected.to_not contain_ini_setting("#{node}/libdir") }
+                    end
+
+                    if mco_settings && mco_settings['plugin.yaml'] && !mco_settings['plugin.yaml'].include?(MCO_PLUGIN_YAML)
+                      it { is_expected.to contain_ini_setting("#{node}/plugin.yaml").with({
+                        'section' => '',
+                        'setting' => 'plugin.yaml',
+                        'path'    => MCO_CFG[node],
+                        'value'   => "#{mco_settings['plugin.yaml']}:#{MCO_PLUGIN_YAML}",
+                      }).that_requires("File[#{MCO_CFG[node]}]") }
+                    else
+                      it { is_expected.to_not contain_ini_setting("#{node}/plugin.yaml") }
+                    end
+
+                    it { is_expected.to contain_ini_setting("#{node}/logfile").with({
                       'section' => '',
-                      'setting' => 'libdir',
+                      'setting' => 'logfile',
                       'path'    => MCO_CFG[node],
-                      'value'   => "#{MCO_LIBDIR}:#{mco_settings['libdir']}",
+                      'value'   => MCO_LOGFILE,
                     }).that_requires("File[#{MCO_CFG[node]}]") }
                   else
-                    it { is_expected.to_not contain_ini_setting("#{node}/libdir") }
+                    it { is_expected.to_not contain_file(MCO_CFG[node]) }
                   end
-
-                  if mco_settings && mco_settings['plugin.yaml'] && !mco_settings['plugin.yaml'].include?(MCO_PLUGIN_YAML)
-                    it { is_expected.to contain_ini_setting("#{node}/plugin.yaml").with({
-                      'section' => '',
-                      'setting' => 'plugin.yaml',
-                      'path'    => MCO_CFG[node],
-                      'value'   => "#{mco_settings['plugin.yaml']}:#{MCO_PLUGIN_YAML}",
-                    }).that_requires("File[#{MCO_CFG[node]}]") }
-                  else
-                    it { is_expected.to_not contain_ini_setting("#{node}/plugin.yaml") }
-                  end
-
-                  it { is_expected.to contain_ini_setting("#{node}/logfile").with({
-                    'section' => '',
-                    'setting' => 'logfile',
-                    'path'    => MCO_CFG[node],
-                    'value'   => MCO_LOGFILE,
-                  }).that_requires("File[#{MCO_CFG[node]}]") }
-                else
-                  it { is_expected.to_not contain_file(MCO_CFG[node]) }
                 end
               end
             end
           end
         end
 
-        ['/etc/puppetlabs', '/etc/puppetlabs/puppet'].each do |dir|
-          it { is_expected.to contain_file(dir).with_ensure('directory') }
-        end
+        # We don't perform file migration post-4 upgrade
+        if Puppet.version < "4.0.0"
+          ['/etc/puppetlabs', '/etc/puppetlabs/puppet'].each do |dir|
+            it { is_expected.to contain_file(dir).with_ensure('directory') }
+          end
 
-        it { is_expected.to contain_file('/etc/puppetlabs/puppet/puppet.conf').with({
-          'ensure' => 'file',
-          'source' => '/dev/null/puppet.conf',
-        }) }
-
-        it { is_expected.to contain_file('/etc/puppetlabs/puppet/ssl').with({
-          'ensure'  => 'directory',
-          'source'  => '/dev/null/ssl',
-          'backup'  => 'false',
-          'recurse' => 'false',
-        }) }
-
-        ['certificate_requests', 'certs', 'private', 'private_keys', 'public_keys'].each do |dir|
-          it { is_expected.to contain_file("/etc/puppetlabs/puppet/ssl/#{dir}").with({
-            'ensure'  => 'directory',
-            'source'  => "/dev/null/ssl/#{dir}",
-            'backup'  => 'false',
-            'recurse' => 'true',
+          it { is_expected.to contain_file('/etc/puppetlabs/puppet/puppet.conf').with({
+            'ensure' => 'file',
+            'source' => '/dev/null/puppet.conf',
           }) }
+
+          it { is_expected.to contain_file('/etc/puppetlabs/puppet/ssl').with({
+            'ensure'  => 'directory',
+            'source'  => '/dev/null/ssl',
+            'backup'  => 'false',
+            'recurse' => 'false',
+          }) }
+
+          ['certificate_requests', 'certs', 'private', 'private_keys', 'public_keys'].each do |dir|
+            it { is_expected.to contain_file("/etc/puppetlabs/puppet/ssl/#{dir}").with({
+              'ensure'  => 'directory',
+              'source'  => "/dev/null/ssl/#{dir}",
+              'backup'  => 'false',
+              'recurse' => 'true',
+            }) }
+          end
+
+          it { is_expected.to contain_file('/etc/puppetlabs/puppet/ssl/crl.pem').with({
+            'ensure' => 'file',
+            'source' => '/dev/null/ssl/crl.pem',
+            'backup' => 'false',
+          }) }
+
+          ['', 'agent', 'main', 'master'].each do |section|
+            ['allow_variables_with_dashes',
+             'async_storeconfigs',
+             'binder',
+             'catalog_format',
+             'certdnsnames',
+             'certificate_expire_warning',
+             'couchdb_url',
+             'dbadapter',
+             'dbconnections',
+             'dblocation',
+             'dbmigrate',
+             'dbname',
+             'dbpassword',
+             'dbport',
+             'dbserver',
+             'dbsocket',
+             'dbuser',
+             'dynamicfacts',
+             'http_compression',
+             'httplog',
+             'ignoreimport',
+             'immutable_node_data',
+             'inventory_port',
+             'inventory_server',
+             'inventory_terminus',
+             'legacy_query_parameter_serialization',
+             'listen',
+             'localconfig',
+             'manifestdir',
+             'masterlog',
+             'parser',
+             'preview_outputdir',
+             'puppetport',
+             'queue_source',
+             'queue_type',
+             'rails_loglevel',
+             'railslog',
+             'report_serialization_format',
+             'reportfrom',
+             'rrddir',
+             'rrdinterval',
+             'sendmail',
+             'smtphelo',
+             'smtpport',
+             'smtpserver',
+             'ssldir',
+             'stringify_facts',
+             'tagmap',
+             'templatedir',
+             'thin_storeconfigs',
+             'trusted_node_data',
+             'zlib',
+             'config_version',
+             'manifest',
+             'modulepath',
+             'disable_warnings',
+             'vardir',
+             'rundir',
+             'libdir',
+             'confdir',
+             'classfile'].each do |setting|
+               it { is_expected.to contain_ini_setting("#{section}/#{setting}").with_ensure('absent') }
+             end
+          end
         end
 
-        it { is_expected.to contain_file('/etc/puppetlabs/puppet/ssl/crl.pem').with({
-          'ensure' => 'file',
-          'source' => '/dev/null/ssl/crl.pem',
-          'backup' => 'false',
-        }) }
-
-        ['', 'agent', 'main', 'master'].each do |section|
-          ['allow_variables_with_dashes',
-           'async_storeconfigs',
-           'binder',
-           'catalog_format',
-           'certdnsnames',
-           'certificate_expire_warning',
-           'couchdb_url',
-           'dbadapter',
-           'dbconnections',
-           'dblocation',
-           'dbmigrate',
-           'dbname',
-           'dbpassword',
-           'dbport',
-           'dbserver',
-           'dbsocket',
-           'dbuser',
-           'dynamicfacts',
-           'http_compression',
-           'httplog',
-           'ignoreimport',
-           'immutable_node_data',
-           'inventory_port',
-           'inventory_server',
-           'inventory_terminus',
-           'legacy_query_parameter_serialization',
-           'listen',
-           'localconfig',
-           'manifestdir',
-           'masterlog',
-           'parser',
-           'preview_outputdir',
-           'puppetport',
-           'queue_source',
-           'queue_type',
-           'rails_loglevel',
-           'railslog',
-           'report_serialization_format',
-           'reportfrom',
-           'rrddir',
-           'rrdinterval',
-           'sendmail',
-           'smtphelo',
-           'smtpport',
-           'smtpserver',
-           'ssldir',
-           'stringify_facts',
-           'tagmap',
-           'templatedir',
-           'thin_storeconfigs',
-           'trusted_node_data',
-           'zlib',
-           'config_version',
-           'manifest',
-           'modulepath',
-           'disable_warnings',
-           'vardir',
-           'rundir',
-           'libdir',
-           'confdir',
-           'classfile'].each do |setting|
-             it { is_expected.to contain_ini_setting("#{section}/#{setting}").with_ensure('absent') }
-           end
+        if Puppet.version >= "4.0.0"
+          it { is_expected.not_to contain_class("puppet_agent::prepare::puppet_config") }
+          it { is_expected.not_to contain_class("puppet_agent::prepare::ssl") }
+          it { is_expected.not_to contain_class("puppet_agent::prepare::mco_client_config") }
         end
 
         it { is_expected.to contain_class("puppet_agent::osfamily::#{facts[:osfamily]}") }

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -1,6 +1,11 @@
 require 'spec_helper'
 
 describe 'puppet_agent' do
+  package_version = '1.2.5'
+  global_params = {
+    :package_version => package_version
+  }
+
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
@@ -29,31 +34,54 @@ describe 'puppet_agent' do
           end
         end
 
+        context 'invalid package_versions' do
+          ['1.3.5banana', '1.2', '10-q-5'].each do |version|
+            let(:params) { { :package_version => version } }
+
+            it { expect { catalogue }.to raise_error(/invalid version/) }
+          end
+        end
+
+        context 'valid package_versions' do
+          ['1.4.0.30.g886c5ab', '1.4.0', '1.4.0-10', '1.4.0.10'].each do |version|
+            let(:params) { { :package_version => version } }
+
+            it { is_expected.to compile.with_all_deps }
+            it { expect { catalogue }.not_to raise_error }
+          end
+        end
+
         [{}, {:service_names => []}].each do |params|
           context "puppet_agent class without any parameters" do
-            let(:params) { params }
+            let(:params) { params.merge(global_params) }
 
             it { is_expected.to compile.with_all_deps }
 
             it { is_expected.to contain_class('puppet_agent') }
             it { is_expected.to contain_class('puppet_agent::params') }
-            if Puppet.version < "4.0.0"
-              it { is_expected.to contain_class('puppet_agent::prepare') }
-              it { is_expected.to contain_class('puppet_agent::install').that_comes_before('puppet_agent::service') }
-              it { is_expected.to contain_class('puppet_agent::service') }
+            it { is_expected.to contain_class('puppet_agent::prepare') }
+            it { is_expected.to contain_class('puppet_agent::install').that_requires('puppet_agent::prepare') }
 
-              if params[:service_names].nil?
+            if facts[:osfamily] == 'RedHat'
+              # Workaround PUP-5802/PUP-5025
+              yum_package_version = package_version + '-1.el' + facts[:operatingsystemmajrelease]
+              it { is_expected.to contain_package('puppet-agent').with_ensure(yum_package_version) }
+            else
+              it { is_expected.to contain_package('puppet-agent').with_ensure(package_version) }
+            end
+
+            if Puppet.version < "4.0.0" && !params[:is_pe]
+              it { is_expected.to contain_class('puppet_agent::service').that_requires('puppet_agent::install') }
+            end
+
+            if params[:service_names].nil?
+              if Puppet.version < "4.0.0" && !params[:is_pe]
                 it { is_expected.to contain_service('puppet') }
                 it { is_expected.to contain_service('mcollective') }
-              else
-                it { is_expected.to_not contain_service('puppet') }
-                it { is_expected.to_not contain_service('mcollective') }
               end
-              it { is_expected.to contain_package('puppet-agent').with_ensure('present') }
             else
               it { is_expected.to_not contain_service('puppet') }
               it { is_expected.to_not contain_service('mcollective') }
-              it { is_expected.to_not contain_package('puppet-agent') }
             end
           end
         end
@@ -61,7 +89,7 @@ describe 'puppet_agent' do
     end
   end
 
-  context 'unsupported operating system', :unless => Puppet.version < "3.8.0" || Puppet.version >= "4.0.0" do
+  context 'unsupported operating system' do
     describe 'puppet_agent class without any parameters on Solaris/Nexenta' do
       let(:facts) {{
         :osfamily        => 'Solaris',
@@ -70,8 +98,9 @@ describe 'puppet_agent' do
         :puppet_config   => '/dev/null/puppet.conf',
         :architecture    => 'i386',
       }}
+      let(:params) { global_params }
 
-      it { expect { is_expected.to contain_package('puppet_agent') }.to raise_error(Puppet::Error, /Nexenta not supported/) }
+      it { is_expected.to raise_error(Puppet::Error, /Nexenta not supported/) }
     end
   end
 end

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -1,183 +1,214 @@
 require 'spec_helper'
 
-RSpec.describe 'puppet_agent', :unless => Puppet.version =~ /^(3\.7|4.\d+)\.\d+/ do
+RSpec.describe 'puppet_agent' do
+  package_version = '1.2.1.1'
+  global_params = {
+    :package_version => package_version
+  }
 
-  if Puppet.version >= "4.0.0"
-    it {
-      is_expected.to_not contain_class('::puppet_agent::windows::install')
-    }
-  elsif Puppet.version >= "3.8.0"
-    {'5.1' => {:expect_arch => 'x86', :appdata => 'C:\Document and Settings\All Users\Application Data'},
-     '6.1' => {:expect_arch => 'x64', :appdata => 'C:\ProgramData'}}.each do |kernelmajversion, values|
-      context "Windows Kernelmajversion #{kernelmajversion}" do
-        facts = {
-          :architecture => 'x64',
-          :env_temp_variable => 'C:\tmp',
-          :kernelmajversion => kernelmajversion,
-          :osfamily => 'windows',
-          :puppetversion => '3.8.0',
-          :puppet_confdir => "#{values[:appdata]}\\Puppetlabs\\puppet\\etc",
-          :mco_confdir => "#{values[:appdata]}\\Puppetlabs\\mcollective\\etc",
-          :puppet_agent_pid => 42,
-          :system32 => 'C:\windows\sysnative',
-          :common_appdata => values[:appdata],
+  {'5.1' => {:expect_arch => 'x86', :appdata => 'C:\Document and Settings\All Users\Application Data'},
+   '6.1' => {:expect_arch => 'x64', :appdata => 'C:\ProgramData'}}.each do |kernelmajversion, values|
+    context "Windows Kernelmajversion #{kernelmajversion}" do
+      facts = {
+        :architecture => 'x64',
+        :env_temp_variable => 'C:\tmp',
+        :kernelmajversion => kernelmajversion,
+        :osfamily => 'windows',
+        :puppetversion => '3.8.0',
+        :puppet_confdir => "#{values[:appdata]}\\Puppetlabs\\puppet\\etc",
+        :mco_confdir => "#{values[:appdata]}\\Puppetlabs\\mcollective\\etc",
+        :puppet_agent_pid => 42,
+        :system32 => 'C:\windows\sysnative',
+        :common_appdata => values[:appdata],
+      }
+
+      let(:facts) { facts }
+      let(:params) { global_params }
+
+      context 'without aio_agent_version (FOSS)' do
+        it { is_expected.to contain_class('puppet_agent::windows::install') }
+      end
+
+      context 'is_pe' do
+        before(:each) do
+          # Need to mock the PE functions
+
+          Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
+            '4.0.0'
+          end
+
+          Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
+            '1.2.1.1'
+          end
+        end
+
+        let(:facts) { facts.merge({:is_pe => true}) }
+
+        it {
+          is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+            %r[#{Regexp.escape("msiexec.exe /qn /norestart /i \"#{values[:appdata]}\\Puppetlabs\\packages\\puppet-agent-#{values[:expect_arch]}.msi\"")}])
         }
 
-        let(:facts) { facts }
+        context 'with up to date aio_agent_version matching server' do
+          let(:facts) { facts.merge({
+            :is_pe => true,
+            :aio_agent_version => package_version
+          })}
 
-        context 'is_pe' do
-          before(:each) do
-            # Need to mock the PE functions
-
-            Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
-              '4.0.0'
-            end
-
-            Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
-              '1.2.1.1'
-            end
-          end
-
-          let(:facts) { facts.merge({:is_pe => true}) }
-
-          it {
-            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-              %r[#{Regexp.escape("msiexec.exe /qn /norestart /i \"#{values[:appdata]}\\Puppetlabs\\packages\\puppet-agent-#{values[:expect_arch]}.msi\"")}])
-          }
+          it { is_expected.not_to contain_class('puppet_agent::windows::install') }
         end
-        context 'source =>' do
-          describe 'https://alterernate.com/puppet-agent.msi' do
-            let(:params) { {
-              :source => 'https://alternate.com/puppet-agent.msi',
-            } }
-            it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "https:\/\/alternate.com\/puppet-agent.msi"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
-            }
-          end
-          describe 'C:/tmp/puppet-agent-x64.msi' do
-            let(:params) { {
-              :source => 'C:/tmp/puppet-agent-x64.msi',
-            } }
-            it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "C:\\tmp\\puppet-agent-x64\.msi"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
-            }
-          end
-          describe 'C:\Temp/ Folder\puppet-agent-x64.msi' do
-            let(:params) { {
-              :source => 'C:\Temp/ Folder\puppet-agent-x64.msi',
-            } }
-            it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "C:\\Temp Folder\\puppet-agent-x64\.msi"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
-            }
-          end
-          describe 'C:/Temp/ Folder/puppet-agent-x64.msi' do
-            let(:params) { {
-              :source => 'C:/Temp/ Folder/puppet-agent-x64.msi',
-            } }
-            it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "C:\\Temp Folder\\puppet-agent-x64\.msi"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
-            }
-          end
-          describe '\\\\garded\c$\puppet-agent-x64.msi' do
-            let(:params) { {
-              :source => "\\\\garded\\c$\\puppet-agent-x64.msi",
-            } }
-            it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "\\\\garded\\c\$\\puppet-agent-x64\.msi"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
-            }
-          end
-          describe 'default source' do
-            let(:params) { {} }
-            it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "https:\/\/downloads.puppetlabs.com\/windows\/puppet-agent-#{values[:expect_arch]}-latest\.msi"/)
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer\.log"/)
-            }
-            it {
-              should contain_exec('install_puppet.bat').with { {
-                       'command' => 'C:\windows\sysnative\cmd.exe /c start /b "C:\tmp\install_puppet.bat" 42',
-                     } }
-            }
-            it {
-              is_expected.to_not contain_file('C:\tmp\puppet-agent.msi')
-            }
-          end
-          describe 'puppet:///puppet_agent/puppet-agent-1.1.0-x86.msi' do
-            let(:params) { {:source => 'puppet:///puppet_agent/puppet-agent-1.1.0-x86.msi'} }
-            it {
-              is_expected.to contain_file('C:\tmp\puppet-agent.msi').with_before('File[C:\tmp\install_puppet.bat]')
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "C:\\tmp\\puppet-agent.msi"/
-                             )
-            }
-          end
-        end
-        context 'arch =>' do
-          describe 'specify x86' do
-            let(:params) { {:arch => 'x86'} }
-            it {
-              is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                               /msiexec.exe \/qn \/norestart \/i "https:\/\/downloads.puppetlabs.com\/windows\/puppet-agent-x86-latest\.msi"/
-                             )
-            }
-          end
 
-          describe 'try x64 on x86 system' do
-            let(:facts) { {
-              :osfamily => 'windows',
-              :puppetversion => '3.8.0',
-              :tmpdir => 'C:\tmp',
-              :architecture => 'x86',
-              :system32 => 'C:\windows\sysnative'
-            } }
-            let(:params) { {:arch => 'x64'} }
-            it {
-              expect { catalogue }.to raise_error(Puppet::Error, /Unable to install x64 on a x86 system/)
-            }
-          end
+        context 'with out of date aio_agent_version' do
+          let(:facts) { facts.merge({
+            :is_pe => true,
+            :aio_agent_version => '1.2.0'
+          })}
+
+          it { is_expected.to contain_class('puppet_agent::windows::install') }
         end
       end
-      context 'rubyplatform' do
-        facts = {
-          :architecture => 'x64',
-          :env_temp_variable => 'C:\tmp',
-          :kernelmajversion => kernelmajversion,
-          :osfamily => 'windows',
-          :puppetversion => '3.8.0',
-          :puppet_confdir => "#{values[:appdata]}/PuppetLabs/puppet/etc",
-          :mco_confdir => "#{values[:appdata]}/PuppetLabs/mcollective/etc",
-          :puppet_agent_pid => 42,
-          :system32 => 'C:\windows\sysnative',
-          :tmpdir => 'C:\tmp',
+
+      context 'source =>' do
+        describe 'https://alterernate.com/puppet-agent.msi' do
+          let(:params) { global_params.merge(
+            {:source => 'https://alternate.com/puppet-agent.msi',})
+          }
+          it {
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+                             /msiexec.exe \/qn \/norestart \/i "https:\/\/alternate.com\/puppet-agent.msi"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+          }
+        end
+        describe 'C:/tmp/puppet-agent-x64.msi' do
+          let(:params) { global_params.merge(
+            {:source => 'C:/tmp/puppet-agent-x64.msi',})
+          }
+          it {
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+                             /msiexec.exe \/qn \/norestart \/i "C:\\tmp\\puppet-agent-x64\.msi"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+          }
+        end
+        describe 'C:\Temp/ Folder\puppet-agent-x64.msi' do
+          let(:params) { global_params.merge(
+            {:source => 'C:\Temp/ Folder\puppet-agent-x64.msi',})
+          }
+          it {
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+                             /msiexec.exe \/qn \/norestart \/i "C:\\Temp Folder\\puppet-agent-x64\.msi"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+          }
+        end
+        describe 'C:/Temp/ Folder/puppet-agent-x64.msi' do
+          let(:params) { global_params.merge(
+            {:source => 'C:/Temp/ Folder/puppet-agent-x64.msi',})
+          }
+          it {
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+                             /msiexec.exe \/qn \/norestart \/i "C:\\Temp Folder\\puppet-agent-x64\.msi"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+          }
+        end
+        describe '\\\\garded\c$\puppet-agent-x64.msi' do
+          let(:params) { global_params.merge(
+            {:source => "\\\\garded\\c$\\puppet-agent-x64.msi",})
+          }
+          it {
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+                             /msiexec.exe \/qn \/norestart \/i "\\\\garded\\c\$\\puppet-agent-x64\.msi"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+          }
+        end
+        describe 'default source' do
+          it {
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+                             /msiexec.exe \/qn \/norestart \/i "https:\/\/downloads.puppetlabs.com\/windows\/puppet-agent-#{values[:expect_arch]}-#{package_version}\.msi"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer\.log"/)
+          }
+          it {
+            should contain_exec('install_puppet.bat').with { {
+                     'command' => 'C:\windows\sysnative\cmd.exe /c start /b "C:\tmp\install_puppet.bat" 42',
+                   } }
+          }
+          it {
+            is_expected.to_not contain_file('C:\tmp\puppet-agent.msi')
+          }
+        end
+        describe 'puppet:///puppet_agent/puppet-agent-1.1.0-x86.msi' do
+          let(:params) { global_params.merge(
+            {:source => 'puppet:///puppet_agent/puppet-agent-1.1.0-x86.msi'})
+          }
+          it {
+            is_expected.to contain_file('C:\tmp\puppet-agent.msi').with_before('File[C:\tmp\install_puppet.bat]')
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+                             /msiexec.exe \/qn \/norestart \/i "C:\\tmp\\puppet-agent.msi"/
+                           )
+          }
+        end
+      end
+      context 'arch =>' do
+        describe 'specify x86' do
+          let(:params) { global_params.merge(
+            {:arch => 'x86'})
+          }
+          it {
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
+                             /msiexec.exe \/qn \/norestart \/i "https:\/\/downloads.puppetlabs.com\/windows\/puppet-agent-x86-#{package_version}\.msi"/
+                           )
+          }
+        end
+
+        describe 'try x64 on x86 system' do
+          let(:facts) { {
+            :osfamily => 'windows',
+            :puppetversion => '3.8.0',
+            :tmpdir => 'C:\tmp',
+            :architecture => 'x86',
+            :system32 => 'C:\windows\sysnative',
+            :puppet_confdir => "#{values[:appdata]}\\Puppetlabs\\puppet\\etc",
+            :mco_confdir => "#{values[:appdata]}\\Puppetlabs\\mcollective\\etc",
+          } }
+          let(:params) { global_params.merge(
+            {:arch => 'x64'})
+          }
+          it {
+            expect { catalogue }.to raise_error(Puppet::Error, /Unable to install x64 on a x86 system/)
+          }
+        end
+      end
+    end
+    context 'rubyplatform' do
+      facts = {
+        :architecture => 'x64',
+        :env_temp_variable => 'C:\tmp',
+        :kernelmajversion => kernelmajversion,
+        :osfamily => 'windows',
+        :puppetversion => '3.8.0',
+        :puppet_confdir => "#{values[:appdata]}/PuppetLabs/puppet/etc",
+        :mco_confdir => "#{values[:appdata]}/PuppetLabs/mcollective/etc",
+        :puppet_agent_pid => 42,
+        :system32 => 'C:\windows\sysnative',
+        :tmpdir => 'C:\tmp',
+      }
+      describe 'i386-ming32' do
+        let(:facts) { facts.merge({:rubyplatform => 'i386-ming32'}) }
+        let(:params) { global_params }
+        it {
+          is_expected.to contain_exec('install_puppet.bat').with { {
+                           'command' => 'C:\windows\sysnative\cmd.exe /c start /b C:\windows\system32\cmd.exe /c "C:\tmp\install_puppet.bat" 42',
+                         } }
+
         }
-        describe 'i386-ming32' do
-          let(:facts) { facts.merge({:rubyplatform => 'i386-ming32'}) }
-          it {
-            is_expected.to contain_exec('install_puppet.bat').with { {
-                             'command' => 'C:\windows\sysnative\cmd.exe /c start /b C:\windows\system32\cmd.exe /c "C:\tmp\install_puppet.bat" 42',
-                           } }
+      end
+      describe 'x86' do
+        let(:facts) { facts.merge({:rubyplatform => 'x86_64'}) }
+        let(:params) { global_params }
+        it {
+          is_expected.to contain_exec('install_puppet.bat').with { {
+                           'command' => 'C:\windows\sysnative\cmd.exe /c start /b C:\windows\sysnative\cmd.exe /c "C:\tmp\install_puppet.bat" 42',
+                         } }
 
-          }
-        end
-        describe 'x86' do
-          let(:facts) { facts.merge({:rubyplatform => 'x86_64'}) }
-          it {
-            is_expected.to contain_exec('install_puppet.bat').with { {
-                             'command' => 'C:\windows\sysnative\cmd.exe /c start /b C:\windows\sysnative\cmd.exe /c "C:\tmp\install_puppet.bat" 42',
-                           } }
-
-          }
-        end
+        }
       end
     end
   end


### PR DESCRIPTION
Prior to this commit we only allowed upgrades with this
module if the current puppet version was pre-4.
This commit removes that restriction and hopefully handles
all the edge cases involved in upgrade between new versions
and doesn't break FOSS. This feature should be tested
thoroughly.