### PR TITLE
(maint) Fix typo breaking Debian upgrade for PE

### DIFF
--- a/manifests/osfamily/debian.pp
+++ b/manifests/osfamily/debian.pp
@@ -27,7 +27,7 @@ class puppet_agent::osfamily::debian(
       "Acquire::https::${source_host}::CaInfo \"${_sslcacert_path}\";",
       "Acquire::https::${source_host}::SslCert \"${_sslclientcert_path}\";",
       "Acquire::https::${source_host}::SslKey \"${_sslclientkey_path}\";",
-      "Acquire::http:::proxy::${source_host} DIRECT;",
+      "Acquire::http::proxy::${source_host} DIRECT;",
     ]
 
     apt::setting { 'conf-pc1_repo':

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -50,7 +50,7 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
       "Acquire::https::master.example.vm::CaInfo \"/etc/puppetlabs/puppet/ssl/certs/ca.pem\";",
       "Acquire::https::master.example.vm::SslCert \"/etc/puppetlabs/puppet/ssl/certs/foo.example.vm.pem\";",
       "Acquire::https::master.example.vm::SslKey \"/etc/puppetlabs/puppet/ssl/private_keys/foo.example.vm.pem\";",
-      "Acquire::http:::proxy::master.example.vm DIRECT;",
+      "Acquire::http::proxy::master.example.vm DIRECT;",
     ]
     it { is_expected.to contain_apt__setting('conf-pc1_repo').with({
       'priority' => 90,


### PR DESCRIPTION
This fixes a typo in the apt settings when configuring the repo on the
MoM for PE. Without this, apt ignores the syntactically invalid
configuration option and attempts to use proxy configuration, which is
incorrect and so it fails.