### PR TITLE
(maint) Obtain apt signing key from MoM on PE

### DIFF
--- a/manifests/osfamily/debian.pp
+++ b/manifests/osfamily/debian.pp
@@ -30,6 +30,12 @@ class puppet_agent::osfamily::debian(
       "Acquire::http::proxy::${source_host} DIRECT;",
     ]
 
+    $_key_settings = {
+      id      => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
+      source  => "${::puppet_agent::source}/GPG-KEY-puppetlabs",
+      options => "ca-cert-file=${_ssl_dir}/certs/ca.pem"
+    }
+
     apt::setting { 'conf-pc1_repo':
       content  => $_apt_settings.join(''),
       priority => 90,
@@ -56,16 +62,18 @@ class puppet_agent::osfamily::debian(
       undef   => 'http://apt.puppetlabs.com',
       default => $::puppet_agent::source,
     }
+
+    $_key_settings = {
+      'id'     => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
+      'server' => 'pgp.mit.edu',
+    }
   }
 
 
   apt::source { 'pc1_repo':
     location => $source,
     repos    => 'PC1',
-    key      => {
-      'id'     => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
-      'server' => 'pgp.mit.edu',
-    },
+    key      => $_key_settings,
     notify   => Notify['pc1_repo_force'],
   }
 

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -61,8 +61,9 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
       'location' => 'https://master.example.vm:8140/packages/4.0.0/debian-7-x86_64',
       'repos'    => 'PC1',
       'key'      => {
-        'id'     => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
-        'server' => 'pgp.mit.edu',
+        'id'      => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
+        'source'  => "https://master.example.vm:8140/packages/GPG-KEY-puppetlabs",
+        'options' => "ca-cert-file=/etc/puppetlabs/puppet/ssl/certs/ca.pem"
       },
     }) }
 


### PR DESCRIPTION
This updates `puppet_agent::osfamily::debian` to pull the package
signing key from the source specified in `$::puppet_agent::source`
rather than from pgp.mit.edu. This allows the module to work properly
when a node has access to the master but does not have general external
web access.

This doesn't change the behavior on FOSS installations since the module
already assumes that the node can reach public servers. It also doesn't
change the behavior for other agent operating systems because Debian is
the only OS where we pull the signing key from pgp.mit.edu.