### PR TITLE
(maint) Fix acceptance using Vagrant configs, allow flexible starting Puppet version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,11 +80,19 @@ Beaker tests with:
     bundle exec rake acceptance
 
 This will use the host described in `spec/acceptance/nodeset/default.yml`
-by default. To run against another host, set the `BEAKER_set` environment
-variable to the name of a host described by a `.yml` file in the
-`nodeset` directory. For example, to run against CentOS 6.4:
+and start from Puppet 3.8.6 by default.
+
+To run against another host, set the `BEAKER_set` environment variable to
+the name of a host described by a `.yml` file in the `nodeset` directory.
+For example, to run against CentOS 6.4:
 
     BEAKER_set=centos-64-x64 bundle exec rake acceptance
+
+To run starting from a different Puppet version, set the
+`PUPPET_CLIENT_VERSION` environment variable to a full version string. For
+example, to start with Puppet 3.7.1:
+
+    PUPPET_CLIENT_VERSION=3.7.1 bundle exec rake acceptance
 
 If you don't want to have to recreate the virtual machine every time you
 can use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will

--- a/spec/acceptance/nodesets/centos-5-x64.yml
+++ b/spec/acceptance/nodesets/centos-5-x64.yml
@@ -7,6 +7,7 @@ HOSTS:
     box: puppetlabs/centos-7.0-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
     hypervisor: vagrant
+    vagrant_memsize: 3072
 
   agent:
     roles:

--- a/spec/acceptance/nodesets/centos-6-x64.yml
+++ b/spec/acceptance/nodesets/centos-6-x64.yml
@@ -7,6 +7,7 @@ HOSTS:
     box: puppetlabs/centos-7.0-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
     hypervisor: vagrant
+    vagrant_memsize: 3072
 
   agent:
     roles:

--- a/spec/acceptance/nodesets/debian-6-x64.yml
+++ b/spec/acceptance/nodesets/debian-6-x64.yml
@@ -7,6 +7,7 @@ HOSTS:
     box: puppetlabs/centos-7.0-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
     hypervisor: vagrant
+    vagrant_memsize: 3072
 
   agent:
     roles:

--- a/spec/acceptance/nodesets/debian-7-x64.yml
+++ b/spec/acceptance/nodesets/debian-7-x64.yml
@@ -7,6 +7,7 @@ HOSTS:
     box: puppetlabs/centos-7.0-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
     hypervisor: vagrant
+    vagrant_memsize: 3072
 
   agent:
     roles:

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -7,6 +7,7 @@ HOSTS:
     box: puppetlabs/centos-7.0-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
     hypervisor: vagrant
+    vagrant_memsize: 3072
 
   agent:
     roles:

--- a/spec/acceptance/nodesets/ubuntu-1204-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-1204-x64.yml
@@ -7,6 +7,7 @@ HOSTS:
     box: puppetlabs/centos-7.0-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
     hypervisor: vagrant
+    vagrant_memsize: 3072
 
   agent:
     roles:

--- a/spec/acceptance/nodesets/ubuntu-1404-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-1404-x64.yml
@@ -7,6 +7,7 @@ HOSTS:
     box: puppetlabs/centos-7.0-64-nocm
     box_url: https://vagrantcloud.com/puppetlabs/boxes/centos-7.0-64-nocm
     hypervisor: vagrant
+    vagrant_memsize: 3072
 
   agent:
     roles:

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -91,7 +91,7 @@ end
 
 def server_opts
   {
-    :master => {:autosign => true},
+    :master => {:autosign => true, :dns_alt_names => master},
   }
 end
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -45,7 +45,7 @@ unless ENV['BEAKER_provision'] == 'no'
     master['puppetservice'] = 'puppetserver'
     master['puppetserver-confdir'] = '/etc/puppetlabs/puppetserver/conf.d'
     master['type'] = 'aio'
-    install_puppet_agent_on master, {:puppet_agent_version => '1.2.1'}
+    install_puppet_agent_on master, {}
     install_package master, 'puppetserver'
     master['use-service'] = true
 
@@ -100,7 +100,7 @@ def setup_puppet_on(host, opts = {})
 
   puts "Setup foss puppet on #{host}"
   configure_defaults_on host, 'foss'
-  install_puppet_on host
+  install_puppet_on host, :version => ENV['PUPPET_CLIENT_VERSION'] || '3.8.6'
 
   configure_puppet_on(host, parser_opts)
 


### PR DESCRIPTION
Changes to puppetserver defaults and beaker VM naming caused acceptance
to start failing when using Vagrant. Add the full VM name to
dns_alt_names and increase memory allocated to the master.

Previously acceptance tests would install puppet-agent 1.2.1, then
install the latest puppetserver prompting an upgrade to a new version of
puppet-agent. Now always install the latest puppet-agent and
puppetserver.

Also provide an environment variable, `PUPPET_CLIENT_VERSION` to allow
specifying the starting Puppet version for acceptance tests. This
provides a flexible way to run tests of Puppet from any prior version to
the latest.