### PR TITLE
(maint) Update supported platforms

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,7 +19,7 @@
 
 ## Overview
 
-A module for upgrading Puppet 3.8 agents to puppet-agent in Puppet Collection 1 (i.e., Puppet 4).
+A module for upgrading Puppet 3 agents to puppet-agent in Puppet Collection 1 (i.e., Puppet 4).
 
 ## Module Description
 
@@ -37,7 +37,9 @@ The puppet_agent module installs the Puppet Collection 1 repo (on systems that s
 
 ### Setup Requirements
 
-Your agents must be running Puppet 3.8 with `stringify_facts` set to 'false'. Agents should already be pointed at a master running Puppet Server 2.1 or greater, and thus successfully applying catalogs compiled with the Puppet 4 language.
+Your agents must be running Puppet 3 with `stringify_facts` set to 'false'. Agents should already be pointed at a master running Puppet Server 2.1 or greater, and thus successfully applying catalogs compiled with the Puppet 4 language.
+
+Puppet 3.7 with future parser is required to compile this module, meaning it can be applied to masterless Puppet 3.7+, or earlier Puppet 3 agents connecting to a Puppet 3.7+ master.
 
 ### Beginning with puppet_agent
 

--- a/README.markdown
+++ b/README.markdown
@@ -93,13 +93,7 @@ Alternate source from which you wish to download the latest version of Puppet.
 
 ## Limitations
 
-This module supports:
-
-* RHEL 5, 6, 7
-* Centos 5, 6, 7
-* Debian 6, 7
-* Ubuntu 12.04, 14.04
-* Windows Server 2003 or later
+This module supports [all PE-supported platforms](https://forge.puppetlabs.com/supported#compat-matrix) except Solaris 11.
 
 ###Known issues
 

--- a/README.markdown
+++ b/README.markdown
@@ -110,6 +110,7 @@ Specifically in the 1.1.0 Release:
 * For Windows, you must trigger an agent run after upgrading so that Puppet can create the necessary directory structures.
 * Upgrading from 2015.2.x to 2015.3.x is not yet supported.
 * Solaris 11 is not yet supported.
+* AIX package names are based on PowerPC architecture version. PowerPC 8 is not yet supported.
 
 ##Development
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,8 +44,6 @@ class puppet_agent (
     } elsif $::operatingsystem == 'aix' and $::architecture =~ /PowerPC_POWER[5,6,7]/ {
       $aix_ver_number = regsubst($::platform_tag,'aix-(\d+\.\d+)-power','\1')
       $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.aix${aix_ver_number}.ppc.rpm"
-    } elsif $::operatingsystem == 'Darwin' and $::macosx_productversion_major =~ /10\.[9,10,11]/ {
-      $_package_file_name = "${puppet_agent::package_name}-${puppet_agent::params::master_agent_version}-1.osx${$::macosx_productversion_major}.dmg"
     } elsif $::osfamily == 'windows' {
       $_arch = $::kernelmajversion ?{
         /^5\.\d+/ => 'x86', # x64 is never allowed on windows 2003

--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -6,6 +6,9 @@ class puppet_agent::osfamily::redhat(
   if $::operatingsystem == 'Fedora' {
     $urlbit = 'fedora/f$releasever'
   }
+  elsif $::operatingsystem == 'Amazon' {
+    $urlbit = 'el/6'
+  }
   else {
     $urlbit = 'el/$releasever'
   }
@@ -23,15 +26,8 @@ class puppet_agent::osfamily::redhat(
     $_sslclientcert_path = "${_ssl_dir}/certs/${::clientcert}.pem"
     $_sslclientkey_path = "${_ssl_dir}/private_keys/${::clientcert}.pem"
 
-    # Treat Amazon Linux just like Enterprise Linux 6
-    if $::operatingsystem == 'Amazon' {
-      $_repo_dir = "el-6-${::architecture}"
-    }
-    else {
-      $_repo_dir = $::platform_tag
-    }
     $pe_server_version = pe_build_version()
-    $source = "${::puppet_agent::source}/${pe_server_version}/${_repo_dir}"
+    $source = "${::puppet_agent::source}/${pe_server_version}/${::puppet_agent::params::pe_repo_dir}"
 
     # Due to the file paths changing on the PE Master, the 3.8 repository is no longer valid.
     # On upgrade, remove the repo file so that a dangling reference is not left behind returning

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class puppet_agent::params {
   }
 
   case $::osfamily {
-    'RedHat', 'Amazon', 'Debian', 'Suse', 'Solaris', 'Darwin', 'AIX': {
+    'RedHat', 'Debian', 'Suse', 'Solaris', 'Darwin', 'AIX': {
       $package_name = 'puppet-agent'
       $service_names = ['puppet', 'mcollective']
 
@@ -65,6 +65,12 @@ class puppet_agent::params {
     default: {
       fail("${::operatingsystem} not supported")
     }
+  }
+
+  # Treat Amazon Linux just like Enterprise Linux 6
+  $pe_repo_dir = ($::operatingsystem == 'Amazon') ? {
+    true    => "el-6-${::architecture}",
+    default =>  $::platform_tag,
   }
 
   # The aio puppet-agent version currently installed on the compiling master

--- a/metadata.json
+++ b/metadata.json
@@ -11,6 +11,7 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
+        "4",
         "5",
         "6",
         "7"
@@ -25,25 +26,19 @@
       ]
     },
     {
-      "operatingsystem": "Darwin",
+      "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "10.9",
-        "10.10",
-        "10.11"
-       ]
-    },
-    {
-      "operatingsystem": "Debian",
-      "operatingsystemrelease": [
+        "5",
         "6",
         "7"
       ]
     },
     {
-      "operatingsystem": "Ubuntu",
+      "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "12.04",
-        "14.04"
+        "5",
+        "6",
+        "7"
       ]
     },
     {
@@ -52,6 +47,30 @@
         "10",
         "11",
         "12"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "6",
+        "7",
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Ubuntu",
+      "operatingsystemrelease": [
+        "10.04",
+        "12.04",
+        "14.04",
+        "15.04",
+        "15.10"
+      ]
+    },
+    {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": [
+        "22"
       ]
     },
     {
@@ -69,9 +88,28 @@
         "Server 2008 R2",
         "Server 2012",
         "Server 2012 R2",
+        "Vista",
         "7",
-        "8"
+        "8",
+        "8.1",
+        "10"
       ]
+    },
+    {
+      "operatingsystem": "AIX",
+      "operatingsystemmajrelease": [
+        "5.3",
+        "6.1",
+        "7.1"
+      ]
+    },
+    {
+      "operatingsystem": "OSX",
+      "operatingsystemrelease": [
+        "10.9",
+        "10.10",
+        "10.11"
+       ]
     }
   ],
   "requirements": [

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -1,17 +1,15 @@
 require 'spec_helper'
 
 describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >= "4.0.0" do
-  [['Fedora', 'fedora/f$releasever'], ['CentOS', 'el/$releasever']].each do |os, urlbit|
+  [['Fedora', 'fedora/f$releasever'], ['CentOS', 'el/$releasever'], ['Amazon', 'el/6']].each do |os, urlbit|
     context "with #{os} and #{urlbit}" do
-      facts = {
+      let(:facts) {{
         :osfamily => 'RedHat',
         :operatingsystem => os,
         :architecture => 'x64',
         :servername   => 'master.example.vm',
         :clientcert   => 'foo.example.vm',
-      }
-
-      let(:facts) { facts }
+      }}
 
       it { is_expected.to contain_exec('import-RPM-GPG-KEY-puppetlabs').with({
         'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
@@ -44,39 +42,44 @@ describe 'puppet_agent', :unless => Puppet.version < "3.8.0" || Puppet.version >
             'gpgkey' => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
         }) }
       end
+    end
+  end
 
-      context 'when PE' do
-        before(:each) do
-          # Need to mock the PE functions
+  [['RedHat', 'el-7-x86_64', 'el-7-x86_64'], ['Amazon', '', 'el-6-x64']].each do |os, tag, repodir|
+    context "when PE on #{os}" do
+      before(:each) do
+        # Need to mock the PE functions
 
-          Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
-            '4.0.0'
-          end
-
-          Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
-            '1.2.5'
-          end
+        Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
+          '4.0.0'
         end
 
-        let(:facts) {
-          facts.merge({
-            :is_pe        => true,
-            :platform_tag => 'el-7-x86_64',
-          })
-        }
-
-        it { is_expected.to contain_yumrepo('puppetlabs-pepackages').with_ensure('absent') }
-
-        it { is_expected.to contain_yumrepo('pc1_repo').with({
-          'baseurl' => "https://master.example.vm:8140/packages/4.0.0/el-7-x86_64",
-          'enabled' => 'true',
-          'gpgcheck' => '1',
-          'gpgkey' => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
-          'sslcacert' => '/etc/puppetlabs/puppet/ssl/certs/ca.pem',
-          'sslclientcert' => '/etc/puppetlabs/puppet/ssl/certs/foo.example.vm.pem',
-          'sslclientkey' => '/etc/puppetlabs/puppet/ssl/private_keys/foo.example.vm.pem',
-        }) }
+        Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
+          '1.2.5'
+        end
       end
+
+      let(:facts) {{
+        :osfamily => 'RedHat',
+        :operatingsystem => os,
+        :architecture => 'x64',
+        :servername   => 'master.example.vm',
+        :clientcert   => 'foo.example.vm',
+        :is_pe        => true,
+        :platform_tag => tag,
+      }}
+
+      it { is_expected.to contain_yumrepo('puppetlabs-pepackages').with_ensure('absent') }
+
+      it { is_expected.to contain_yumrepo('pc1_repo').with({
+        'baseurl' => "https://master.example.vm:8140/packages/4.0.0/#{repodir}",
+        'enabled' => 'true',
+        'gpgcheck' => '1',
+        'gpgkey' => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
+        'sslcacert' => '/etc/puppetlabs/puppet/ssl/certs/ca.pem',
+        'sslclientcert' => '/etc/puppetlabs/puppet/ssl/certs/foo.example.vm.pem',
+        'sslclientkey' => '/etc/puppetlabs/puppet/ssl/private_keys/foo.example.vm.pem',
+      }) }
     end
   end
 end


### PR DESCRIPTION
Updates supported platforms for new package releases, AIX PowerPC 8
hardware, and platforms that were added but not noted as supported.

Note that specific upgrade scenarios will still depend on Puppet being
installed from packages prior to upgrade. `puppet-agent` packages should
exist for all supported platforms.