### PR TITLE
(PE-12299) Add Solaris 11 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :test do
   gem 'rspec-puppet', '~> 2.2'
   gem 'puppetlabs_spec_helper', '~> 0.10'
   gem 'metadata-json-lint', '~> 0.0'
-  gem 'rspec-puppet-facts', '~> 0.10'
+  gem 'rspec-puppet-facts', '~> 1.3'
 end
 
 group :system_tests do

--- a/files/solaris_start_puppet.sh
+++ b/files/solaris_start_puppet.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-puppet_pid="<%= @puppet_agent_pid %>"
+puppet_pid=$1
 while $(kill -0 ${puppet_pid:?}); do
   sleep 5
 done

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,11 +56,25 @@ class puppet_agent (
 
     if $::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '10' {
       $_package_file_name = "${puppet_agent::package_name}-${_package_version}-1.sles10.${::architecture}.rpm"
-    } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '10' {
+    } elsif $::operatingsystem == 'Solaris' {
       if $arch =~ /^sun4[uv]$/ {
-        $_package_file_name = "${puppet_agent::package_name}-${_package_version}-1.sparc.pkg.gz"
+        if $::operatingsystemmajrelease == '10' {
+          $_package_file_name = "${puppet_agent::package_name}-${_package_version}-1.sparc.pkg.gz"
+        } elsif $::operatingsystemmajrelease == '11' {
+          # Strip letters from development builds.
+          $_version_without_letters = regsubst($_package_version, /[a-zA-Z]/, '', 'G')
+          $_solaris_version = regsubst($_version_without_letters, /(^-|-$)/, '', 'G')
+          $_package_file_name = "${puppet_agent::package_name}@${_solaris_version},5.11-1.sparc.p5p"
+        }
       } else {
-        $_package_file_name = "${puppet_agent::package_name}-${_package_version}-1.i386.pkg.gz"
+        if $::operatingsystemmajrelease == '10' {
+          $_package_file_name = "${puppet_agent::package_name}-${_package_version}-1.i386.pkg.gz"
+        } elsif $::operatingsystemmajrelease == '11' {
+          # Strip letters from development builds.
+          $_version_without_letters = regsubst($_package_version, /[a-zA-Z]/, '', 'G')
+          $_solaris_version = regsubst($_version_without_letters, /(^-|-$)/, '', 'G')
+          $_package_file_name = "${puppet_agent::package_name}@${_solaris_version},5.11-1.i386.p5p"
+        }
       }
     } elsif $::operatingsystem == 'Darwin' and $::macosx_productversion_major =~ /10\.[9,10,11]/ {
       $_package_file_name = "${puppet_agent::package_name}-${_package_version}-1.osx${$::macosx_productversion_major}.dmg"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,10 @@
 # [package_name]
 #   The package to upgrade to, i.e. `puppet-agent`.
 # [package_version]
-#   The package version to upgrade to. Defaults to undef, meaning only upgrade from Puppet < 4.0.
+#   The package version to upgrade to. When upgrading from Puppet < 4.0, defaults to
+#   the puppet master's latest supported version if compiled with a PE master or
+#   undef otherwise (meaning get the latest Open Source release). Explicitly specify
+#   a version to upgrade from puppet-agent packages (implying Puppet >= 4.0).
 # [service_names]
 #   An array of services to start, normally `puppet` and `mcollective`.
 #   None will be started if the array is empty.
@@ -28,22 +31,16 @@ class puppet_agent (
   $collection      = 'PC1',
   $is_pe           = $::puppet_agent::params::_is_pe,
   $package_name    = $::puppet_agent::params::package_name,
-  $package_version = undef,
+  $package_version = $::puppet_agent::params::package_version,
   $service_names   = $::puppet_agent::params::service_names,
   $source          = $::puppet_agent::params::_source,
 ) inherits ::puppet_agent::params {
 
   validate_re($arch, ['^x86$','^x64$','^i386$','^i86pc$','^amd64$','^x86_64$','^power$','^sun4[uv]$','PowerPC_POWER'])
 
-  if ($package_version == undef and $puppet_agent::params::master_agent_version != undef and versioncmp("${::clientversion}", '4.0.0') < 0) {
-    $_package_version = $puppet_agent::params::master_agent_version
-  } else {
-    $_package_version = $package_version
-  }
-
-  if $_package_version == undef and versioncmp("${::clientversion}", '4.0.0') >= 0 {
+  if $package_version == undef and versioncmp("${::clientversion}", '4.0.0') >= 0 {
     info('puppet_agent performs no actions if a package_version is not specified on Puppet 4')
-  } elsif $_package_version == undef and $is_pe {
+  } elsif $package_version == undef and $is_pe {
     info("puppet_agent performs no actions if the master's agent version cannot be determed on PE 3.x")
   } else {
     if $package_version != undef and $package_version !~ /^\d+\.\d+\.\d+([.-]?\d*|\.\d+\.g[0-9a-f]+)$/ {
@@ -55,32 +52,32 @@ class puppet_agent (
     }
 
     if $::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '10' {
-      $_package_file_name = "${puppet_agent::package_name}-${_package_version}-1.sles10.${::architecture}.rpm"
+      $_package_file_name = "${puppet_agent::package_name}-${package_version}-1.sles10.${::architecture}.rpm"
     } elsif $::operatingsystem == 'Solaris' {
       if $arch =~ /^sun4[uv]$/ {
         if $::operatingsystemmajrelease == '10' {
-          $_package_file_name = "${puppet_agent::package_name}-${_package_version}-1.sparc.pkg.gz"
+          $_package_file_name = "${puppet_agent::package_name}-${package_version}-1.sparc.pkg.gz"
         } elsif $::operatingsystemmajrelease == '11' {
           # Strip letters from development builds.
-          $_version_without_letters = regsubst($_package_version, /[a-zA-Z]/, '', 'G')
+          $_version_without_letters = regsubst($package_version, /[a-zA-Z]/, '', 'G')
           $_solaris_version = regsubst($_version_without_letters, /(^-|-$)/, '', 'G')
           $_package_file_name = "${puppet_agent::package_name}@${_solaris_version},5.11-1.sparc.p5p"
         }
       } else {
         if $::operatingsystemmajrelease == '10' {
-          $_package_file_name = "${puppet_agent::package_name}-${_package_version}-1.i386.pkg.gz"
+          $_package_file_name = "${puppet_agent::package_name}-${package_version}-1.i386.pkg.gz"
         } elsif $::operatingsystemmajrelease == '11' {
           # Strip letters from development builds.
-          $_version_without_letters = regsubst($_package_version, /[a-zA-Z]/, '', 'G')
+          $_version_without_letters = regsubst($package_version, /[a-zA-Z]/, '', 'G')
           $_solaris_version = regsubst($_version_without_letters, /(^-|-$)/, '', 'G')
           $_package_file_name = "${puppet_agent::package_name}@${_solaris_version},5.11-1.i386.p5p"
         }
       }
     } elsif $::operatingsystem == 'Darwin' and $::macosx_productversion_major =~ /10\.[9,10,11]/ {
-      $_package_file_name = "${puppet_agent::package_name}-${_package_version}-1.osx${$::macosx_productversion_major}.dmg"
+      $_package_file_name = "${puppet_agent::package_name}-${package_version}-1.osx${$::macosx_productversion_major}.dmg"
     } elsif $::operatingsystem == 'aix' and $::architecture =~ /PowerPC_POWER[5,6,7]/ {
       $aix_ver_number = regsubst($::platform_tag,'aix-(\d+\.\d+)-power','\1')
-      $_package_file_name = "${puppet_agent::package_name}-${_package_version}-1.aix${aix_ver_number}.ppc.rpm"
+      $_package_file_name = "${puppet_agent::package_name}-${package_version}-1.aix${aix_ver_number}.ppc.rpm"
     } elsif $::osfamily == 'windows' {
       $_arch = $::kernelmajversion ?{
         /^5\.\d+/ => 'x86', # x64 is never allowed on windows 2003
@@ -89,8 +86,8 @@ class puppet_agent (
 
       if $is_pe {
         $_package_file_name = "${package_name}-${_arch}.msi"
-      } elsif $_package_version != undef {
-        $_package_file_name = "${package_name}-${_arch}-${_package_version}.msi"
+      } elsif $package_version != undef {
+        $_package_file_name = "${package_name}-${_arch}-${package_version}.msi"
       } else {
         $_package_file_name = "${package_name}-${_arch}-latest.msi"
       }
@@ -103,7 +100,7 @@ class puppet_agent (
     } ->
     class { '::puppet_agent::install':
       package_file_name => $_package_file_name,
-      package_version   => $_package_version,
+      package_version   => $package_version,
     }
 
     contain '::puppet_agent::prepare'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,24 +54,19 @@ class puppet_agent (
     if $::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '10' {
       $_package_file_name = "${puppet_agent::package_name}-${package_version}-1.sles10.${::architecture}.rpm"
     } elsif $::operatingsystem == 'Solaris' {
-      if $arch =~ /^sun4[uv]$/ {
-        if $::operatingsystemmajrelease == '10' {
-          $_package_file_name = "${puppet_agent::package_name}-${package_version}-1.sparc.pkg.gz"
-        } elsif $::operatingsystemmajrelease == '11' {
-          # Strip letters from development builds.
-          $_version_without_letters = regsubst($package_version, /[a-zA-Z]/, '', 'G')
-          $_solaris_version = regsubst($_version_without_letters, /(^-|-$)/, '', 'G')
-          $_package_file_name = "${puppet_agent::package_name}@${_solaris_version},5.11-1.sparc.p5p"
-        }
-      } else {
-        if $::operatingsystemmajrelease == '10' {
-          $_package_file_name = "${puppet_agent::package_name}-${package_version}-1.i386.pkg.gz"
-        } elsif $::operatingsystemmajrelease == '11' {
-          # Strip letters from development builds.
-          $_version_without_letters = regsubst($package_version, /[a-zA-Z]/, '', 'G')
-          $_solaris_version = regsubst($_version_without_letters, /(^-|-$)/, '', 'G')
-          $_package_file_name = "${puppet_agent::package_name}@${_solaris_version},5.11-1.i386.p5p"
-        }
+      $pkg_arch = $arch ? {
+        /^sun4[uv]$/ => 'sparc',
+        default      => 'i386',
+      }
+
+      if $::operatingsystemmajrelease == '10' {
+        $_package_file_name = "${puppet_agent::package_name}-${package_version}-1.${pkg_arch}.pkg.gz"
+      } elsif $::operatingsystemmajrelease == '11' {
+        # Strip letters from development builds. Unique to Solaris 11 packaging.
+        $_version_without_letters = regsubst($package_version, /[a-zA-Z]/, '', 'G')
+        $_solaris_version = regsubst($_version_without_letters, /(^-|-$)/, '', 'G')
+
+        $_package_file_name = "${puppet_agent::package_name}@${_solaris_version},5.11-1.${pkg_arch}.p5p"
       }
     } elsif $::operatingsystem == 'Darwin' and $::macosx_productversion_major =~ /10\.[9,10,11]/ {
       $_package_file_name = "${puppet_agent::package_name}-${package_version}-1.osx${$::macosx_productversion_major}.dmg"

--- a/manifests/install/remove_packages.pp
+++ b/manifests/install/remove_packages.pp
@@ -25,7 +25,7 @@ class puppet_agent::install::remove_packages(
       },
       'Solaris' => {
         ensure            => 'absent',
-        adminfile => '/opt/puppetlabs/packages/solaris-noask',
+        adminfile         => '/opt/puppetlabs/packages/solaris-noask',
       },
       default => {
         ensure            => 'absent',
@@ -35,8 +35,8 @@ class puppet_agent::install::remove_packages(
     if versioncmp("${::clientversion}", '4.0.0') < 0 {
       # We only need to remove these packages if we are transitioning from PE
       # versions that are pre AIO.
-      $packages = $::operatingsystem ? {
-        'Solaris' => [
+      if $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '10' {
+        $packages = [
           'PUPpuppet',
           'PUPaugeas',
           'PUPdeep-merge',
@@ -51,8 +51,70 @@ class puppet_agent::install::remove_packages(
           'PUPruby-rgen',
           'PUPruby-shadow',
           'PUPstomp',
-        ],
-        default => [
+        ]
+      } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '11' {
+        $packages = [
+          'pe-mcollective',
+          'pe-mcollective-common',
+          'pe-virt-what',
+          'pe-libldap',
+          'pe-deep-merge',
+          'pe-ruby-ldap',
+          'pe-ruby-augeas',
+          'pe-ruby-shadow',
+          'pe-puppet',
+          'pe-facter',
+        ]
+        package { 'pe-augeas':
+          ensure  => absent,
+          require => Package['pe-ruby-augeas'],
+        }
+        package { 'pe-stomp':
+          ensure  => absent,
+          require => Package['pe-mcollective'],
+        }
+        package { ['pe-hiera', 'pe-ruby-rgen']:
+          ensure  => absent,
+          require => Package['pe-puppet'],
+        }
+        package { 'pe-ruby':
+          ensure  => absent,
+          require => Package[
+            'pe-hiera',
+            'pe-deep-merge',
+            'pe-ruby-rgen',
+            'pe-stomp',
+            'pe-ruby-shadow',
+            'pe-puppet',
+            'pe-mcollective',
+            'pe-facter',
+            'pe-facter',
+            'pe-ruby-augeas'
+          ]
+        }
+        package { ['pe-openssl', 'pe-libyaml']:
+          ensure  => absent,
+          require => Package['pe-ruby'],
+        }
+        package { 'pe-puppet-enterprise-release':
+          ensure  => absent,
+          require => Package[
+            'pe-hiera',
+            'pe-stomp',
+            'pe-deep-merge',
+            'pe-libyaml',
+            'pe-ruby',
+            'pe-ruby-shadow',
+            'pe-augeas',
+            'pe-puppet',
+            'pe-ruby-rgen',
+            'pe-facter',
+            'pe-mcollective',
+            'pe-ruby-augeas'
+          ],
+        }
+      } else {
+        $packages = [
           'pe-augeas',
           'pe-mcollective-common',
           'pe-rubygem-deep-merge',

--- a/manifests/osfamily/solaris.pp
+++ b/manifests/osfamily/solaris.pp
@@ -87,15 +87,17 @@ class puppet_agent::osfamily::solaris(
         logoutput => 'on_failure',
       }
 
-      # Backup user configuration because solaris 11 will blow away
-      # /etc/puppetlabs/ when uninstalling the pe-* modules.
-      file { '/tmp/puppet_agent/':
-        ensure => directory,
-      } ->
-      exec { 'puppet_agent backup /etc/puppetlabs/':
-        command => 'cp -r /etc/puppetlabs/ /tmp/puppet_agent/',
-        require => Exec['puppet_agent copy packages'],
-        path    => '/bin:/usr/bin:/sbin:/usr/sbin',
+      if versioncmp("${::clientversion}", '4.0.0') < 0 {
+        # Backup user configuration because solaris 11 will blow away
+        # /etc/puppetlabs/ when uninstalling the pe-* modules.
+        file { '/tmp/puppet_agent/':
+          ensure => directory,
+        } ->
+        exec { 'puppet_agent backup /etc/puppetlabs/':
+          command => 'cp -r /etc/puppetlabs/ /tmp/puppet_agent/',
+          require => Exec['puppet_agent copy packages'],
+          path    => '/bin:/usr/bin:/sbin:/usr/sbin',
+        }
       }
 
     }

--- a/manifests/osfamily/solaris.pp
+++ b/manifests/osfamily/solaris.pp
@@ -43,48 +43,55 @@ class puppet_agent::osfamily::solaris(
       contain puppet_agent::prepare::package
 
       $pkgrepo_dir = '/etc/puppetlabs/installer/solaris.repo'
-
-      # Make sure the pkg publishers are all available.  Broken
-      # publisher entries will stop the installation process.
-      # This must happen before removing any packages.
-      # We rely on the puppetlabs.com publisher previously being
-      # setup (during the initial install).
-      exec { 'puppet_agent ensure pkg publishers are available':
-        command   => 'pkg refresh',
-        path      => '/bin:/usr/bin:/sbin:/usr/sbin',
-        logoutput => 'on_failure',
-        notify    => Exec['puppet_agent remove existing repo'],
+      $publisher = 'puppetlabs.com'
+      $arch = $::architecture ? {
+        /^sun4[uv]$/ => 'sparc',
+        default      => 'i386',
       }
+      $pkg_name = basename($package_file_name, ".${arch}.p5p")
 
       exec { 'puppet_agent remove existing repo':
         command   => "rm -rf '${pkgrepo_dir}'",
         path      => '/bin:/usr/bin:/sbin:/usr/sbin',
         onlyif    => "test -d ${pkgrepo_dir}",
         logoutput => 'on_failure',
-        notify    => Exec['puppet_agent create repo'],
-      }
-
+        unless    => "pkgrepo list -p ${publisher} -s ${pkgrepo_dir} ${pkg_name}",
+      } ~>
       exec { 'puppet_agent create repo':
         command     => "pkgrepo create ${pkgrepo_dir}",
         path        => '/bin:/usr/bin:/sbin:/usr/sbin',
         unless      => "test -f ${pkgrepo_dir}/pkg5.repository",
         logoutput   => 'on_failure',
-        notify      => Exec['puppet_agent set publisher'],
         refreshonly => true,
-      }
-
+      } ~>
       exec { 'puppet_agent set publisher':
-        command     => "pkgrepo set -s ${pkgrepo_dir} publisher/prefix=puppetlabs.com",
+        command     => "pkgrepo set -s ${pkgrepo_dir} publisher/prefix=${publisher}",
         path        => '/bin:/usr/bin:/sbin:/usr/sbin',
         logoutput   => 'on_failure',
         refreshonly => true,
-      }
-
+      } ~>
+      exec { 'puppet_agent ensure pkgrepo is up-to-date':
+        command     => "pkgrepo refresh -s ${pkgrepo_dir}",
+        path        => '/bin:/usr/bin:/sbin:/usr/sbin',
+        logoutput   => 'on_failure',
+        refreshonly => true,
+      } ~>
       exec { 'puppet_agent copy packages':
-        command   => "pkgrecv -s file:///opt/puppetlabs/packages/${package_file_name} -d ${pkgrepo_dir} '*'",
-        path      => '/bin:/usr/bin:/sbin:/usr/sbin',
-        require   => Exec['puppet_agent set publisher'],
-        logoutput => 'on_failure',
+        command     => "pkgrecv -s file:///opt/puppetlabs/packages/${package_file_name} -d ${pkgrepo_dir} '*'",
+        path        => '/bin:/usr/bin:/sbin:/usr/sbin',
+        logoutput   => 'on_failure',
+        refreshonly => true,
+      } ~>
+      # Make sure the pkg publishers are all available.  Broken
+      # publisher entries will stop the installation process.
+      # This must happen before removing any packages.
+      # We rely on the puppetlabs.com publisher previously being
+      # setup (during the initial install).
+      exec { 'puppet_agent ensure pkg publishers are available':
+        command     => "pkg refresh ${publisher}",
+        path        => '/bin:/usr/bin:/sbin:/usr/sbin',
+        logoutput   => 'on_failure',
+        refreshonly => true,
       }
 
       if versioncmp("${::clientversion}", '4.0.0') < 0 {

--- a/manifests/osfamily/solaris.pp
+++ b/manifests/osfamily/solaris.pp
@@ -36,6 +36,69 @@ class puppet_agent::osfamily::solaris(
         source => "puppet:///pe_packages/${pe_server_version}/${::platform_tag}/solaris-noask",
       }
     }
+    '11': {
+      class { 'puppet_agent::prepare::package':
+        package_file_name => $package_file_name,
+      }
+      contain puppet_agent::prepare::package
+
+      $pkgrepo_dir = '/etc/puppetlabs/installer/solaris.repo'
+
+      # Make sure the pkg publishers are all available.  Broken
+      # publisher entries will stop the installation process.
+      # This must happen before removing any packages.
+      # We rely on the puppetlabs.com publisher previously being
+      # setup (during the initial install).
+      exec { 'puppet_agent ensure pkg publishers are available':
+        command   => 'pkg refresh',
+        path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+        logoutput => 'on_failure',
+        notify    => Exec['puppet_agent remove existing repo'],
+      }
+
+      exec { 'puppet_agent remove existing repo':
+        command   => "rm -rf '${pkgrepo_dir}'",
+        path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+        onlyif    => "test -d ${pkgrepo_dir}",
+        logoutput => 'on_failure',
+        notify    => Exec['puppet_agent create repo'],
+      }
+
+      exec { 'puppet_agent create repo':
+        command     => "pkgrepo create ${pkgrepo_dir}",
+        path        => '/bin:/usr/bin:/sbin:/usr/sbin',
+        unless      => "test -f ${pkgrepo_dir}/pkg5.repository",
+        logoutput   => 'on_failure',
+        notify      => Exec['puppet_agent set publisher'],
+        refreshonly => true,
+      }
+
+      exec { 'puppet_agent set publisher':
+        command     => "pkgrepo set -s ${pkgrepo_dir} publisher/prefix=puppetlabs.com",
+        path        => '/bin:/usr/bin:/sbin:/usr/sbin',
+        logoutput   => 'on_failure',
+        refreshonly => true,
+      }
+
+      exec { 'puppet_agent copy packages':
+        command   => "pkgrecv -s file:///opt/puppetlabs/packages/${package_file_name} -d ${pkgrepo_dir} '*'",
+        path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+        require   => Exec['puppet_agent set publisher'],
+        logoutput => 'on_failure',
+      }
+
+      # Backup user configuration because solaris 11 will blow away
+      # /etc/puppetlabs/ when uninstalling the pe-* modules.
+      file { '/tmp/puppet_agent/':
+        ensure => directory,
+      } ->
+      exec { 'puppet_agent backup /etc/puppetlabs/':
+        command => 'cp -r /etc/puppetlabs/ /tmp/puppet_agent/',
+        require => Exec['puppet_agent copy packages'],
+        path    => '/bin:/usr/bin:/sbin:/usr/sbin',
+      }
+
+    }
     default: {
       fail("${::operatingsystem} ${::operatingsystemmajrelease} not supported")
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,9 +21,10 @@ class puppet_agent::params {
     }
   }
 
+  $package_name = 'puppet-agent'
+
   case $::osfamily {
     'RedHat', 'Debian', 'Suse', 'Solaris', 'Darwin', 'AIX': {
-      $package_name = 'puppet-agent'
       if !($::osfamily == 'Solaris' and $::operatingsystemmajrelease == '11') {
         $service_names = ['puppet', 'mcollective']
       }
@@ -48,7 +49,6 @@ class puppet_agent::params {
       $group = 0
     }
     'windows' : {
-      $package_name = 'puppet-agent'
       $service_names = ['puppet', 'mcollective']
 
       $local_puppet_dir = windows_native_path("${::common_appdata}/Puppetlabs")
@@ -80,6 +80,12 @@ class puppet_agent::params {
   $master_agent_version = $_is_pe ? {
     true    => pe_compiling_server_aio_build(),
     default => undef,
+  }
+
+  if ($master_agent_version != undef and versioncmp("${::clientversion}", '4.0.0') < 0) {
+    $package_version = $master_agent_version
+  } else {
+    $package_version = undef
   }
 
   $ssldir = "${confdir}/ssl"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,7 +24,9 @@ class puppet_agent::params {
   case $::osfamily {
     'RedHat', 'Debian', 'Suse', 'Solaris', 'Darwin', 'AIX': {
       $package_name = 'puppet-agent'
-      $service_names = ['puppet', 'mcollective']
+      if !($::osfamily == 'Solaris' and $::operatingsystemmajrelease == '11') {
+        $service_names = ['puppet', 'mcollective']
+      }
 
       $local_puppet_dir = '/opt/puppetlabs'
       $local_packages_dir = "${local_puppet_dir}/packages"

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,17 +6,25 @@
 class puppet_agent::service {
   assert_private()
 
-  $::puppet_agent::service_names.each |$service| {
-    service { $service:
-      ensure     => running,
-      enable     => true,
-      hasstatus  => true,
-      hasrestart => true,
+
+  if $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '11' {
+    contain '::puppet_agent::service::solaris'
+  } else {
+
+    $::puppet_agent::service_names.each |$service| {
+      service { $service:
+        ensure     => running,
+        enable     => true,
+        hasstatus  => true,
+        hasrestart => true,
+      }
     }
+
+    if $::operatingsystem == 'Solaris' {
+      contain '::puppet_agent::service::solaris'
+      Service[$::puppet_agent::service_names] -> Class['::puppet_agent::service::solaris']
+    }
+
   }
 
-  if $::operatingsystem == 'Solaris' {
-    contain '::puppet_agent::service::solaris'
-    Service[$::puppet_agent::service_names] -> Class['::puppet_agent::service::solaris']
-  }
 }

--- a/manifests/service/solaris.pp
+++ b/manifests/service/solaris.pp
@@ -15,12 +15,12 @@ class puppet_agent::service::solaris {
     }
   } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '11' {
     file { '/tmp/solaris_start_puppet.sh':
-      ensure  => file,
-      content => template('puppet_agent/solaris_start_puppet.sh.erb'),
-      mode    => '0755',
+      ensure => file,
+      source => 'puppet:///modules/puppet_agent/solaris_start_puppet.sh',
+      mode   => '0755',
     } ->
     exec { 'solaris_start_puppet.sh':
-      command => '/tmp/solaris_start_puppet.sh &',
+      command => "/tmp/solaris_start_puppet.sh ${::puppet_agent_pid} &",
       path    => '/usr/bin:/bin:/usr/sbin',
     }
     file { ['/var/opt/lib', '/var/opt/lib/pe-puppet', '/var/opt/lib/pe-puppet/state']:

--- a/manifests/service/solaris.pp
+++ b/manifests/service/solaris.pp
@@ -13,5 +13,18 @@ class puppet_agent::service::solaris {
     service { 'pe-puppet':
       ensure => stopped,
     }
+  } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '11' {
+    file { '/tmp/solaris_start_puppet.sh':
+      ensure  => file,
+      content => template('puppet_agent/solaris_start_puppet.sh.erb'),
+      mode    => '0755',
+    } ->
+    exec { 'solaris_start_puppet.sh':
+      command => '/tmp/solaris_start_puppet.sh &',
+      path    => '/usr/bin:/bin:/usr/sbin',
+    }
+    file { ['/var/opt/lib', '/var/opt/lib/pe-puppet', '/var/opt/lib/pe-puppet/state']:
+      ensure => directory,
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -76,7 +76,8 @@
     {
       "operatingsystem": "Solaris",
       "operatingsystemrelease": [
-        "10"
+        "10",
+        "11"
       ]
     },
     {

--- a/spec/classes/puppet_agent_osfamily_solaris_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_solaris_spec.rb
@@ -76,6 +76,7 @@ describe 'puppet_agent' do
         is_expected.to contain_exec('puppet_agent create repo').with_command('pkgrepo create /etc/puppetlabs/installer/solaris.repo')
         is_expected.to contain_exec('puppet_agent set publisher').with_command('pkgrepo set -s /etc/puppetlabs/installer/solaris.repo publisher/prefix=puppetlabs.com')
         is_expected.to contain_exec('puppet_agent copy packages').with_command("pkgrecv -s file:///opt/puppetlabs/packages/puppet-agent@1.2.5,5.11-1.i386.p5p -d /etc/puppetlabs/installer/solaris.repo '*'")
+        is_expected.to contain_exec('puppet_agent ensure pkgrepo is up-to-date').with_command('pkgrepo refresh -s /etc/puppetlabs/installer/solaris.repo')
       end
 
       if Puppet.version < "4.0.0"
@@ -144,6 +145,7 @@ describe 'puppet_agent' do
         is_expected.to contain_exec('puppet_agent create repo').with_command('pkgrepo create /etc/puppetlabs/installer/solaris.repo')
         is_expected.to contain_exec('puppet_agent set publisher').with_command('pkgrepo set -s /etc/puppetlabs/installer/solaris.repo publisher/prefix=puppetlabs.com')
         is_expected.to contain_exec('puppet_agent copy packages').with_command("pkgrecv -s file:///opt/puppetlabs/packages/puppet-agent@1.2.5,5.11-1.sparc.p5p -d /etc/puppetlabs/installer/solaris.repo '*'")
+        is_expected.to contain_exec('puppet_agent ensure pkgrepo is up-to-date').with_command('pkgrepo refresh -s /etc/puppetlabs/installer/solaris.repo')
 
       end
 

--- a/spec/classes/puppet_agent_osfamily_solaris_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_solaris_spec.rb
@@ -11,6 +11,7 @@ describe 'puppet_agent' do
   }
 
   package_version = '1.2.5'
+  pe_version = '2000.0.0'
   if Puppet.version >= "4.0.0"
     let(:params) do
       {
@@ -39,39 +40,156 @@ describe 'puppet_agent' do
     end
   end
 
-  describe 'not yet supported releases' do
-    before(:each) do
-      # Need to mock the PE functions
-      Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
-        "4.0.0"
-      end
-
-      Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
-        package_version
-      end
-    end
-
-    context 'when Solaris 11' do
-      let(:facts) do
-        facts.merge({
-          :is_pe => true,
-          :operatingsystemmajrelease => '11',
-        })
-      end
-
-      it { expect { catalogue }.to raise_error(/Solaris 11 not supported/) }
-    end
-  end
-
   describe 'supported environment' do
     before(:each) do
       # Need to mock the PE functions
       Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
-        "4.0.0"
+        pe_version
       end
 
       Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
         package_version
+      end
+    end
+
+    context "when Solaris 11 i386" do
+      let(:facts) do
+        facts.merge({
+          :is_pe                     => true,
+          :platform_tag              => "solaris-11-i386",
+          :operatingsystemmajrelease => '11',
+        })
+      end
+
+      it { should compile.with_all_deps }
+      it { is_expected.to contain_file('/opt/puppetlabs') }
+      it { is_expected.to contain_file('/opt/puppetlabs/packages') }
+      it do
+        is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent@#{package_version},5.11-1.i386.p5p").with_ensure('present')
+        is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent@#{package_version},5.11-1.i386.p5p").with({
+          'source' => "puppet:///pe_packages/#{pe_version}/solaris-11-i386/puppet-agent@#{package_version},5.11-1.i386.p5p",
+        })
+      end
+
+      it do
+        is_expected.to contain_exec('puppet_agent backup /etc/puppetlabs/').with({
+          'command' => 'cp -r /etc/puppetlabs/ /tmp/puppet_agent/',
+        })
+        is_expected.to contain_exec('puppet_agent remove existing repo').with_command("rm -rf '/etc/puppetlabs/installer/solaris.repo'")
+        is_expected.to contain_exec('puppet_agent create repo').with_command('pkgrepo create /etc/puppetlabs/installer/solaris.repo')
+        is_expected.to contain_exec('puppet_agent set publisher').with_command('pkgrepo set -s /etc/puppetlabs/installer/solaris.repo publisher/prefix=puppetlabs.com')
+        is_expected.to contain_exec('puppet_agent copy packages').with_command("pkgrecv -s file:///opt/puppetlabs/packages/puppet-agent@1.2.5,5.11-1.i386.p5p -d /etc/puppetlabs/installer/solaris.repo '*'")
+
+      end
+
+      if Puppet.version < "4.0.0"
+        [
+          'pe-augeas',
+          'pe-deep-merge',
+          'pe-facter',
+          'pe-hiera',
+          'pe-libldap',
+          'pe-libyaml',
+          'pe-mcollective',
+          'pe-mcollective-common',
+          'pe-openssl',
+          'pe-puppet',
+          'pe-puppet-enterprise-release',
+          'pe-ruby',
+          'pe-ruby-augeas',
+          'pe-ruby-ldap',
+          'pe-ruby-rgen',
+          'pe-ruby-shadow',
+          'pe-stomp',
+          'pe-virt-what',
+        ].each do |package|
+          it do
+            is_expected.to contain_package(package).with_ensure('absent')
+          end
+        end
+      else
+        it do
+          is_expected.to contain_transition("remove puppet-agent").with(
+            :attributes => {
+              'ensure' => 'absent',
+              'adminfile' => '/opt/puppetlabs/packages/solaris-noask',
+            })
+        end
+      end
+
+      it do
+        is_expected.to contain_package('puppet-agent').with_ensure('present')
+      end
+    end
+
+    context "when Solaris 11 sparc sun4u" do
+      let(:facts) do
+        facts.merge({
+          :is_pe                     => true,
+          :platform_tag              => "solaris-11-sparc",
+          :operatingsystemmajrelease => '11',
+          :architecture              => 'sun4u',
+        })
+      end
+
+      it { should compile.with_all_deps }
+      it { is_expected.to contain_file('/opt/puppetlabs') }
+      it { is_expected.to contain_file('/opt/puppetlabs/packages') }
+      it do
+        is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent@1.2.5,5.11-1.sparc.p5p').with_ensure('present')
+        is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent@1.2.5,5.11-1.sparc.p5p').with({
+          'source' => "puppet:///pe_packages/#{pe_version}/solaris-11-sparc/puppet-agent@#{package_version},5.11-1.sparc.p5p",
+        })
+      end
+
+      it do
+        is_expected.to contain_exec('puppet_agent backup /etc/puppetlabs/').with({
+          'command' => 'cp -r /etc/puppetlabs/ /tmp/puppet_agent/',
+        })
+        is_expected.to contain_exec('puppet_agent remove existing repo').with_command("rm -rf '/etc/puppetlabs/installer/solaris.repo'")
+        is_expected.to contain_exec('puppet_agent create repo').with_command('pkgrepo create /etc/puppetlabs/installer/solaris.repo')
+        is_expected.to contain_exec('puppet_agent set publisher').with_command('pkgrepo set -s /etc/puppetlabs/installer/solaris.repo publisher/prefix=puppetlabs.com')
+        is_expected.to contain_exec('puppet_agent copy packages').with_command("pkgrecv -s file:///opt/puppetlabs/packages/puppet-agent@1.2.5,5.11-1.sparc.p5p -d /etc/puppetlabs/installer/solaris.repo '*'")
+
+      end
+
+      if Puppet.version < "4.0.0"
+        [
+          'pe-augeas',
+          'pe-deep-merge',
+          'pe-facter',
+          'pe-hiera',
+          'pe-libldap',
+          'pe-libyaml',
+          'pe-mcollective',
+          'pe-mcollective-common',
+          'pe-openssl',
+          'pe-puppet',
+          'pe-puppet-enterprise-release',
+          'pe-ruby',
+          'pe-ruby-augeas',
+          'pe-ruby-ldap',
+          'pe-ruby-rgen',
+          'pe-ruby-shadow',
+          'pe-stomp',
+          'pe-virt-what',
+        ].each do |package|
+          it do
+            is_expected.to contain_package(package).with_ensure('absent')
+          end
+        end
+      else
+        it do
+          is_expected.to contain_transition("remove puppet-agent").with(
+            :attributes => {
+              'ensure' => 'absent',
+              'adminfile' => '/opt/puppetlabs/packages/solaris-noask',
+            })
+        end
+      end
+
+      it do
+        is_expected.to contain_package('puppet-agent').with_ensure('present')
       end
     end
 
@@ -89,10 +207,10 @@ describe 'puppet_agent' do
       it { is_expected.to contain_file('/opt/puppetlabs/packages') }
       it do
         is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.i386.pkg.gz").with_ensure('present')
-        is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.i386.pkg.gz").with_source("puppet:///pe_packages/4.0.0/solaris-10-i386/puppet-agent-#{package_version}-1.i386.pkg.gz")
+        is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.i386.pkg.gz").with_source("puppet:///pe_packages/#{pe_version}/solaris-10-i386/puppet-agent-#{package_version}-1.i386.pkg.gz")
       end
 
-      it { is_expected.to contain_file('/opt/puppetlabs/packages/solaris-noask').with_source('puppet:///pe_packages/4.0.0/solaris-10-i386/solaris-noask') }
+      it { is_expected.to contain_file('/opt/puppetlabs/packages/solaris-noask').with_source("puppet:///pe_packages/#{pe_version}/solaris-10-i386/solaris-noask") }
       it do
         is_expected.to contain_exec("unzip puppet-agent-#{package_version}-1.i386.pkg.gz").with_command("gzip -d /opt/puppetlabs/packages/puppet-agent-#{package_version}-1.i386.pkg.gz")
         is_expected.to contain_exec("unzip puppet-agent-#{package_version}-1.i386.pkg.gz").with_creates("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.i386.pkg")
@@ -147,7 +265,7 @@ describe 'puppet_agent' do
       before(:each) do
         # Need to mock the PE functions
         Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
-          "4.0.0"
+          pe_version
         end
 
         Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
@@ -169,10 +287,10 @@ describe 'puppet_agent' do
       it { is_expected.to contain_file('/opt/puppetlabs/packages') }
       it do
         is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.sparc.pkg.gz").with_ensure('present')
-        is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.sparc.pkg.gz").with_source("puppet:///pe_packages/4.0.0/solaris-10-sparc/puppet-agent-#{package_version}-1.sparc.pkg.gz")
+        is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.sparc.pkg.gz").with_source("puppet:///pe_packages/#{pe_version}/solaris-10-sparc/puppet-agent-#{package_version}-1.sparc.pkg.gz")
       end
 
-      it { is_expected.to contain_file('/opt/puppetlabs/packages/solaris-noask').with_source('puppet:///pe_packages/4.0.0/solaris-10-sparc/solaris-noask') }
+      it { is_expected.to contain_file('/opt/puppetlabs/packages/solaris-noask').with_source("puppet:///pe_packages/#{pe_version}/solaris-10-sparc/solaris-noask") }
       it do
         is_expected.to contain_exec("unzip puppet-agent-#{package_version}-1.sparc.pkg.gz").with_command("gzip -d /opt/puppetlabs/packages/puppet-agent-#{package_version}-1.sparc.pkg.gz")
         is_expected.to contain_exec("unzip puppet-agent-#{package_version}-1.sparc.pkg.gz").with_creates("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.sparc.pkg")

--- a/spec/classes/puppet_agent_osfamily_solaris_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_solaris_spec.rb
@@ -72,14 +72,10 @@ describe 'puppet_agent' do
       end
 
       it do
-        is_expected.to contain_exec('puppet_agent backup /etc/puppetlabs/').with({
-          'command' => 'cp -r /etc/puppetlabs/ /tmp/puppet_agent/',
-        })
         is_expected.to contain_exec('puppet_agent remove existing repo').with_command("rm -rf '/etc/puppetlabs/installer/solaris.repo'")
         is_expected.to contain_exec('puppet_agent create repo').with_command('pkgrepo create /etc/puppetlabs/installer/solaris.repo')
         is_expected.to contain_exec('puppet_agent set publisher').with_command('pkgrepo set -s /etc/puppetlabs/installer/solaris.repo publisher/prefix=puppetlabs.com')
         is_expected.to contain_exec('puppet_agent copy packages').with_command("pkgrecv -s file:///opt/puppetlabs/packages/puppet-agent@1.2.5,5.11-1.i386.p5p -d /etc/puppetlabs/installer/solaris.repo '*'")
-
       end
 
       if Puppet.version < "4.0.0"
@@ -107,18 +103,19 @@ describe 'puppet_agent' do
             is_expected.to contain_package(package).with_ensure('absent')
           end
         end
+
+        it do
+          is_expected.to contain_exec('puppet_agent backup /etc/puppetlabs/').with({
+            'command' => 'cp -r /etc/puppetlabs/ /tmp/puppet_agent/',
+          })
+
+          is_expected.to contain_package('puppet-agent').with_ensure('present')
+        end
       else
         it do
-          is_expected.to contain_transition("remove puppet-agent").with(
-            :attributes => {
-              'ensure' => 'absent',
-              'adminfile' => '/opt/puppetlabs/packages/solaris-noask',
-            })
+          is_expected.not_to contain_transition("remove puppet-agent")
+          is_expected.to contain_package('puppet-agent').with_ensure(package_version)
         end
-      end
-
-      it do
-        is_expected.to contain_package('puppet-agent').with_ensure('present')
       end
     end
 
@@ -143,9 +140,6 @@ describe 'puppet_agent' do
       end
 
       it do
-        is_expected.to contain_exec('puppet_agent backup /etc/puppetlabs/').with({
-          'command' => 'cp -r /etc/puppetlabs/ /tmp/puppet_agent/',
-        })
         is_expected.to contain_exec('puppet_agent remove existing repo').with_command("rm -rf '/etc/puppetlabs/installer/solaris.repo'")
         is_expected.to contain_exec('puppet_agent create repo').with_command('pkgrepo create /etc/puppetlabs/installer/solaris.repo')
         is_expected.to contain_exec('puppet_agent set publisher').with_command('pkgrepo set -s /etc/puppetlabs/installer/solaris.repo publisher/prefix=puppetlabs.com')
@@ -178,18 +172,19 @@ describe 'puppet_agent' do
             is_expected.to contain_package(package).with_ensure('absent')
           end
         end
+
+        it do
+          is_expected.to contain_exec('puppet_agent backup /etc/puppetlabs/').with({
+            'command' => 'cp -r /etc/puppetlabs/ /tmp/puppet_agent/',
+          })
+
+          is_expected.to contain_package('puppet-agent').with_ensure('present')
+        end
       else
         it do
-          is_expected.to contain_transition("remove puppet-agent").with(
-            :attributes => {
-              'ensure' => 'absent',
-              'adminfile' => '/opt/puppetlabs/packages/solaris-noask',
-            })
+          is_expected.not_to contain_transition("remove puppet-agent")
+          is_expected.to contain_package('puppet-agent').with_ensure(package_version)
         end
-      end
-
-      it do
-        is_expected.to contain_package('puppet-agent').with_ensure('present')
       end
     end
 

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -15,13 +15,17 @@ describe 'puppet_agent' do
               :is_pe => true,
               :operatingsystemmajrelease => facts[:operatingsystemrelease].split('.')[0],
             })
+          elsif os =~ /solaris/
+            facts.merge({
+              :is_pe => true,
+            })
           else
             facts
           end
         end
 
         before(:each) do
-          if os =~ /sles/
+          if os =~ /sles/ || os =~ /solaris/
             # Need to mock the PE functions
 
             Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
@@ -70,6 +74,8 @@ describe 'puppet_agent' do
               # Workaround PUP-5802/PUP-5025
               deb_package_version = package_version + '-1' + facts[:lsbdistcodename]
               it { is_expected.to contain_package('puppet-agent').with_ensure(deb_package_version) }
+            elsif facts[:osfamily] == 'Solaris'
+              it { is_expected.to contain_package('puppet-agent').with_ensure('present') }
             else
               it { is_expected.to contain_package('puppet-agent').with_ensure(package_version) }
             end
@@ -78,11 +84,11 @@ describe 'puppet_agent' do
               it { is_expected.to contain_class('puppet_agent::service').that_requires('puppet_agent::install') }
             end
 
-            if params[:service_names].nil?
-              if Puppet.version < "4.0.0" && !params[:is_pe]
-                it { is_expected.to contain_service('puppet') }
-                it { is_expected.to contain_service('mcollective') }
-              end
+            if params[:service_names].nil? &&
+              !(facts[:osfamily] == 'Solaris' and facts[:operatingsystemmajrelease] == '11') &&
+              Puppet.version < "4.0.0" && !params[:is_pe]
+              it { is_expected.to contain_service('puppet') }
+              it { is_expected.to contain_service('mcollective') }
             else
               it { is_expected.to_not contain_service('puppet') }
               it { is_expected.to_not contain_service('mcollective') }

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -74,7 +74,7 @@ describe 'puppet_agent' do
               # Workaround PUP-5802/PUP-5025
               deb_package_version = package_version + '-1' + facts[:lsbdistcodename]
               it { is_expected.to contain_package('puppet-agent').with_ensure(deb_package_version) }
-            elsif facts[:osfamily] == 'Solaris'
+            elsif facts[:osfamily] == 'Solaris' && (facts[:operatingsystemmajrelease] == '10' || Puppet.version < '4.0.0')
               it { is_expected.to contain_package('puppet-agent').with_ensure('present') }
             else
               it { is_expected.to contain_package('puppet-agent').with_ensure(package_version) }

--- a/templates/solaris_start_puppet.sh.erb
+++ b/templates/solaris_start_puppet.sh.erb
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+puppet_pid="<%= @puppet_agent_pid %>"
+while $(kill -0 ${puppet_pid:?}); do
+  sleep 5
+done
+
+function start_service() {
+  service="${1:?}"
+  /opt/puppetlabs/bin/puppet resource service "${service:?}" ensure=running enable=true
+}
+
+start_service puppet
+start_service mcollective


### PR DESCRIPTION
This commit plumbs the puppet agent module to add Solaris 11 support.

This commit should be fairly consistent with how pe_repo handles
upgrading agents on Solaris 11 by updating the repo in
`/etc/puppetlabs/installer/solaris.repo` with the new puppet-agent
package and installing puppet-agent from there

Lots of things in this commit are less than ideal but the current state
of how Solaris 11 packaging handles files through
uninstallation/installation.

Since Solaris 11 will not uninstall packages if dependant packages are
also installed so the packages must be removed in a specific order or
else the puppet run will fail.

When uninstalling the pe-* packages, Solaris 11 decides to completely
remove everything in `/etc/puppetlabs/` which is why this commit has to
go through and copy it to a temporary location during the upgrade.
However to install puppet-agent, the package needs to be in the repo
that lives in `/etc/puppetlabs/installer/solaris.repo` so the that repo
needs to be put back into place. After installing the puppet-agent
package it overwrites the existing configuration files with the default
configuration files. After installing the puppet-agent module the
/etc/puppetlabs directory is again copied into place so that the user
doesn't lose the ability to talk to the master server or any other
configurations that live in /etc/puppetlabs.

When upgrading Solaris 11 agents, the services are in a maintenance
state where Puppet is unable to start them. Use a script that waits for
the currently running agent run to stop and then calls puppet to ensure
that puppet and mcollective are running so that users do not have to
login to the nodes to perform these steps by hand.

This behavior is currently what windows is doing to start puppet and
mcollective agents when upgrading with the puppet_agent module.