### PR TITLE
(PE-11531) Fix Debian ensure => version

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -80,6 +80,12 @@ class puppet_agent::install(
       ensure => "${package_version}-1.el${::operatingsystemmajrelease}",
       *      => $_package_options,
     }
+  } elsif ($::osfamily == 'Debian') and ($package_version != 'present') {
+    # Workaround PUP-5802/PUP-5025
+    package { $::puppet_agent::package_name:
+      ensure => "${package_version}-1${::lsbdistcodename}",
+      *      => $_package_options,
+    }
   } else {
     package { $::puppet_agent::package_name:
       ensure => $package_version,

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -66,6 +66,10 @@ describe 'puppet_agent' do
               # Workaround PUP-5802/PUP-5025
               yum_package_version = package_version + '-1.el' + facts[:operatingsystemmajrelease]
               it { is_expected.to contain_package('puppet-agent').with_ensure(yum_package_version) }
+            elsif facts[:osfamily] == 'Debian'
+              # Workaround PUP-5802/PUP-5025
+              deb_package_version = package_version + '-1' + facts[:lsbdistcodename]
+              it { is_expected.to contain_package('puppet-agent').with_ensure(deb_package_version) }
             else
               it { is_expected.to contain_package('puppet-agent').with_ensure(package_version) }
             end


### PR DESCRIPTION
Prior to this commit I assumed that I could ensure the package
version on Debian based platforms using the regular X.Y.Z version.
This commit fixes what is ensured on Debian platforms to
`X.Y.Z-1codename`, which is what apt expects.