### PR TITLE
(maint) Re-enable open-source upgrades from 3.x

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,7 +84,6 @@ class puppet_agent (
 
     class { '::puppet_agent::prepare':
       package_file_name => $_package_file_name,
-      package_version   => $_package_version,
     } ->
     class { '::puppet_agent::install':
       package_file_name => $_package_file_name,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,12 +37,14 @@ class puppet_agent (
 
   if ($package_version == undef and $puppet_agent::params::master_agent_version != undef and versioncmp("${::clientversion}", '4.0.0') < 0) {
     $_package_version = $puppet_agent::params::master_agent_version
-  } elsif $package_version != undef {
+  } else {
     $_package_version = $package_version
   }
 
-  if $_package_version == undef  {
-    info("puppet_agent performs no actions if a package_version is not specified on Puppet 4, or if the master's agent version cannot be determined on Puppet 3.8")
+  if $_package_version == undef and versioncmp("${::clientversion}", '4.0.0') >= 0 {
+    info('puppet_agent performs no actions if a package_version is not specified on Puppet 4')
+  } elsif $_package_version == undef and $is_pe {
+    info("puppet_agent performs no actions if the master's agent version cannot be determed on PE 3.x")
   } else {
     if $package_version != undef and $package_version !~ /^\d+\.\d+\.\d+([.-]?\d*|\.\d+\.g[0-9a-f]+)$/ {
       fail("invalid version ${package_version} requested")

--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -13,7 +13,6 @@
 #
 class puppet_agent::prepare(
   $package_file_name = undef,
-  $package_version
 ){
   include puppet_agent::params
   $_windows_client = downcase($::osfamily) == 'windows'

--- a/spec/classes/puppet_agent_prepare_spec.rb
+++ b/spec/classes/puppet_agent_prepare_spec.rb
@@ -6,9 +6,6 @@ MCO_PLUGIN_YAML = '/etc/puppetlabs/mcollective/facts.yaml'
 MCO_LOGFILE = '/var/log/puppetlabs/mcollective.log'
 
 describe 'puppet_agent::prepare' do
-  let(:params) { {
-    :package_version => '4.0.0',
-  } }
   context 'supported operating system families' do
     ['Debian', 'RedHat', 'SuSE'].each do |osfamily|
       case osfamily

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -31,6 +31,7 @@ def install_modules_on(host)
   on host, puppet('module', 'install', 'puppetlabs-stdlib'), {:acceptable_exit_codes => [0, 1]}
   on host, puppet('module', 'install', 'puppetlabs-inifile'), {:acceptable_exit_codes => [0, 1]}
   on host, puppet('module', 'install', 'puppetlabs-apt'), {:acceptable_exit_codes => [0, 1]}
+  on host, puppet('module', 'install', 'puppetlabs-transition'), {:acceptable_exit_codes => [0, 1]}
 end
 
 unless ENV['BEAKER_provision'] == 'no'
@@ -73,7 +74,7 @@ end
 unless ENV['MODULE_provision'] == 'no'
   if default['platform'] =~ /windows/i
     target = (on default, puppet('config print modulepath')).stdout.split(';')[0]
-    {'stdlib' => '4.6.0', 'inifile' => '1.3.0', 'apt' => '2.0.1'}.each do |repo, version|
+    {'stdlib' => '4.6.0', 'inifile' => '1.3.0', 'apt' => '2.0.1', 'transition' => '0.1.0'}.each do |repo, version|
       on default, "rm -rf \"#{target}/#{repo}\";git clone --branch #{version} --depth 1 https://github.com/puppetlabs/puppetlabs-#{repo} \"#{target}/#{repo}\""
     end
     # default['distmoduledir'] = '`cygpath -smF 35`/PuppetLabs/puppet/etc/modules' should be set
@@ -144,14 +145,14 @@ end
 
 def teardown_puppet_on(host)
   puts "Purge puppet from #{host}"
-  # Note pc1_repo is specific to the module's manifests. This is knowledge we need to clean
+  # Note pc_repo is specific to the module's manifests. This is knowledge we need to clean
   # the machine after each run.
   case host['platform']
     when /debian|ubuntu/
       on host, '/opt/puppetlabs/bin/puppet module install puppetlabs-apt', {:acceptable_exit_codes => [0, 1]}
-      clean_repo = "include apt\napt::source { 'pc1_repo': ensure => absent, notify => Package['puppet-agent'] }"
+      clean_repo = "include apt\napt::source { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"
     when /fedora|el|centos/
-      clean_repo = "yumrepo { 'pc1_repo': ensure => absent, notify => Package['puppet-agent'] }"
+      clean_repo = "yumrepo { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"
     else
       logger.notify("Not sure how to remove repos on #{host['platform']}")
       clean_repo = ''


### PR DESCRIPTION
The prior commit to enable puppet-agent to puppet-agent upgrades set an
expectation that a target version would always be required, either from
the master or explicitly specified as a parameter. That broke the
previous open-source upgrade behavior when upgrading from Puppet 3.x.

Restore that behavior by allowing the target version to be unspecified
if not on Puppet Enterprise and upgrading from Puppet 3.x. Also add the
new dependency puppetlabs-transition for acceptance testing.