### PR TITLE
(maint) Fix a dependency cycle introduced on Windows by Sol11 work

### DIFF
--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -17,6 +17,7 @@ class puppet_agent::prepare(
   include puppet_agent::params
   $_windows_client = downcase($::osfamily) == 'windows'
   if $_windows_client {
+
     File{
       source_permissions => ignore,
     }
@@ -24,6 +25,15 @@ class puppet_agent::prepare(
   else  {
     File {
       source_permissions => use,
+    }
+  }
+
+  # Manage /opt/puppetlabs for platforms. This is done before both config and prepare because,
+  # on Windows, both can be in C:/ProgramData/Puppet Labs; doing it later creates a dependency
+  # cycle.
+  if !defined(File[$::puppet_agent::params::local_puppet_dir]) {
+    file { $::puppet_agent::params::local_puppet_dir:
+      ensure => directory,
     }
   }
 

--- a/manifests/prepare/package.pp
+++ b/manifests/prepare/package.pp
@@ -27,13 +27,6 @@ class puppet_agent::prepare::package(
       $source = "puppet:///pe_packages/${pe_server_version}/${::platform_tag}/${package_file_name}"
     }
 
-    # Manage /opt/puppetlabs for platforms
-    if !defined(File[$::puppet_agent::params::local_puppet_dir]) {
-      file { $::puppet_agent::params::local_puppet_dir:
-        ensure => directory,
-      }
-    }
-
     file { $::puppet_agent::params::local_packages_dir:
       ensure => directory,
     }


### PR DESCRIPTION
Fixes a dependency cycle introduced by Solaris 11 work. Solaris 11
requires managing config files before preparing packages, because part
of preparing the package is saving /etc/puppetlabs where the configs are
stored.

On Windows, a dependency was introduced because the package is stored to
`C:/ProgramData/Puppet Labs/...`, and config files are also stored
there. So creating an order of configs before package prepare caused a
requirement that C:/ProgramData/Puppet Labs exists both before and after
managing config files. Fix that dependency cycle by mananging
`C:/ProgramData/Puppet Labs` earlier.