### PR TITLE
(maint) Fix spec that should've skipped Solaris

### DIFF
--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -28,7 +28,7 @@ describe 'puppet_agent' do
           global_facts(facts, os)
         end
 
-        if os !~ /sles/ and os !~ /sles/
+        if os !~ /sles/ and os !~ /solaris/
           context 'package_version is undef by default' do
             let(:facts) do
               global_facts(facts, os).merge({:is_pe => false})


### PR DESCRIPTION
Typo in previous spec meant it only skipped SLES (as a PE-only
platform). It must also skip Solaris.