### PR TITLE
(PE-11531) Don't remove packages if package_version undef

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -77,7 +77,7 @@ class puppet_agent::install(
 
   if $::osfamily == 'windows' {
     # Prevent re-running the batch install
-    if versioncmp("${::aio_agent_version}", "${package_version}") < 0 {
+    if $package_version != undef and versioncmp("${::aio_agent_version}", "${package_version}") < 0 {
       if $::puppet_agent::is_pe == true and empty($::puppet_agent::source) and defined(File["${::puppet_agent::params::local_packages_dir}/${package_file_name}"]) {
         class { 'puppet_agent::windows::install':
           package_file_name => $package_file_name,

--- a/manifests/install/remove_packages.pp
+++ b/manifests/install/remove_packages.pp
@@ -135,7 +135,7 @@ class puppet_agent::install::remove_packages(
           'pe-ruby-ldap',
         ]
       }
-    } elsif versioncmp("${::aio_agent_version}", "${::puppet_agent::package_version}") < 0 {
+    } elsif $puppet_agent::package_version != undef and versioncmp("${::aio_agent_version}", "${::puppet_agent::package_version}") < 0 {
       $packages = [ 'puppet-agent' ]
     } else {
       $packages = []

--- a/manifests/install/remove_packages_osx.pp
+++ b/manifests/install/remove_packages_osx.pp
@@ -57,7 +57,7 @@ class puppet_agent::install::remove_packages_osx {
           require => File['/opt/puppet'],
         }
       }
-    } elsif versioncmp("${::aio_agent_version}", "${puppet_agent::package_version}") < 0 {
+    } elsif $puppet_agent::package_version != undef and versioncmp("${::aio_agent_version}", "${puppet_agent::package_version}") < 0 {
       exec { 'forget puppet-agent':
         command => '/usr/sbin/pkgutil --forget com.puppetlabs.puppet-agent',
       }


### PR DESCRIPTION
Prior to this commit we were removing the puppet-agent package
if the `package_version` happened to be unset, due to the
behavior of `versioncmp`. This is obviously not what we want to
have happen.
This commit updates all of the calls that compare `package_version`
with `aio_agent_version` with `versioncmp` to be gated on
`package_version` not being undef, thus preventing the packages
from being removed on every run.