### PR TITLE
(PE-11531) Centralize check for aio upgrade

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,10 @@ class puppet_agent (
       fail("invalid version ${package_version} requested")
     }
 
+    $aio_upgrade_required = ($is_pe == false and $package_version != undef) or
+      ($::aio_agent_version != undef and $package_version != undef and
+        versioncmp("${::aio_agent_version}", "${package_version}") < 0)
+
     if $::architecture == 'x86' and $arch == 'x64' {
       fail('Unable to install x64 on a x86 system')
     }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -77,7 +77,7 @@ class puppet_agent::install(
 
   if $::osfamily == 'windows' {
     # Prevent re-running the batch install
-    if $package_version != undef and versioncmp("${::aio_agent_version}", "${package_version}") < 0 {
+    if $old_packages or $puppet_agent::aio_upgrade_required {
       if $::puppet_agent::is_pe == true and empty($::puppet_agent::source) and defined(File["${::puppet_agent::params::local_packages_dir}/${package_file_name}"]) {
         class { 'puppet_agent::windows::install':
           package_file_name => $package_file_name,

--- a/manifests/install/remove_packages.pp
+++ b/manifests/install/remove_packages.pp
@@ -135,7 +135,7 @@ class puppet_agent::install::remove_packages(
           'pe-ruby-ldap',
         ]
       }
-    } elsif $puppet_agent::package_version != undef and versioncmp("${::aio_agent_version}", "${::puppet_agent::package_version}") < 0 {
+    } elsif $puppet_agent::aio_upgrade_required {
       $packages = [ 'puppet-agent' ]
     } else {
       $packages = []
@@ -145,7 +145,7 @@ class puppet_agent::install::remove_packages(
         package { $old_package:
           * => $package_options,
         }
-      } else {
+      } elsif $puppet_agent::aio_upgrade_required {
         # We must use transition here because we would have a duplicate package
         # declaration if we used a Package.
         notify { "using puppetlabs-transition to remove ${old_package}: ${::operatingsystem} does not support versionable": }

--- a/manifests/install/remove_packages_osx.pp
+++ b/manifests/install/remove_packages_osx.pp
@@ -57,7 +57,7 @@ class puppet_agent::install::remove_packages_osx {
           require => File['/opt/puppet'],
         }
       }
-    } elsif $puppet_agent::package_version != undef and versioncmp("${::aio_agent_version}", "${puppet_agent::package_version}") < 0 {
+    } elsif $puppet_agent::aio_upgrade_required {
       exec { 'forget puppet-agent':
         command => '/usr/sbin/pkgutil --forget com.puppetlabs.puppet-agent',
       }

--- a/spec/classes/puppet_agent_osfamily_darwin_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_darwin_spec.rb
@@ -94,7 +94,17 @@ describe 'puppet_agent' do
               it { is_expected.to contain_exec("forget #{package}").with_require('File[/opt/puppet]') }
             end
           else
-            it { is_expected.to contain_exec('forget puppet-agent').with_command("/usr/sbin/pkgutil --forget com.puppetlabs.puppet-agent") }
+            context 'aio_agent_version is out of date' do
+              let(:facts) do
+                facts.merge({
+                  :aio_agent_version => '1.0.0'
+                })
+              end
+
+              it { is_expected.to contain_exec('forget puppet-agent').with_command("/usr/sbin/pkgutil --forget com.puppetlabs.puppet-agent") }
+            end
+
+            it { is_expected.not_to contain_exec('forget puppet-agent') }
           end
         end
       end

--- a/spec/classes/puppet_agent_osfamily_solaris_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_solaris_spec.rb
@@ -50,6 +50,10 @@ describe 'puppet_agent' do
       Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
         package_version
       end
+
+      # Ensure we get a versionable package provider
+      pkg = Puppet::Type.type(:package)
+      pkg.stubs(:defaultprovider).returns(pkg.provider(:pkg))
     end
 
     context "when Solaris 11 i386" do
@@ -242,12 +246,36 @@ describe 'puppet_agent' do
           end
         end
       else
-        it do
-          is_expected.to contain_transition("remove puppet-agent").with(
-            :attributes => {
-              'ensure' => 'absent',
-              'adminfile' => '/opt/puppetlabs/packages/solaris-noask',
+        context 'with older aio_agent_version' do
+          let(:facts) do
+            facts.merge({
+              :is_pe                     => true,
+              :platform_tag              => "solaris-10-i386",
+              :operatingsystemmajrelease => '10',
+              :aio_agent_version         => '1.0.0',
             })
+          end
+
+          it do
+            is_expected.to contain_transition("remove puppet-agent").with(
+              :attributes => {
+                'ensure' => 'absent',
+                'adminfile' => '/opt/puppetlabs/packages/solaris-noask',
+              })
+          end
+        end
+
+        context 'with up-to-date aio_agent_version' do
+          let(:facts) do
+            facts.merge({
+              :is_pe                     => true,
+              :platform_tag              => "solaris-10-i386",
+              :operatingsystemmajrelease => '10',
+              :aio_agent_version         => package_version,
+            })
+          end
+
+          it { is_expected.not_to contain_transition("remove puppet-agent") }
         end
       end
 
@@ -322,13 +350,27 @@ describe 'puppet_agent' do
           end
         end
       else
-        it do
-          is_expected.to contain_transition("remove puppet-agent").with(
-            :attributes => {
-              'ensure' => 'absent',
-              'adminfile' => '/opt/puppetlabs/packages/solaris-noask',
+        context 'aio_agent_version is out of date' do
+          let(:facts) do
+            facts.merge({
+              :is_pe                     => true,
+              :platform_tag              => "solaris-10-sparc",
+              :operatingsystemmajrelease => '10',
+              :architecture              => 'sun4u',
+              :aio_agent_version         => '1.0.0'
             })
+          end
+
+          it do
+            is_expected.to contain_transition("remove puppet-agent").with(
+              :attributes => {
+                'ensure' => 'absent',
+                'adminfile' => '/opt/puppetlabs/packages/solaris-noask',
+              })
+          end
         end
+
+        it { is_expected.not_to contain_transition("remove puppet-agent") }
       end
 
       it do

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -107,12 +107,26 @@ describe 'puppet_agent' do
           end
         end
       else
-        it do
-          is_expected.to contain_transition('remove puppet-agent').with_attributes(
-            'ensure' => 'absent',
-            'uninstall_options' => '--nodeps',
-            'provider' => 'rpm')
+        context 'aio_agent_version is out of date' do
+          let(:facts) do
+            facts.merge({
+              :operatingsystemmajrelease => '10',
+              :platform_tag              => "sles-10-x86_64",
+              :architecture              => "x86_64",
+              :aio_agent_version         => '1.0.0'
+            })
+          end
+
+          it { is_expected.to contain_class("puppet_agent::install::remove_packages") }
+          it do
+            is_expected.to contain_transition('remove puppet-agent').with_attributes(
+              'ensure' => 'absent',
+              'uninstall_options' => '--nodeps',
+              'provider' => 'rpm')
+          end
         end
+
+        it { is_expected.not_to contain_transition("remove puppet-agent") }
       end
 
       it do


### PR DESCRIPTION
Prior to this commit we had the same AIO upgrade expression scattered
in 3 different places with slightly different syntax. Also, we did not
account for the fact that `aio_agent_version` is a PE only fact.
This commit creates a `$aio_upgrade_required` var in the main class
that will 1) always be true if not PE and `package_version` is set 2) be
true if `aio_agent_version` and `package_version` are set and
the `aio_agent_version` is less than (-1) the `package_version`.