### PR TITLE
(PE-11531) Stop OSX from forgetting packages

### DIFF
--- a/manifests/install/remove_packages_osx.pp
+++ b/manifests/install/remove_packages_osx.pp
@@ -57,10 +57,6 @@ class puppet_agent::install::remove_packages_osx {
           require => File['/opt/puppet'],
         }
       }
-    } elsif $puppet_agent::aio_upgrade_required {
-      exec { 'forget puppet-agent':
-        command => '/usr/sbin/pkgutil --forget com.puppetlabs.puppet-agent',
-      }
     }
   }
 }

--- a/spec/classes/puppet_agent_osfamily_darwin_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_darwin_spec.rb
@@ -101,7 +101,7 @@ describe 'puppet_agent' do
                 })
               end
 
-              it { is_expected.to contain_exec('forget puppet-agent').with_command("/usr/sbin/pkgutil --forget com.puppetlabs.puppet-agent") }
+              it { is_expected.not_to contain_exec('forget puppet-agent') }
             end
 
             it { is_expected.not_to contain_exec('forget puppet-agent') }


### PR DESCRIPTION
Turns out we don't need to bother forgetting the old package when doing
an OSX upgrade between AIO versions, that was only necessary for 3.8
upgrades.