### PR TITLE
(PE-15036) Fix Windows permission inheritance

### DIFF
--- a/lib/facter/settings.rb
+++ b/lib/facter/settings.rb
@@ -40,6 +40,12 @@ Facter.add('puppet_confdir') do
   end
 end
 
+Facter.add('puppet_client_datadir') do
+  setcode do
+    Puppet.settings['client_datadir']
+  end
+end
+
 Facter.add('mco_confdir') do
   setcode do
     File.expand_path(File.join(Puppet.settings['confdir'],'../../mcollective/etc'))

--- a/manifests/windows/install.pp
+++ b/manifests/windows/install.pp
@@ -56,4 +56,11 @@ class puppet_agent::windows::install(
     command => "${::system32}\\cmd.exe /c start /b ${_cmd_location} /c \"${_installbat}\" ${::puppet_agent_pid}",
     path    => $::path,
   }
+
+  # PUP-5480/PE-15037 Cache dir loses inheritable SYSTEM perms
+  exec { 'fix inheritable SYSTEM perms':
+    command => "${::system32}\\icacls.exe \"${::puppet_client_datadir}\" /grant \"SYSTEM:(OI)(CI)(F)\"",
+    unless  => "${::system32}\\icacls.exe \"${::puppet_client_datadir}\" | findstr \"SYSTEM:(OI)(CI)(F)\"",
+    require => Exec['install_puppet.bat'],
+  }
 }

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe 'puppet_agent' do
             it { is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
                 %r[#{Regexp.escape("msiexec.exe /qn /norestart /i \"#{values[:appdata]}\\Puppetlabs\\packages\\puppet-agent-#{values[:expect_arch]}.msi\"")}])
             }
+            it { is_expected.to contain_exec('fix inheritable SYSTEM perms') }
           end
         end
 
@@ -64,6 +65,7 @@ RSpec.describe 'puppet_agent' do
 
             it { is_expected.not_to contain_class('puppet_agent::windows::install') }
             it { is_expected.not_to contain_file('c:\tmp\install_puppet.bat') }
+            it { is_expected.not_to contain_exec('fix inheritable SYSTEM perms') }
           end
 
           context 'with out of date aio_agent_version' do
@@ -76,6 +78,7 @@ RSpec.describe 'puppet_agent' do
             it { is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
                 %r[#{Regexp.escape("msiexec.exe /qn /norestart /i \"#{values[:appdata]}\\Puppetlabs\\packages\\puppet-agent-#{values[:expect_arch]}.msi\"")}])
             }
+            it { is_expected.to contain_exec('fix inheritable SYSTEM perms') }
           end
         end
       end
@@ -90,6 +93,7 @@ RSpec.describe 'puppet_agent' do
                              /msiexec.exe \/qn \/norestart \/i "https:\/\/alternate.com\/puppet-agent.msi"/)
             is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
           }
+          it { is_expected.to contain_exec('fix inheritable SYSTEM perms') }
         end
         describe 'C:/tmp/puppet-agent-x64.msi' do
           let(:params) { global_params.merge(
@@ -100,6 +104,7 @@ RSpec.describe 'puppet_agent' do
                              /msiexec.exe \/qn \/norestart \/i "C:\\tmp\\puppet-agent-x64\.msi"/)
             is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
           }
+          it { is_expected.to contain_exec('fix inheritable SYSTEM perms') }
         end
         describe 'C:\Temp/ Folder\puppet-agent-x64.msi' do
           let(:params) { global_params.merge(
@@ -110,6 +115,7 @@ RSpec.describe 'puppet_agent' do
                              /msiexec.exe \/qn \/norestart \/i "C:\\Temp Folder\\puppet-agent-x64\.msi"/)
             is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
           }
+          it { is_expected.to contain_exec('fix inheritable SYSTEM perms') }
         end
         describe 'C:/Temp/ Folder/puppet-agent-x64.msi' do
           let(:params) { global_params.merge(
@@ -120,6 +126,7 @@ RSpec.describe 'puppet_agent' do
                              /msiexec.exe \/qn \/norestart \/i "C:\\Temp Folder\\puppet-agent-x64\.msi"/)
             is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
           }
+          it { is_expected.to contain_exec('fix inheritable SYSTEM perms') }
         end
         describe '\\\\garded\c$\puppet-agent-x64.msi' do
           let(:params) { global_params.merge(
@@ -130,6 +137,7 @@ RSpec.describe 'puppet_agent' do
                              /msiexec.exe \/qn \/norestart \/i "\\\\garded\\c\$\\puppet-agent-x64\.msi"/)
             is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
           }
+          it { is_expected.to contain_exec('fix inheritable SYSTEM perms') }
         end
         describe 'default source' do
           it {
@@ -145,6 +153,7 @@ RSpec.describe 'puppet_agent' do
           it {
             is_expected.to_not contain_file('C:\tmp\puppet-agent.msi')
           }
+          it { is_expected.to contain_exec('fix inheritable SYSTEM perms') }
         end
         describe 'puppet:///puppet_agent/puppet-agent-1.1.0-x86.msi' do
           let(:params) { global_params.merge(
@@ -156,6 +165,7 @@ RSpec.describe 'puppet_agent' do
                              /msiexec.exe \/qn \/norestart \/i "C:\\tmp\\puppet-agent.msi"/
                            )
           }
+          it { is_expected.to contain_exec('fix inheritable SYSTEM perms') }
         end
       end
       context 'arch =>' do
@@ -211,6 +221,7 @@ RSpec.describe 'puppet_agent' do
                          } }
 
         }
+        it { is_expected.to contain_exec('fix inheritable SYSTEM perms') }
       end
       describe 'x86' do
         let(:facts) { facts.merge({:rubyplatform => 'x86_64'}) }
@@ -221,6 +232,7 @@ RSpec.describe 'puppet_agent' do
                          } }
 
         }
+        it { is_expected.to contain_exec('fix inheritable SYSTEM perms') }
       end
     end
   end


### PR DESCRIPTION
Prior to this commit there was an issue where the inherit permission
value on the `client_datadir` folder was being lost, causing the folder
to be inaccessible to the MCO/PCP daemons.

This commit ensures that directory has the proper inherit permission,
if it appears that it does not have it. For more details: PE-15036