### PR TITLE
(PE-11531) Fix upgrade issue with dev builds

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,9 +47,16 @@ class puppet_agent (
       fail("invalid version ${package_version} requested")
     }
 
-    $aio_upgrade_required = ($is_pe == false and $package_version != undef) or
-      ($::aio_agent_version != undef and $package_version != undef and
-        versioncmp("${::aio_agent_version}", "${package_version}") < 0)
+    # Strip git sha from dev builds
+    if $package_version != undef and $package_version =~ /g/ {
+      $_expected_package_version = split($package_version, /[.-]g.*/)[0]
+    } else {
+      $_expected_package_version = $package_version
+    }
+
+    $aio_upgrade_required = ($is_pe == false and $_expected_package_version != undef) or
+      ($::aio_agent_version != undef and $_expected_package_version != undef and
+        versioncmp("${::aio_agent_version}", "${_expected_package_version}") < 0)
 
     if $::architecture == 'x86' and $arch == 'x64' {
       fail('Unable to install x64 on a x86 system')

--- a/spec/classes/puppet_agent_osfamily_solaris_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_solaris_spec.rb
@@ -283,6 +283,19 @@ describe 'puppet_agent' do
 
           it { is_expected.not_to contain_transition("remove puppet-agent") }
         end
+
+        context 'with up-to-date aio_agent_version missing git sha' do
+          let(:facts) do
+            facts.merge({
+              :is_pe                     => true,
+              :platform_tag              => "solaris-10-i386",
+              :operatingsystemmajrelease => '10',
+              :aio_agent_version         => '1.2.5.90',
+            })
+          end
+
+          it { is_expected.not_to contain_transition("remove puppet-agent") }
+        end
       end
 
       it do

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -62,8 +62,21 @@ RSpec.describe 'puppet_agent' do
               :aio_agent_version => package_version
             })}
 
-            it { is_expected.not_to contain_class('puppet_agent::windows::install') }
             it { is_expected.not_to contain_file('c:\tmp\install_puppet.bat') }
+          end
+
+          context 'with equal package_version containing git sha' do
+            let(:facts) { facts.merge({
+              :is_pe => true,
+              :aio_agent_version => package_version
+            })}
+
+            let(:params) {
+              global_params.merge(:package_version => "#{package_version}.g886c5ab")
+            }
+
+            it { is_expected.not_to contain_file('c:\tmp\install_puppet.bat') }
+            it { is_expected.not_to contain_exec('install_puppet.bat') }
           end
 
           context 'with out of date aio_agent_version' do


### PR DESCRIPTION
Prior to this commit the module would always upgrade with dev
builds because they have a git SHA appended to the end, which
`versioncmp` considers to be greater than the version reported
by `aio_agent_version`, which lacks the extra git sha characters.
This commit updates the update check to strip the git sha when
comparing the `aio_agent_version` to the requested `packace_version`.