### PR TITLE
(MODULES-3304/PE-15256) Fix Windows 2008 upgrades

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -78,10 +78,12 @@ class puppet_agent::install(
   if $::osfamily == 'windows' {
     # Prevent re-running the batch install
     if $old_packages or $puppet_agent::aio_upgrade_required {
-      if $::puppet_agent::is_pe == true and empty($::puppet_agent::source) and defined(File["${::puppet_agent::params::local_packages_dir}/${package_file_name}"]) {
+      if $::puppet_agent::is_pe == true and empty($::puppet_agent::source) {
+        $local_package_file_path = windows_native_path("${::puppet_agent::params::local_packages_dir}/${package_file_name}")
         class { 'puppet_agent::windows::install':
           package_file_name => $package_file_name,
-          source            => windows_native_path("${::puppet_agent::params::local_packages_dir}/${package_file_name}"),
+          source            => $local_package_file_path,
+          require           => File[$local_package_file_path],
         }
       } else {
         class { 'puppet_agent::windows::install':

--- a/manifests/prepare/package.pp
+++ b/manifests/prepare/package.pp
@@ -30,7 +30,14 @@ class puppet_agent::prepare::package(
     file { $::puppet_agent::params::local_packages_dir:
       ensure => directory,
     }
-    file { "${::puppet_agent::params::local_packages_dir}/${package_file_name}":
+
+    if $::osfamily =~ /windows/ {
+      $local_package_file_path = windows_native_path("${::puppet_agent::params::local_packages_dir}/${package_file_name}")
+    } else {
+      $local_package_file_path = "${::puppet_agent::params::local_packages_dir}/${package_file_name}"
+    }
+
+    file { $local_package_file_path:
       ensure  => present,
       owner   => $::puppet_agent::params::user,
       group   => $::puppet_agent::params::group,

--- a/spec/classes/puppet_agent_osfamily_windows_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_windows_spec.rb
@@ -38,7 +38,7 @@ describe 'puppet_agent' do
       it { is_expected.to contain_file("#{appdata}\\Puppetlabs") }
       it { is_expected.to contain_file("#{appdata}\\Puppetlabs\\packages") }
       it {
-        is_expected.to contain_file("#{appdata}\\Puppetlabs\\packages/puppet-agent-#{arch}.msi").with(
+        is_expected.to contain_file("#{appdata}\\Puppetlabs\\packages\\puppet-agent-#{arch}.msi").with(
           'source' => "puppet:///pe_packages/#{pe_version}/windows-#{tag}/puppet-agent-#{arch}.msi"
         )
       }


### PR DESCRIPTION
Prior to this commit the path being used to locate the local
prepared copy of the windows MSI had a bug where one area of
the module would use a forward slash, and the other would use a
backslash. Additionally, the install class did not depend on the
prepare step's file resource that is created and instead used the
`defined` function to check for the file.
This commit updates the slashes to be consistent and adds an
explicit require on the File resource that prepares the local
copy of the MSI.