### PR TITLE
(MODULES-3433) Write Windows PID file on upgrade

### DIFF
--- a/templates/install_puppet.bat.erb
+++ b/templates/install_puppet.bat.erb
@@ -1,4 +1,13 @@
 set AGENT_PID=%1
+set windowTitle=Puppet Agent Upgrade
+title %windowTitle%
+
+set pid=
+for /f "tokens=2" %%a in ('tasklist /v ^| findstr /c:"%windowTitle%"') do set pid=%%a
+set pid_path=%TEMP%\puppet_agent_upgrade.pid
+
+if exist %pid_path% del %pid_path%
+@echo %pid%> %pid_path%
 
 :wait_for_pid
 timeout /t 5 /nobreak > NUL
@@ -7,6 +16,8 @@ echo %_task% | findstr "No tasks are running" >nul
 IF NOT %errorlevel% == 0 ( GOTO wait_for_pid )
 
 start /wait msiexec.exe /qn /norestart /i "<%= @_msi_location %>" /l*v "<%= @_logfile %>" PUPPET_MASTER_SERVER="<%= @_puppet_master %>"
+
+if exist %pid_path% del %pid_path%
 
 :End
 ENDLOCAL


### PR DESCRIPTION
 - It can be difficult to determine when an agent upgrade has actually
   completed on Windows, because a sequence of events must occur:

   * the current puppet run must complete, preventing file locking
   * the install_puppet.bat script waits 5 seconds, then infinite
     loops until a given PID is no longer running (from prior run)
   * the actual MSI must run to completion (it may encounter issues if
     for some reason any Puppet services / processes are still running)

   This can make it very difficult to implement a deterministic
   behavior around waiting until an upgrade completes in an effort to
   synchronize / orchestrate additional actions post-upgrade.  This
   is of particular importance to tests that may eagerly perform
   validations on the upgrade prior to the upgrade actually finishing.

 - Improve the process by writing a %TEMP%\puppet_agent_upgrade.pid
   file during the upgrade that is cleared after an upgrade completes.
   Other external parties may use the existence of this file as an
   indicator that an upgrade is underway.