### PR TITLE
(MODULES-3449) Stop Windows pxp-agent service

### DIFF
--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'puppet_agent' do
           it {
             is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
                              /msiexec.exe \/qn \/norestart \/i "https:\/\/alternate.com\/puppet-agent.msi"/)
-            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*vx "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
           }
           it { is_expected.to contain_exec('fix inheritable SYSTEM perms') }
         end
@@ -115,7 +115,7 @@ RSpec.describe 'puppet_agent' do
           it {
             is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
                              /msiexec.exe \/qn \/norestart \/i "C:\\tmp\\puppet-agent-x64\.msi"/)
-            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*vx "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
           }
           it { is_expected.to contain_exec('fix inheritable SYSTEM perms') }
         end
@@ -126,7 +126,7 @@ RSpec.describe 'puppet_agent' do
           it {
             is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
                              /msiexec.exe \/qn \/norestart \/i "C:\\Temp Folder\\puppet-agent-x64\.msi"/)
-            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*vx "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
           }
           it { is_expected.to contain_exec('fix inheritable SYSTEM perms') }
         end
@@ -137,7 +137,7 @@ RSpec.describe 'puppet_agent' do
           it {
             is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
                              /msiexec.exe \/qn \/norestart \/i "C:\\Temp Folder\\puppet-agent-x64\.msi"/)
-            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*vx "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
           }
           it { is_expected.to contain_exec('fix inheritable SYSTEM perms') }
         end
@@ -148,7 +148,7 @@ RSpec.describe 'puppet_agent' do
           it {
             is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
                              /msiexec.exe \/qn \/norestart \/i "\\\\garded\\c\$\\puppet-agent-x64\.msi"/)
-            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*vx "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log"/)
           }
           it { is_expected.to contain_exec('fix inheritable SYSTEM perms') }
         end
@@ -156,7 +156,7 @@ RSpec.describe 'puppet_agent' do
           it {
             is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
                              /msiexec.exe \/qn \/norestart \/i "https:\/\/downloads.puppetlabs.com\/windows\/puppet-agent-#{values[:expect_arch]}-#{package_version}\.msi"/)
-            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*v "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer\.log"/)
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*vx "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer\.log"/)
           }
           it {
             should contain_exec('install_puppet.bat').with { {

--- a/templates/install_puppet.bat.erb
+++ b/templates/install_puppet.bat.erb
@@ -15,6 +15,14 @@ FOR /F "tokens=*" %%A IN ('tasklist /FI "PID eq %AGENT_PID%" /NH') DO set _task=
 echo %_task% | findstr "No tasks are running" >nul
 IF NOT %errorlevel% == 0 ( GOTO wait_for_pid )
 
+REM This *must* occur after Puppet Agent has finished applying its
+REM prior catalog which manages the pxp-agent service state. If not,
+REM the catalog includes the PE module which starts the service and
+REM sets its startup type, which prevents installs from proceeding.
+REM This may fail on agents without pxp-agent, but since this is not
+REM run interactively and the next command sets ERRORLEVEL, it's OK.
+net stop pxp-agent
+
 start /wait msiexec.exe /qn /norestart /i "<%= @_msi_location %>" /l*v "<%= @_logfile %>" PUPPET_MASTER_SERVER="<%= @_puppet_master %>"
 
 if exist %pid_path% del %pid_path%

--- a/templates/install_puppet.bat.erb
+++ b/templates/install_puppet.bat.erb
@@ -23,7 +23,7 @@ REM This may fail on agents without pxp-agent, but since this is not
 REM run interactively and the next command sets ERRORLEVEL, it's OK.
 net stop pxp-agent
 
-start /wait msiexec.exe /qn /norestart /i "<%= @_msi_location %>" /l*v "<%= @_logfile %>" PUPPET_MASTER_SERVER="<%= @_puppet_master %>"
+start /wait msiexec.exe /qn /norestart /i "<%= @_msi_location %>" /l*vx "<%= @_logfile %>" PUPPET_MASTER_SERVER="<%= @_puppet_master %>"
 
 if exist %pid_path% del %pid_path%
 


### PR DESCRIPTION
 - Previously, upgrades could fail as a result of the pxp-agent service
   holding file locks.  While we have been previously aware of the
   potential for this isssue, given pxp-agent runs under nssm.exe on
   Windows, prior investigation had shown this to not be an issue on
   silent installations (see PA-65).

   However, in practice, while upgrading from puppet-agent 1.4.2 to
   puppet-agent 1.5.0, a running pxp-agent service is preventing
   installs from proceeding as requested with a 1603 failure. NSSM.exe
   is not affiliated with the pxp-agent service in the MSI and therefore
   the Restart Manager has no understanding that it will be later
   shutdown and unlocked.

   The solution is to simply request a `net stop pxp-agent` prior to
   running the MSI.  It's very important that this be done *after* the
   puppet run responsible for triggering the upgrade has been performed.
   If the pxp-agent service shutdown occurs before, then the puppet run
   will typically turn it back on as part of managing the node with the
   Puppet Enterprise modules.