### PR TITLE
Adds install_path for windows. Also fixes puppet service startup

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -131,6 +131,12 @@ An array of services to start, normally `puppet` and `mcollective`. If the array
 
 Alternate source from which you wish to download the latest version of Puppet.
 
+####`install_dir`
+
+The directory the puppet agent should be installed to. This is only applicable for windows operating systems.
+This only applies to an agent upgrade and will not change an already installed agent.
+
+
 ## Limitations
 
 Mac OS X Open Source packages are currently not supported.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,6 +25,9 @@
 #   None will be started if the array is empty.
 # [source]
 #   The location to find packages.
+# [install_dir]
+#   The directory the puppet agent should be installed to. This is only applicable for windows operating systems.
+#   This only applies to an agent upgrade and will not change an already installed agent.
 #
 class puppet_agent (
   $arch            = $::architecture,
@@ -34,9 +37,14 @@ class puppet_agent (
   $package_version = $::puppet_agent::params::package_version,
   $service_names   = $::puppet_agent::params::service_names,
   $source          = $::puppet_agent::params::_source,
+  $install_dir     = $::puppet_agent::params::install_dir,
 ) inherits ::puppet_agent::params {
 
   validate_re($arch, ['^x86$','^x64$','^i386$','^i86pc$','^amd64$','^x86_64$','^power$','^sun4[uv]$','PowerPC_POWER'])
+
+  if $::osfamily == 'windows' and $install_dir != undef {
+    validate_absolute_path($install_dir)
+  }
 
   if $package_version == undef and versioncmp("${::clientversion}", '4.0.0') >= 0 {
     info('puppet_agent performs no actions if a package_version is not specified on Puppet 4')
@@ -116,6 +124,7 @@ class puppet_agent (
     class { '::puppet_agent::install':
       package_file_name => $_package_file_name,
       package_version   => $_package_version,
+      install_dir       => $install_dir,
     }
 
     contain '::puppet_agent::prepare'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -13,6 +13,7 @@
 class puppet_agent::install(
   $package_file_name = undef,
   $package_version   = 'present',
+  $install_dir       = undef,
 ) {
   assert_private()
 
@@ -83,12 +84,14 @@ class puppet_agent::install(
         class { 'puppet_agent::windows::install':
           package_file_name => $package_file_name,
           source            => $local_package_file_path,
+          install_dir       => $install_dir,
           require           => File[$local_package_file_path],
         }
       } else {
         class { 'puppet_agent::windows::install':
           package_file_name => $package_file_name,
           source            => $::puppet_agent::source,
+          install_dir       => $install_dir,
         }
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,7 @@ class puppet_agent::params {
   }
 
   $package_name = 'puppet-agent'
+  $install_dir = undef
 
   case $::osfamily {
     'RedHat', 'Debian', 'Suse', 'Solaris', 'Darwin', 'AIX': {

--- a/manifests/windows/install.pp
+++ b/manifests/windows/install.pp
@@ -7,13 +7,9 @@
 class puppet_agent::windows::install(
   $package_file_name,
   $source            = $::puppet_agent::source,
-  $install_dir       = '',
+  $install_dir       = undef,
   ) {
   assert_private()
-
-  if !empty($install_dir) {
-    validate_absolute_path($install_dir)
-  }
 
   if $::puppet_agent::is_pe {
     $_agent_version = $puppet_agent::params::master_agent_version

--- a/templates/install_puppet.bat.erb
+++ b/templates/install_puppet.bat.erb
@@ -27,6 +27,5 @@ start /wait msiexec.exe /qn /norestart /i "<%= @_msi_location %>" /l*vx "<%= @_l
 
 if exist %pid_path% del %pid_path%
 
-
 :End
 ENDLOCAL

--- a/templates/install_puppet.bat.erb
+++ b/templates/install_puppet.bat.erb
@@ -23,9 +23,7 @@ REM This may fail on agents without pxp-agent, but since this is not
 REM run interactively and the next command sets ERRORLEVEL, it's OK.
 net stop pxp-agent
 
-start /wait msiexec.exe /qn /norestart /i "<%= @_msi_location %>" /l*vx "<%= @_logfile %>" PUPPET_MASTER_SERVER="<%= @_puppet_master %>" <% unless @install_dir.empty? -%>INSTALDIR="<%= @install_dir %>"<% end -%>
-
-start /wait sc start puppet
+start /wait msiexec.exe /qn /norestart /i "<%= @_msi_location %>" /l*vx "<%= @_logfile %>" PUPPET_MASTER_SERVER="<%= @_puppet_master %>" <% unless @install_dir.empty? -%>INSTALLDIR="<%= @install_dir %>"<% end -%>
 
 if exist %pid_path% del %pid_path%
 


### PR DESCRIPTION
This patch allows you to specify an installation path for the windows msi installation (We had puppet installed in a different path on our servers)

We also noticed that, after upgrading, the puppet service would not always be started by the msi so I also added an "sc start puppet" to the upgrade script to ensure the service is running after upgrading.

I tested this on live systems running windows 2008R2 and 2012R2