### PR TITLE
Explicitly setting environment to nodes current environment

### DIFF
--- a/templates/install_puppet.bat.erb
+++ b/templates/install_puppet.bat.erb
@@ -6,6 +6,9 @@ set pid=
 for /f "tokens=2" %%a in ('tasklist /v ^| findstr /c:"%windowTitle%"') do set pid=%%a
 set pid_path=%TEMP%\puppet_agent_upgrade.pid
 
+set environment=
+for /f "delims=" %%i in ('puppet config print --section agent environment') do set environment=%%i
+
 if exist %pid_path% del %pid_path%
 @echo %pid%> %pid_path%
 
@@ -23,7 +26,7 @@ REM This may fail on agents without pxp-agent, but since this is not
 REM run interactively and the next command sets ERRORLEVEL, it's OK.
 net stop pxp-agent
 
-start /wait msiexec.exe /qn /norestart /i "<%= @_msi_location %>" /l*vx "<%= @_logfile %>" PUPPET_MASTER_SERVER="<%= @_puppet_master %>"
+start /wait msiexec.exe /qn /norestart /i "<%= @_msi_location %>" /l*vx "<%= @_logfile %>" PUPPET_MASTER_SERVER="<%= @_puppet_master %>" PUPPET_AGENT_ENVIRONMENT="%environment%"
 
 if exist %pid_path% del %pid_path%
 


### PR DESCRIPTION
Per #126 the windows agent upgrade batch script does not preserve the agent configured environment. This change will persist the environment config post upgrade.

Additionally the updated gems for Lint cause 140 character check issues, and complains about puppet:// source paths where modules/ is not in the string. I have suppressed these lint checks as they cause issues with the existing untouched code base.