### PR TITLE
(PE-16317) Disable client SSL verification on Xenial

### DIFF
--- a/manifests/osfamily/debian.pp
+++ b/manifests/osfamily/debian.pp
@@ -23,12 +23,31 @@ class puppet_agent::osfamily::debian(
     # For debian based platforms, in order to add SSL verification, you need to add a
     # configuration file specific to just the sources host
     $source_host = uri_host_from_string($source)
-    $_apt_settings = [
-      "Acquire::https::${source_host}::CaInfo \"${_sslcacert_path}\";",
+    $_client_cert_verification = [
       "Acquire::https::${source_host}::SslCert \"${_sslclientcert_path}\";",
       "Acquire::https::${source_host}::SslKey \"${_sslclientkey_path}\";",
+    ]
+    $_ca_cert_verification = [
+      "Acquire::https::${source_host}::CaInfo \"${_sslcacert_path}\";",
+    ]
+    $_proxy_host = [
       "Acquire::http::proxy::${source_host} DIRECT;",
     ]
+
+    # Xenial has some sort of change that seems to have broke client cert
+    # verification in APT. While it is nice to have client cert verification,
+    # it is not strictly necessary since really all that we want to verify is
+    # that there isn't a MITM on the route to the master.
+    if ($::operatingsystem == 'Ubuntu' and $::lsbdistcodename == 'xenial') {
+      $_apt_settings = concat(
+        $_ca_cert_verification,
+        $_proxy_host)
+    } else {
+      $_apt_settings = concat(
+        $_ca_cert_verification,
+        $_client_cert_verification,
+        $_proxy_host)
+    }
 
     apt::setting { 'conf-pc_repo':
       content  => $_apt_settings.join(''),

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -54,6 +54,26 @@ describe 'puppet_agent' do
       'ensure'   => 'absent',
     }) }
 
+    context "xenial" do
+      let(:facts) {
+        facts.merge({
+          :is_pe        => true,
+          :platform_tag => 'ubuntu-1604-x86_64',
+          :operatingsystem => 'Ubuntu',
+          :lsbdistcodename => 'xenial',
+        })
+      }
+
+      apt_settings = [
+        "Acquire::https::master.example.vm::CaInfo \"/etc/puppetlabs/puppet/ssl/certs/ca.pem\";",
+        "Acquire::http::proxy::master.example.vm DIRECT;",
+      ]
+      it { is_expected.to contain_apt__setting('conf-pc_repo').with({
+        'priority' => 90,
+        'content'  => apt_settings.join(''),
+      }) }
+    end
+
     apt_settings = [
       "Acquire::https::master.example.vm::CaInfo \"/etc/puppetlabs/puppet/ssl/certs/ca.pem\";",
       "Acquire::https::master.example.vm::SslCert \"/etc/puppetlabs/puppet/ssl/certs/foo.example.vm.pem\";",


### PR DESCRIPTION
This commit disables client SSL verification on Xenial. We had to
do this in order to work around an issue where client ssl seems to
not be compatible with the SSL certs that PE uses. The root cause of
this change, and why it only occurs in Xenial, is unknown at this time.