### PR TITLE
Test if stringify_facts = true on agent

### DIFF
--- a/manifests/prepare/ssl.pp
+++ b/manifests/prepare/ssl.pp
@@ -23,23 +23,30 @@ class puppet_agent::prepare::ssl {
     'requestdir'    => 'certificate_requests',
   }
 
-  $sslpaths.each |String $setting, String $subdir| {
-    if $::puppet_sslpaths[$setting]['path_exists'] {
-      file { "${ssl_dir}/${subdir}":
-        ensure  => directory,
-        source  => $::puppet_sslpaths[$setting]['path'],
-        backup  => false,
-        recurse => true,
+  case $::puppet_sslpaths {
+    Hash: {
+      $sslpaths.each |String $setting, String $subdir| {
+        if $::puppet_sslpaths[$setting]['path_exists'] {
+          file { "${ssl_dir}/${subdir}":
+            ensure  => directory,
+            source  => $::puppet_sslpaths[$setting]['path'],
+            backup  => false,
+            recurse => true,
+          }
+        }
+      }
+
+      # The only one that's a file, not a directory.
+      if $::puppet_sslpaths['hostcrl']['path_exists'] {
+        file { "${ssl_dir}/crl.pem":
+          ensure => file,
+          source => $::puppet_sslpaths['hostcrl']['path'],
+          backup => false
+        }
       }
     }
-  }
-
-  # The only one that's a file, not a directory.
-  if $::puppet_sslpaths['hostcrl']['path_exists'] {
-    file { "${ssl_dir}/crl.pem":
-      ensure => file,
-      source => $::puppet_sslpaths['hostcrl']['path'],
-      backup => false
+    default: {
+      fail('$::puppet-sslpaths must be a Hash. Is it possible stringify_facts is not set to false in the main section of the agent puppet.conf?')
     }
   }
 }

--- a/manifests/prepare/ssl.pp
+++ b/manifests/prepare/ssl.pp
@@ -46,7 +46,7 @@ class puppet_agent::prepare::ssl {
       }
     }
     default: {
-      fail('$::puppet-sslpaths must be a Hash. Is it possible stringify_facts is not set to false in the main section of the agent puppet.conf?')
+      fail('$::puppet-sslpaths is not a Hash. Is stringify_facts not set to false in the main section of the agent puppet.conf?')
     }
   }
 }


### PR DESCRIPTION
and give a helpful error message if it is.

stringify_facts = false is a stated requirement in the documentation.

However,  if that is missed, or if the occasional agent has it unset (and therefore true) then the error message is indecipherable. To aid the unlucky troubleshooter, this PR will identify the consequence of stringify_facts being true and a particular data structure being a String instead of a Hash.