### PR TITLE
add support for non-US-English systems

### DIFF
--- a/templates/install_puppet.bat.erb
+++ b/templates/install_puppet.bat.erb
@@ -2,6 +2,9 @@ set AGENT_PID=%1
 set windowTitle=Puppet Agent Upgrade
 title %windowTitle%
 
+REM set code page to US (English) to adjust non-US English systems if required
+chcp 437
+
 set pid=
 for /f "tokens=2" %%a in ('tasklist /v ^| findstr /c:"%windowTitle%"') do set pid=%%a
 set pid_path=%TEMP%\puppet_agent_upgrade.pid


### PR DESCRIPTION
We found non-US-English systems (specifically, Japanese) kept spawning additional copies of this script.  Adding a code-page-change to 437 (US English) corrected that behavior and allowed agent upgrade to proceed.