### PR TITLE
(MODULES-3636) Upgrade on non-English Windows

### DIFF
--- a/templates/install_puppet.bat.erb
+++ b/templates/install_puppet.bat.erb
@@ -14,9 +14,8 @@ if exist %pid_path% del %pid_path%
 
 :wait_for_pid
 timeout /t 5 /nobreak > NUL
-FOR /F "tokens=*" %%A IN ('tasklist /FI "PID eq %AGENT_PID%" /NH') DO set _task=%%A
-echo %_task% | findstr "No tasks are running" >nul
-IF NOT %errorlevel% == 0 ( GOTO wait_for_pid )
+wmic path Win32_Process where handle=%AGENT_PID% get handle /format:textvaluelist | findstr /I "Handle=%AGENT_PID%"
+IF %errorlevel% == 0 ( GOTO wait_for_pid )
 
 REM This *must* occur after Puppet Agent has finished applying its
 REM prior catalog which manages the pxp-agent service state. If not,


### PR DESCRIPTION
- The previous checks for PID running uses a combination of tasklist,
   findstr and some more cryptic batch-isms to detect if a puppet
   agent is currently executing (by PID).  This check also relies on
   the English string "No tasks are running", because tasklist.exe
   doesn't set exitcodes as desired when the query is not a match.

   C:\Users\Administrator>tasklist.exe /FI "PID eq 1234" /NH
   INFO: No tasks are running which match the specified criteria.

   C:\Users\Administrator>echo %ERRORLEVEL%
   0

   There are a couple of alternative methods for achieving the
   desired functionality.  The simplest is qprocess.exe:

   C:\Users\Administrator>qprocess 1234
   No Process exists for 1234
   C:\Users\Administrator>echo %ERRORLEVEL%
   1

   C:\Users\Administrator>qprocess 32936
   USERNAME              SESSIONNAME         ID    PID  IMAGE
   >administrator         console              1  32936  mmc.exe
   C:\Users\Administrator>echo %ERRORLEVEL%
   0

   Unfortunately qprocess is no longer available on Nano Server, so
   the next best option is wmic.exe, which exists everywhere.

   C:\>wmic PATH Win32_Process where handle=1111 get handle /format:textvaluelist |
     findstr /I "Handle=1111"
   No Instance(s) Available.

   C:\>echo %ERRORLEVEL%
   1

   The string 'Handle' appears everywhere, so no locale specific
   string parsing is required on non-English versions of Windows, such
   as German:

   C:\Users\moses>tasklist /FI "PID eq 1234" /NH
   INFORMATION: Es werden keine Aufgaben mit den angegebenen Kriterien ausgeführt.

   C:\Users\moses>echo %ERRORLEVEL%
   0