### PR TITLE
(MODULES-3657) Fix waiting on Windows during upgrade

### DIFF
--- a/templates/install_puppet.bat.erb
+++ b/templates/install_puppet.bat.erb
@@ -14,9 +14,8 @@ if exist %pid_path% del %pid_path%
 
 :wait_for_pid
 timeout /t 5 /nobreak > NUL
-FOR /F "tokens=*" %%A IN ('tasklist /FI "PID eq %AGENT_PID%" /NH') DO set _task=%%A
-echo %_task% | findstr "No tasks are running" >nul
-IF NOT %errorlevel% == 0 ( GOTO wait_for_pid )
+wmic path Win32_Process where handle=%AGENT_PID% get handle /format:textvaluelist | findstr /I "Handle=%AGENT_PID%"
+IF %errorlevel% == 0 ( GOTO wait_for_pid )
 
 REM This *must* occur after Puppet Agent has finished applying its
 REM prior catalog which manages the pxp-agent service state. If not,

--- a/templates/install_puppet.bat.erb
+++ b/templates/install_puppet.bat.erb
@@ -1,10 +1,12 @@
+SET
+
 set AGENT_PID=%1
 set windowTitle=Puppet Agent Upgrade
 title %windowTitle%
 
 set pid=
 for /f "tokens=2" %%a in ('tasklist /v ^| findstr /c:"%windowTitle%"') do set pid=%%a
-set pid_path=%TEMP%\puppet_agent_upgrade.pid
+set pid_path=%~dp0puppet_agent_upgrade.pid
 
 set environment=
 for /f "delims=" %%i in ('puppet config print --section agent environment') do set environment=%%i
@@ -15,7 +17,8 @@ if exist %pid_path% del %pid_path%
 SET /A pid_checks_performed=0
 
 :wait_for_pid
-timeout /t 5 /nobreak > NUL
+REM Wait 5 seconds
+ping 127.0.0.1 -n 6 > NUL
 wmic path Win32_Process where handle=%AGENT_PID% get handle /format:textvaluelist | findstr /I "Handle=%AGENT_PID%"
 
 SET /A pid_checks_performed+=1

--- a/templates/install_puppet.bat.erb
+++ b/templates/install_puppet.bat.erb
@@ -12,9 +12,21 @@ for /f "delims=" %%i in ('puppet config print --section agent environment') do s
 if exist %pid_path% del %pid_path%
 @echo %pid%> %pid_path%
 
+SET /A pid_checks_performed=0
+
 :wait_for_pid
 timeout /t 5 /nobreak > NUL
 wmic path Win32_Process where handle=%AGENT_PID% get handle /format:textvaluelist | findstr /I "Handle=%AGENT_PID%"
+
+SET /A pid_checks_performed+=1
+REM Wait for a max of 120 seconds (or 24 iterations) before aborting the upgrade
+IF %errorlevel% == 0 IF %pid_checks_performed% == 24 (
+  REM Adding CustomSource allows EventCreate to work properly
+  reg add HKLM\SYSTEM\CurrentControlSet\services\eventlog\Application\Puppet /v CustomSource /t REG_DWORD /d 1 /f
+  EVENTCREATE /T ERROR /L APPLICATION /SO Puppet /ID 101 /D "Puppet agent upgrade failed while waiting for Puppet process [ID: %AGENT_PID%] to exit."
+  GOTO End
+)
+
 IF %errorlevel% == 0 ( GOTO wait_for_pid )
 
 REM This *must* occur after Puppet Agent has finished applying its
@@ -27,7 +39,8 @@ net stop pxp-agent
 
 start /wait msiexec.exe /qn /norestart /i "<%= @_msi_location %>" /l*vx "<%= @_logfile %>" PUPPET_MASTER_SERVER="<%= @_puppet_master %>" PUPPET_AGENT_ENVIRONMENT="%environment%" <% unless @install_dir.to_s.empty? -%>INSTALLDIR="<%= @install_dir %>"<% end -%>
 
+:End
+
 if exist %pid_path% del %pid_path%
 
-:End
 ENDLOCAL


### PR DESCRIPTION
Previously the script was using the timeout.exe application however this
attempts to redirect STDIN and during a headless operation, for example during
an actual puppet run, this throws an error and does not wait the proper time.
This commit changes the wait method to use ping.  Ping waits 1 second between
attempts therefore a simple `ping 127.0.0.1 -n 6` will pause for 5 seconds.

This commit also changes the location of the PID file slightly.  Previously it
used `%TEMP%` however this variable can be removed or be in an unexpected place.
Instead the PID file is always placed in the same directory as the
script (`%~dp0`).

To assist in debugging upgrade failures the install batch file also outputs
all environment variables prior to running.

This PR builds on #136 and #135 