### PR TITLE
(maint) Add puppet-lint workarounds for CI, use valid certnames

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -20,12 +20,13 @@ end
 PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('relative')
 PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_140chars')
 PuppetLint.configuration.send('disable_puppet_url_without_modules')
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')
 PuppetLint.configuration.send('disable_documentation')
 PuppetLint.configuration.send('disable_single_quote_string_with_variables')
 PuppetLint.configuration.send('disable_only_variable_string')
-PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp" "bundle/**/*" "vendor/**/*"]
 
 PuppetSyntax.exclude_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -23,7 +23,7 @@ TEST_FILES = File.expand_path(File.join(File.dirname(__FILE__), 'acceptance', 'f
 
 # Helper for setting the activemq host in erb templates.
 def activemq_host
-  master
+  'activemq'
 end
 
 def install_modules_on(host)
@@ -123,6 +123,9 @@ def setup_puppet_on(host, opts = {})
     scp_to host, "#{TEST_FILES}/client.crt", '/etc/mcollective/ssl-clients/client.pem'
     on host, 'mkdir -p /usr/libexec/mcollective/plugins'
 
+    # Ensure the domain used to find activemq_host resolves to an ip address.
+    # The domain is set based on the certificate used for testing.
+    on host, puppet('resource', 'host', activemq_host, "ip=#{master['ip']}")
     on host, puppet('resource', 'service', 'mcollective', 'ensure=stopped')
     on host, puppet('resource', 'service', 'mcollective', 'ensure=running')
   end


### PR DESCRIPTION
**(maint) Add puppet-lint workarounds for CI**

Our CI setup puts extra files in the project workspace, which
puppet-lint then tries to lint. This fails for older versions of Puppet.

**(maint) Fix test to use valid certnames**

Fix up SSL configuration for use with fixes in stomp 1.4.1.
Without this the activemq-stomp connection will reject the connection.