### PR TITLE
(PE-17012) Do not manage puppet symlink

### DIFF
--- a/manifests/osfamily/aix.pp
+++ b/manifests/osfamily/aix.pp
@@ -8,9 +8,4 @@ class puppet_agent::osfamily::aix(
   }
 
   contain puppet_agent::prepare::package
-
-  file { '/usr/local/bin/puppet':
-    ensure => 'link',
-    target => '/opt/puppetlabs/bin/puppet',
-  }
 }


### PR DESCRIPTION
Prior to this commit we were managing the puppet symlink, even
though that symlink is also managed by PE and most likely a
user would manage it themselves if they wanted it.
This commit removes management of the symlink, since it conflicts
with PE and is generally inconsistent with the rest of the OSes
managed by this module.