### PR TITLE
Set perms for Windows package differently than for Linux

### DIFF
--- a/manifests/prepare/package.pp
+++ b/manifests/prepare/package.pp
@@ -33,15 +33,17 @@ class puppet_agent::prepare::package(
 
     if $::osfamily =~ /windows/ {
       $local_package_file_path = windows_native_path("${::puppet_agent::params::local_packages_dir}/${package_file_name}")
+      $mode = undef
     } else {
       $local_package_file_path = "${::puppet_agent::params::local_packages_dir}/${package_file_name}"
+      $mode = '0644'
     }
 
     file { $local_package_file_path:
       ensure  => present,
       owner   => $::puppet_agent::params::user,
       group   => $::puppet_agent::params::group,
-      mode    => '0644',
+      mode    => $mode,
       source  => $source,
       require => File[$::puppet_agent::params::local_packages_dir],
     }

--- a/manifests/prepare/puppet_config.pp
+++ b/manifests/prepare/puppet_config.pp
@@ -25,7 +25,7 @@ class puppet_agent::prepare::puppet_config (
     $section = $loop_section
 
     if versioncmp("${::clientversion}", '4.0.0') < 0 {
-      $_removedSettings = [# Removed settings
+      $_removed_settings = [# Removed settings
         'allow_variables_with_dashes', 'async_storeconfigs', 'binder', 'catalog_format', 'certdnsnames',
         'certificate_expire_warning', 'couchdb_url', 'dbadapter', 'dbconnections', 'dblocation', 'dbmigrate', 'dbname',
         'dbpassword', 'dbport', 'dbserver', 'dbsocket', 'dbuser', 'dynamicfacts', 'http_compression', 'httplog',
@@ -39,18 +39,18 @@ class puppet_agent::prepare::puppet_config (
         # Settings that should be reset to defaults
         'disable_warnings', 'vardir', 'rundir', 'libdir', 'confdir', 'ssldir', 'classfile']
     } else {
-      $_removedSettings = []
+      $_removed_settings = []
     }
 
     # When upgrading to 1.4.x or later remove pluginsync
     if (($package_version == undef and $old_packages) or (versioncmp($package_version, '1.4.0') >= 0))
         and !defined(Ini_setting["${section}/pluginsync"]) {
-      $removedSettings = $_removedSettings + ['pluginsync']
+      $removed_settings = $_removed_settings + ['pluginsync']
     } else {
-      $removedSettings = $_removedSettings
+      $removed_settings = $_removed_settings
     }
 
-    $removedSettings.each |$setting| {
+    $removed_settings.each |$setting| {
       ini_setting { "${section}/${setting}":
         ensure  => absent,
         section => $section,


### PR DESCRIPTION
See issue:
https://github.com/puppetlabs/puppetlabs-puppet_agent/issues/146

All I did was set the Windows permissions on that file to be 0664 and leave everything else 0644.  I don't know if this is the correct way to patch what I was seeing or not, but I figured I'd put in the PR anyway.  I'll have more testing done in the next couple of days as I move all my agents to PE 2016.