### PR TITLE
(PE-17157) Do not attempt to unzip tarball when upgrade is unneeded

### DIFF
--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -94,7 +94,7 @@ class puppet_agent::prepare(
       contain $_osfamily_class
     }
     'solaris': {
-      if $::aio_agent_version != $package_version {
+      if $::puppet_agent::aio_upgrade_required {
         class { $_osfamily_class:
           package_file_name => $package_file_name,
         }

--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -87,11 +87,19 @@ class puppet_agent::prepare(
   # the osfamily of the client being configured.
 
   case $::osfamily {
-    'redhat', 'debian', 'windows', 'solaris', 'aix', 'suse', 'darwin': {
+    'redhat', 'debian', 'windows', 'aix', 'suse', 'darwin': {
       class { $_osfamily_class:
         package_file_name => $package_file_name,
       }
       contain $_osfamily_class
+    }
+    'solaris': {
+      if $::aio_agent_version != $package_version {
+        class { $_osfamily_class:
+          package_file_name => $package_file_name,
+        }
+        contain $_osfamily_class
+      }
     }
     default: {
       fail("puppet_agent not supported on ${::osfamily}")

--- a/spec/classes/puppet_agent_osfamily_solaris_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_solaris_spec.rb
@@ -24,6 +24,24 @@ describe 'puppet_agent' do
     end
   end
 
+  describe 'agent version is the same as the master' do
+    context 'does not attempt to upgrade' do
+      let(:facts) do
+        facts.merge({
+          :aio_agent_version => '2000.0.0',
+          :is_pe => true,
+        })
+      end
+
+      Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
+        '2000.0.0'
+      end
+      it { should compile.with_all_deps }
+      it { is_expected.to_not contain_exec('unzip puppet-agent-2000.0.0.sparc.pkg.gz') }
+
+    end
+  end
+
   describe 'unsupported environment' do
     context 'when not PE' do
       let(:facts) do

--- a/spec/classes/puppet_agent_osfamily_solaris_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_solaris_spec.rb
@@ -24,24 +24,6 @@ describe 'puppet_agent' do
     end
   end
 
-  describe 'agent version is the same as the master' do
-    context 'does not attempt to upgrade' do
-      let(:facts) do
-        facts.merge({
-          :aio_agent_version => '2000.0.0',
-          :is_pe => true,
-        })
-      end
-
-      Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
-        '2000.0.0'
-      end
-      it { should compile.with_all_deps }
-      it { is_expected.to_not contain_exec('unzip puppet-agent-2000.0.0.sparc.pkg.gz') }
-
-    end
-  end
-
   describe 'unsupported environment' do
     context 'when not PE' do
       let(:facts) do
@@ -77,6 +59,22 @@ describe 'puppet_agent' do
       pkg = Puppet::Type.type(:package)
       pkg.stubs(:defaultprovider).returns(pkg.provider(:pkg))
     end
+
+    context 'does not attempt to upgrade when master and agent version match' do
+      let(:facts) do
+        puts sol11_package_version
+        facts.merge({
+          :aio_agent_version         => sol11_package_version,
+          :is_pe                     => true,
+          :platform_tag              => "solaris-11-i386",
+          :operatingsystemmajrelease => '11',
+        })
+      end
+
+      it { should compile.with_all_deps }
+      it { is_expected.to_not contain_class("puppet_agent::osfamily::solaris") }
+    end
+
 
     context "when Solaris 11 i386" do
       let(:facts) do


### PR DESCRIPTION
Before this commit if you were on solaris with puppet aio and ran puppet
agent -t after classifying the node with the puppet agent module the
manifest would fail to apply because there was no logic which gated us
from unzipping the agent tarball if an upgrade was not needed.

This commit verifies that the version of puppet agent on the master is
the same on the agent before attempting an upgrade.
