### PR TITLE
(MODULES-4236) Disable proxy for yum repo as it will not pass through to Puppet Server and will not hand over the certs.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,7 @@ class puppet_agent (
   $service_names   = $::puppet_agent::params::service_names,
   $source          = $::puppet_agent::params::_source,
   $install_dir     = $::puppet_agent::params::install_dir,
+  $disable_proxy   = false,
 ) inherits ::puppet_agent::params {
 
   validate_re($arch, ['^x86$','^x64$','^i386$','^i86pc$','^amd64$','^x86_64$','^power$','^sun4[uv]$','PowerPC_POWER'])
@@ -64,7 +65,7 @@ class puppet_agent (
     }
 
     # Strip git sha from dev builds
-    if $package_version != undef and $package_version =~ /g/ {
+    if ($package_version != undef and $package_version =~ /g/){
       $_expected_package_version = split($package_version, /[.-]g.*/)[0]
     } else {
       $_expected_package_version = $package_version

--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -92,12 +92,17 @@ class puppet_agent::osfamily::redhat(
   }
 
   if $::puppet_agent::manage_repo {
+    $_proxy = $puppet_agent::disable_proxy ? {
+      true    => '_none_',
+      default => undef,
+    }
     yumrepo { 'pc_repo':
       baseurl       => $source,
       descr         => "Puppet Labs ${::puppet_agent::collection} Repository",
       enabled       => true,
       gpgcheck      => '1',
       gpgkey        => "${gpg_keys}",
+      proxy         => $_proxy,
       sslcacert     => $_sslcacert_path,
       sslclientcert => $_sslclientcert_path,
       sslclientkey  => $_sslclientkey_path,

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -136,6 +136,18 @@ describe 'puppet_agent' do
           'sslclientcert' => '/etc/puppetlabs/puppet/ssl/certs/foo.example.vm.pem',
           'sslclientkey' => '/etc/puppetlabs/puppet/ssl/private_keys/foo.example.vm.pem',
         }) }
+        describe 'disable proxy' do
+          let(:params) {
+            {
+              :manage_repo => true,
+              :package_version => package_version,
+              :disable_proxy   => true,
+            }
+          }
+          it {
+            is_expected.to contain_yumrepo('pc_repo').with_proxy('_none_')
+          }
+        end
       end
 
       context 'with manage_repo disabled' do


### PR DESCRIPTION
- We have system wide proxy for all repos and this is critical for us so we can use the module
