### PR TITLE
(PE-17508) Fix puppet-agent suffix on fedora

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -107,8 +107,13 @@ class puppet_agent::install(
     }
   } elsif ($::osfamily == 'RedHat') and ($package_version != 'present') {
     # Workaround PUP-5802/PUP-5025
+    if ($::operatingsystem == 'Fedora') {
+      $pkg_os_suffix = 'fedoraf'
+    } else {
+      $pkg_os_suffix = 'el'
+    }
     package { $::puppet_agent::package_name:
-      ensure => "${package_version}-1.el${::operatingsystemmajrelease}",
+      ensure => "${package_version}-1.${pkg_os_suffix}${::operatingsystemmajrelease}",
       *      => $_package_options,
     }
   } elsif ($::osfamily == 'Debian') and ($package_version != 'present') {

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -121,9 +121,14 @@ describe 'puppet_agent' do
             it { is_expected.to contain_class('puppet_agent::install').that_requires('puppet_agent::prepare') }
 
             if facts[:osfamily] == 'RedHat'
-              # Workaround PUP-5802/PUP-5025
-              yum_package_version = package_version + '-1.el' + facts[:operatingsystemmajrelease]
-              it { is_expected.to contain_package('puppet-agent').with_ensure(yum_package_version) }
+              if facts[:operatingsystem] == 'Fedora'
+                # Workaround PUP-5802/PUP-5025
+                yum_package_version = package_version + '-1.fedoraf' + facts[:operatingsystemmajrelease]
+                it { is_expected.to contain_package('puppet-agent').with_ensure(yum_package_version) }
+              else
+                yum_package_version = package_version + '-1.el' + facts[:operatingsystemmajrelease]
+                it { is_expected.to contain_package('puppet-agent').with_ensure(yum_package_version) }
+              end
             elsif facts[:osfamily] == 'Debian'
               # Workaround PUP-5802/PUP-5025
               deb_package_version = package_version + '-1' + facts[:lsbdistcodename]


### PR DESCRIPTION
This commit modifies the install logic when `osfamily` is `RedHat`
to accommodate for the `fedoraf` package suffix when the OS is
fedora rather than an `el` derivative.

Prior to this commit the `puppet-agent` package would be suffixed
with `el` which does not match the package naming convention for
fedora.