### PR TITLE
updated unless condition on Suse/Redhat GPG key imports to ensure downcasing

### DIFF
--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -66,7 +66,7 @@ class puppet_agent::osfamily::redhat(
   exec {  "import-${legacy_keyname}":
     path      => '/bin:/usr/bin:/sbin:/usr/sbin',
     command   => "rpm --import ${legacy_gpg_path}",
-    unless    => "rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < ${legacy_gpg_path}) | cut --characters=11-18 | tr [A-Z] [a-z]`",
+    unless    => "rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < ${legacy_gpg_path}) | cut --characters=11-18 | tr [:upper:] [:lower:]`",
     require   => File[$legacy_gpg_path],
     logoutput => 'on_failure',
   }
@@ -83,7 +83,7 @@ class puppet_agent::osfamily::redhat(
   exec {  "import-${keyname}":
     path      => '/bin:/usr/bin:/sbin:/usr/sbin',
     command   => "rpm --import ${gpg_path}",
-    unless    => "rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < ${gpg_path}) | cut --characters=11-18 | tr [A-Z] [a-z]`",
+    unless    => "rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < ${gpg_path}) | cut --characters=11-18 | tr [:upper:] [:lower:]`",
     require   => File[$gpg_path],
     logoutput => 'on_failure',
   }

--- a/manifests/osfamily/suse.pp
+++ b/manifests/osfamily/suse.pp
@@ -49,7 +49,7 @@ class puppet_agent::osfamily::suse(
       exec { "import-${legacy_keyname}":
         path      => '/bin:/usr/bin:/sbin:/usr/sbin',
         command   => "rpm --import ${legacy_gpg_path}",
-        unless    => "rpm -q ${legacy_gpg_pubkey} | cut --characters=11-18 | tr [A-Z] [a-z])",
+        unless    => "rpm -q ${legacy_gpg_pubkey} | cut --characters=11-18 | tr [:upper:] [:lower:])",
         require   => File[$legacy_gpg_path],
         logoutput => 'on_failure',
       }
@@ -57,7 +57,7 @@ class puppet_agent::osfamily::suse(
       exec { "import-${keyname}":
         path      => '/bin:/usr/bin:/sbin:/usr/sbin',
         command   => "rpm --import ${gpg_path}",
-        unless    => "rpm -q ${gpg_pubkey} | cut --characters=11-18 | tr [A-Z] [a-z])",
+        unless    => "rpm -q ${gpg_pubkey} | cut --characters=11-18 | tr [:upper:] [:lower:])",
         require   => File[$gpg_path],
         logoutput => 'on_failure',
       }

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -23,7 +23,7 @@ describe 'puppet_agent' do
       it { is_expected.to contain_exec('import-RPM-GPG-KEY-puppetlabs').with({
         'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
         'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
-        'unless'    => 'rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs) | cut --characters=11-18 | tr [A-Z] [a-z]`',
+        'unless'    => 'rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs) | cut --characters=11-18 | tr [:upper:] [:lower:]`',
         'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs]',
         'logoutput' => 'on_failure',
       }) }
@@ -31,7 +31,7 @@ describe 'puppet_agent' do
       it { is_expected.to contain_exec('import-RPM-GPG-KEY-puppet').with({
         'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
         'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet',
-        'unless'    => 'rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet) | cut --characters=11-18 | tr [A-Z] [a-z]`',
+        'unless'    => 'rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet) | cut --characters=11-18 | tr [:upper:] [:lower:]`',
         'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet]',
         'logoutput' => 'on_failure',
       }) }

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -146,10 +146,18 @@ describe 'puppet_agent' do
             })
           end
 
+          it { is_expected.to contain_exec('import-RPM-GPG-KEY-puppet').with({
+            'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
+            'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet',
+            'unless'    => 'rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet) | cut --characters=11-18 | tr [:upper:] [:lower:])',
+            'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet]',
+            'logoutput' => 'on_failure',
+          }) }
+
           it { is_expected.to contain_exec('import-RPM-GPG-KEY-puppetlabs').with({
             'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
             'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
-            'unless'    => 'rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs) | cut --characters=11-18 | tr [A-Z] [a-z])',
+            'unless'    => 'rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs) | cut --characters=11-18 | tr [:upper:] [:lower:])',
             'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs]',
             'logoutput' => 'on_failure',
           }) }


### PR DESCRIPTION
the current code on Suse simply converts all letters to the character 'a' and causes each run to re-import keys - so just for consistency sake, setting redhat/suse to both use the [:upper:] [:lower:] syntax

* edit - I should clarify - this doesn't happen on all systems,  but the behavior appears to occur on older versions of coreutils