### PR TITLE
(MODULES-3896) Avoid unknown variables

### DIFF
--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -37,6 +37,9 @@ class puppet_agent::osfamily::redhat(
     }
   }
   else {
+    $_sslcacert_path = undef
+    $_sslclientcert_path = undef
+    $_sslclientkey_path = undef
     $source = $::puppet_agent::source ? {
       undef   => "https://yum.puppetlabs.com/${urlbit}/${::puppet_agent::collection}/${::architecture}",
       default => $::puppet_agent::source,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,9 +71,14 @@ class puppet_agent::params {
   }
 
   # Treat Amazon Linux just like Enterprise Linux 6
+  if $_is_pe {
+    $_platform_tag = $::platform_tag
+  } else {
+    $_platform_tag = undef
+  }
   $pe_repo_dir = ($::operatingsystem == 'Amazon') ? {
     true    => "el-6-${::architecture}",
-    default =>  $::platform_tag,
+    default =>  $_platform_tag,
   }
 
   # The aio puppet-agent version currently installed on the compiling master


### PR DESCRIPTION
Puppet 4 warns about unknown variables, as in
```
Warning: Unknown variable: '::platform_tag'. at
/root/puppet/modules/puppet_agent/manifests/params.pp:75:17
Warning: Unknown variable: '_package_version'. at
/root/puppet/modules/puppet_agent/manifests/init.pp:108:8
```

Fix by avoiding unknown variables, or guarding variables we know aren't
defined. Fixes #156.