### PR TITLE
(FM-4989) Remove POWER version constraint for AIX

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,7 +105,7 @@ class puppet_agent (
       }
     } elsif $::operatingsystem == 'Darwin' and $::macosx_productversion_major =~ /10\.[9,10,11]/ {
       $_package_file_name = "${puppet_agent::package_name}-${package_version}-1.osx${$::macosx_productversion_major}.dmg"
-    } elsif $::operatingsystem == 'aix' and $::architecture =~ /PowerPC_POWER[5,6,7]/ {
+    } elsif $::operatingsystem == 'AIX' {
       $aix_ver_number = regsubst($::platform_tag,'aix-(\d+\.\d+)-power','\1')
       $_package_file_name = "${puppet_agent::package_name}-${package_version}-1.aix${aix_ver_number}.ppc.rpm"
     } elsif $::osfamily == 'windows' {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,7 +20,7 @@ class puppet_agent::install(
   $old_packages = (versioncmp("${::clientversion}", '4.0.0') < 0)
 
   if ($::operatingsystem == 'SLES' and $::operatingsystemmajrelease == '10') or
-        ($::operatingsystem == 'AIX' and  $::architecture =~ /PowerPC_POWER[5,6,7]/) {
+        $::operatingsystem == 'AIX' {
     contain puppet_agent::install::remove_packages
 
     exec { 'replace puppet.conf removed by package removal':

--- a/spec/classes/puppet_agent_osfamily_aix_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_aix_spec.rb
@@ -28,17 +28,17 @@ describe 'puppet_agent' do
     :clientcert      => 'foo.example.vm',
   }
 
-  ['7', '6', '5'].each do |aixver|
+  [['7.2', '8'], ['7.1', '7'], ['6.1', '7'], ['5.3', '7']].each do |aixver, powerver|
     context "aix #{aixver}" do
 
       let(:facts) do
         facts.merge({
-          :architecture    => "PowerPC_POWER#{aixver}",
-          :platform_tag    => "aix-#{aixver}.1-power"
+          :architecture    => "PowerPC_POWER#{powerver}",
+          :platform_tag    => "aix-#{aixver}-power"
         })
       end
 
-      rpmname = "puppet-agent-#{package_version}-1.aix#{aixver}.1.ppc.rpm"
+      rpmname = "puppet-agent-#{package_version}-1.aix#{aixver}.ppc.rpm"
 
       if Puppet.version < "4.0.0"
         it { is_expected.to contain_file('/etc/puppetlabs/puppet') }
@@ -103,22 +103,6 @@ describe 'puppet_agent' do
           end
         end
       end
-    end
-  end
-
-  ['4', '8'].each do |aixver|
-    context "aix #{aixver}" do
-      let(:facts) do
-        facts.merge({
-          :architecture    => "PowerPC_POWER#{aixver}",
-          :platform_tag    => "aix-#{aixver}.1-power"
-        })
-      end
-
-      rpmname = "puppet-agent-#{package_version}-1.aix#{aixver}.1.ppc.rpm"
-
-      it {
-        is_expected.to_not contain_file("/opt/puppetlabs/packages/#{rpmname}") }
     end
   end
 end


### PR DESCRIPTION
Prior to this commit, puppet-agent upgrades on AIX were constrained to
POWER 5-7 architectures.

However, if Puppet is already running on a supported version of AIX, it
should be safe to assume we're on a supported POWER version.

This commit removes the POWER version constraint, allowing upgrade on
POWER8 and higher architectures.