### PR TITLE
(PE-17663) update logic for solaris 11 package name

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,7 +85,8 @@ class puppet_agent (
       # Strip letters from development builds. Unique to Solaris 11 packaging.
       # Need to pass the regex as strings for Puppet 3 compatibility.
       $_version_without_letters = regsubst($package_version, '[a-zA-Z]', '', 'G')
-      $_package_version = regsubst($_version_without_letters, '(^-|-$)', '', 'G')
+      $_version_without_orphan_dashes = regsubst($_version_without_letters, '(^-|-$)', '', 'G')
+      $_package_version = regsubst($_version_without_orphan_dashes, '\b(?:0*?)([1-9]\d*|0)\b', '\1', 'G')
     } else {
       $_package_version = $package_version
     }


### PR DESCRIPTION
This commit updates the logic for cleaning a vanagon package version
name to be compatible with the IPS requirements for solaris ll p5p
package naming. It adds the same logic found in vanagon itself for
removing any leading zeros from the dotted segments of the version
string.

Prior to this commit, leading zeros in a version segment were left
in the package name which violates p5p naming rules. This caused
vanagon builds containing such a version to fail the install
process.

Ref:
[vanagon ips version code](https://github.com/puppetlabs/vanagon/blob/master/lib/vanagon/platform/solaris_11.rb#L94-L107)
[Solaris 11 package versioning](http://www.oracle.com/technetwork/articles/servers-storage-admin/ips-package-versioning-2232906.html)