### PR TITLE
(maint) correct spelling error in README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -115,7 +115,7 @@ The Puppet Collection to track. Defaults to `PC1`.
 
 #####`is_pe`
 
-Install from Puppet Enterprise rpos. Enabled if communicating with a PE master.
+Install from Puppet Enterprise repos. Enabled if communicating with a PE master.
 
 #####`manage_repo`
 


### PR DESCRIPTION
This commit corrects `rpos` to `repos`, the correct spelling, in
README.markdown.

Signed-off-by: Moses Mendoza <moses@puppet.com>