### PR TITLE
(maint) Use the forge for test fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,8 @@
 fixtures:
-  repositories:
-    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    transition: "https://github.com/puppetlabs/puppetlabs-transition.git"
-    inifile: "https://github.com/puppetlabs/puppetlabs-inifile.git"
-    apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
+  forge_modules:
+    stdlib: "puppetlabs/stdlib"
+    transition: "puppetlabs/transition"
+    inifile: "puppetlabs/inifile"
+    apt: "puppetlabs/apt"
   symlinks:
     puppet_agent: "#{source_dir}"


### PR DESCRIPTION
Previously the test fixtures used pointed to the head of git repos however there
is no certainty that the code at HEAD is working.  This commit changes the
fixtures to use the forge which uses publicly released modules.