### PR TITLE
(maint) add task for generating nodesets for testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,5 @@ end
 group :system_tests do
   gem 'beaker', '~> 2.16'
   gem 'beaker-rspec', '~> 5.1'
+  gem 'beaker-hostgenerator'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -50,3 +50,36 @@ task :test => [
   :spec,
   :metadata,
 ]
+
+desc 'Generate pooler nodesets'
+task :gen_nodeset do
+  require 'beaker-hostgenerator'
+  require 'securerandom'
+  require 'fileutils'
+
+  agent_target = ENV['TEST_TARGET']
+  if ! agent_target
+    STDERR.puts 'TEST_TARGET environment variable is not set'
+    STDERR.puts 'setting to default value of "redhat7-64default.a"'
+    agent_target = 'redhat7-64default.a'
+  end
+
+  master_target = ENV['MASTER_TEST_TARGET']
+  if ! master_target
+    STDERR.puts 'MASTER_TEST_TARGET environment variable is not set'
+    STDERR.puts 'setting to default value of "redhat7-64mdca"'
+    master_target = 'redhat7-64mcda'
+  end
+
+  targets = "#{master_target}-#{agent_target}"
+  cli = BeakerHostGenerator::CLI.new([targets])
+  nodeset_dir = "tmp/nodesets"
+  nodeset = "#{nodeset_dir}/#{targets}-#{SecureRandom.uuid}.yaml"
+  FileUtils.mkdir_p(nodeset_dir)
+  File.open(nodeset, 'w') do |fh|
+    fh.print(cli.execute)
+  end
+  puts nodeset
+  puts "\n"
+  puts "do `export BEAKER_setfile=#{nodeset}` to use this nodeset with `rake beaker`"
+end


### PR DESCRIPTION
This commit adds a rake task (copied from puppetlabs-apt) that uses
beaker-hostgenerator to generate a nodeset compatible with our vmpooler. This
enables local testing with the vmpooler, in addition to the default testing
using vagrant. Note that we still need to tell beaker to look for our nodeset
using BEAKER_setfile=<nodeset>. Credit to @DavidS for the original contribution
to puppetlabs-apt.

Signed-off-by: Moses Mendoza <moses@puppet.com>