### PR TITLE
(MODULES-3951) Add explicit check for stringify_facts

### DIFF
--- a/lib/facter/settings.rb
+++ b/lib/facter/settings.rb
@@ -12,6 +12,12 @@ Facter.add('puppet_config') do
   end
 end
 
+Facter.add('puppet_stringify_facts') do
+  setcode do
+    Puppet.settings['stringify_facts'] || false
+  end
+end
+
 Facter.add('puppet_sslpaths') do
   setcode do
     result = {}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,10 @@
 #
 class puppet_agent::params {
 
+  if $::puppet_stringify_facts {
+    fail('The puppet_agent class requires stringify_facts to be disabled')
+  }
+
   # The `is_pe` fact currently works by echoing out the puppet version
   # and greping for "puppet enterprise". With Puppet 4 and PE 2015.2, there
   # is no longer a "PE Puppet", and so that fact will no longer work.

--- a/manifests/prepare/ssl.pp
+++ b/manifests/prepare/ssl.pp
@@ -23,30 +23,23 @@ class puppet_agent::prepare::ssl {
     'requestdir'    => 'certificate_requests',
   }
 
-  case $::puppet_sslpaths {
-    Hash: {
-      $sslpaths.each |String $setting, String $subdir| {
-        if $::puppet_sslpaths[$setting]['path_exists'] {
-          file { "${ssl_dir}/${subdir}":
-            ensure  => directory,
-            source  => $::puppet_sslpaths[$setting]['path'],
-            backup  => false,
-            recurse => true,
-          }
-        }
-      }
-
-      # The only one that's a file, not a directory.
-      if $::puppet_sslpaths['hostcrl']['path_exists'] {
-        file { "${ssl_dir}/crl.pem":
-          ensure => file,
-          source => $::puppet_sslpaths['hostcrl']['path'],
-          backup => false
-        }
+  $sslpaths.each |String $setting, String $subdir| {
+    if $::puppet_sslpaths[$setting]['path_exists'] {
+      file { "${ssl_dir}/${subdir}":
+        ensure  => directory,
+        source  => $::puppet_sslpaths[$setting]['path'],
+        backup  => false,
+        recurse => true,
       }
     }
-    default: {
-      fail('$::puppet-sslpaths is not a Hash. Is stringify_facts not set to false in the main section of the agent puppet.conf?')
+  }
+
+  # The only one that's a file, not a directory.
+  if $::puppet_sslpaths['hostcrl']['path_exists'] {
+    file { "${ssl_dir}/crl.pem":
+      ensure => file,
+      source => $::puppet_sslpaths['hostcrl']['path'],
+      backup => false
     }
   }
 }

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -172,4 +172,21 @@ describe 'puppet_agent' do
       it { is_expected.to raise_error(Puppet::Error, /Nexenta not supported/) }
     end
   end
+
+  context 'stringify_facts is set to true' do
+    describe 'when puppet_stringify_facts evaluates as true ' do
+      # Mock a supported agent but with puppet_stringify_facts set to true
+      let(:facts) {{
+        :osfamily               => 'windows',
+        :operatingsystem        => '',
+        :puppet_ssldir          => '/dev/null/ssl',
+        :puppet_config          => '/dev/null/puppet.conf',
+        :architecture           => 'i386',
+        :puppet_stringify_facts => true,
+      }}
+      let(:params) { global_params }
+      
+      it { is_expected.to raise_error(Puppet::Error, /requires stringify_facts to be disabled/) }
+    end
+  end 
 end

--- a/spec/unit/facter/settings_spec.rb
+++ b/spec/unit/facter/settings_spec.rb
@@ -18,6 +18,48 @@ describe 'puppet_config fact' do
   end
 end
 
+describe "puppet_stringify_facts fact for Puppet 4.x+", :unless => /3\./ =~ Puppet.version do
+  subject { Facter.fact("puppet_stringify_facts".to_sym).value }  
+  after(:each) { Facter.clear }
+
+  describe 'should always be false' do
+    it { is_expected.to eq(false) }
+  end
+end
+
+describe "puppet_stringify_facts fact for Puppet 3.x", :if => /3\./ =~ Puppet.version do
+  subject { Facter.fact("puppet_stringify_facts".to_sym).value }  
+  after(:each) { Facter.clear }
+
+  describe 'when not set in Puppet' do
+    before(:each) {
+      mocked_settings = Puppet::Settings.new
+      Puppet.stubs(:settings).returns(mocked_settings)
+    }
+    it { is_expected.to eq(false) }
+  end
+
+  describe 'when set false in Puppet' do
+    before(:each) {
+      mocked_settings = Puppet::Settings.new
+      mocked_settings.define_settings :main, :stringify_facts => { :default => false, :type => :boolean, :desc => 'mocked stringify_facts setting' }
+      Puppet.stubs(:settings).returns(mocked_settings)
+    }
+
+    it { is_expected.to eq(false) }
+  end
+
+  describe 'when set true in Puppet' do
+    before(:each) {
+      mocked_settings = Puppet::Settings.new
+      mocked_settings.define_settings :main, :stringify_facts => { :default => true, :type => :boolean, :desc => 'mocked stringify_facts setting' }
+      Puppet.stubs(:settings).returns(mocked_settings)
+    }
+
+    it { is_expected.to eq(true) }
+  end
+end
+
 describe "puppet_sslpaths fact" do
   subject { Facter.fact("puppet_sslpaths".to_sym).value }
   after(:each) { Facter.clear }


### PR DESCRIPTION
Without this check, you get incomprehensible results. The is_pe fact is
evaluated as true, and so the class bails out. In some cases the
info() function isn't loud enough and so it appears to do nothing.

This just fails hard and makes it obvious why.