### PR TITLE
(MODULES-3953) avoid applying settings catalog in acceptance

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -166,7 +166,7 @@ def teardown_puppet_on(host)
 file { ['/etc/puppet', '/etc/puppetlabs', '/etc/mcollective']: ensure => absent, force => true, backup => false }
 package { ['puppet-agent', 'puppet', 'mcollective', 'mcollective-client']: ensure => purged }
   EOS
-  on host, puppet('apply', '-e', "\"#{pp}\"")
+  on host, puppet('apply', '-e', "\"#{pp}\"", '--no-report')
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
Prior to this commit, throughout acceptance tests whenever the
teardown_puppet_on(host) method of spec_helper_acceptance.rb was called,
several errors would result of the form:

  Error: Cannot create /etc/puppetlabs/puppet; parent directory /etc/puppetlabs
  does not exist
  Error: /File[/etc/puppetlabs/puppet]/ensure: change from absent
  to directory failed: Cannot create /etc/puppetlabs/puppet; parent directory
  /etc/puppetlabs does not exist
  Error: Cannot create /etc/puppetlabs/code;
  parent directory /etc/puppetlabs does not exist
  ...

This is because during the puppet apply, puppet was attempting to apply the
Settings catalog, in which resources are created from puppet config settings
and puppet attempts to validate them[1]. Normally this is fine, but because
we've just purged puppet itself, none of the directories specified by
Puppet::Settings exist. The settings catalog application was actually just
getting triggered by Puppet::Configurer#send_report, so by passing
`--no-report` to apply, we avoid applying the settings catalog altogether.

[1] https://github.com/puppetlabs/puppet/blob/master/docs/catalogs.md#settings-catalog