### PR TITLE
(MODULES-3912) Remove POWER8 hardware constraint from README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -169,7 +169,6 @@ In addition, there are several known issues with Windows:
  
 Specifically in the 1.2.0 Release:
 * For Windows, you must trigger an agent run after upgrading so that Puppet can create the necessary directory structures.
-* AIX package names are based on PowerPC architecture version. PowerPC 8 is not yet supported.
 
 ## Development
 

--- a/spec/classes/puppet_agent_osfamily_aix_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_aix_spec.rb
@@ -28,7 +28,7 @@ describe 'puppet_agent' do
     :clientcert      => 'foo.example.vm',
   }
 
-  [['7.2', '8'], ['7.1', '7'], ['6.1', '7'], ['5.3', '7']].each do |aixver, powerver|
+  [['7.1', '8'], ['7.1', '7'], ['6.1', '7'], ['5.3', '7']].each do |aixver, powerver|
     context "aix #{aixver}" do
 
       let(:facts) do


### PR DESCRIPTION
Starting with the 1.3.0 release of the puppet_agent module, use of the
module is no longer constrained by the PowerPC architecture version of
the target system's underlying hardware.

Here we update README.markdown to reflect this change.