### PR TITLE
(maint) Add MAINTAINERS file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "file_format": "This MAINTAINERS file format is described at http://pup.pt/maintainers",
+  "issues": "https://github.com/puppetlabs/puppetlabs-puppet_agent/issues",
+  "people": [
+    {
+      "github": "MikaelSmith",
+      "email": "michael.smith@puppet.com",
+      "name": "Michael Smith"
+    },
+    {
+      "github": "highb",
+      "email": "brandon.high@puppet.com",
+      "name": "Brandon High"
+    }
+  ]
+}


### PR DESCRIPTION
This commit adds a MAINTAINERS file to the puppetlabs-puppet_agent repo in the
format described by github.com/puppetlabs/maintainers. It is created initially
with the two individuals currently listed in the repository README. This change
is to bring this repo inline with others at Puppet following the maintainer
paradigm.

Signed-off-by: Moses Mendoza <moses@puppet.com>