### PR TITLE
(maint) Add Moses and Glenn as maintainers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -12,6 +12,11 @@
       "github": "highb",
       "email": "brandon.high@puppet.com",
       "name": "Brandon High"
+    },
+    {
+      "github": "MosesMendoza",
+      "email": "moses@puppet.com",
+      "name": "Moses Mendoza"
     }
   ]
 }

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -17,6 +17,11 @@
       "github": "MosesMendoza",
       "email": "moses@puppet.com",
       "name": "Moses Mendoza"
+    },
+    {
+      "github": "glennsarti",
+      "email": "glenn.sarti@puppet.com",
+      "name": "Glenn Sarti"
     }
   ]
 }

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "file_format": "This MAINTAINERS file format is described at http://pup.pt/maintainers",
+  "issues": "https://github.com/puppetlabs/puppetlabs-puppet_agent/issues",
+  "people": [
+    {
+      "github": "MikaelSmith",
+      "email": "michael.smith@puppet.com",
+      "name": "Michael Smith"
+    },
+    {
+      "github": "highb",
+      "email": "brandon.high@puppet.com",
+      "name": "Brandon High"
+    }
+  ]
+}

--- a/README.markdown
+++ b/README.markdown
@@ -181,6 +181,6 @@ To contribute to the puppet_agent module, see [Contributing.md](https://github.c
 
 ## Maintenance
 
-Maintainers: Michael Smith <michael.smith@puppet.com>, Brandon High <brandon.high@puppet.com>
+See [MAINTAINERS](MAINTAINERS)
 
 Tickets: https://tickets.puppetlabs.com/browse/MODULES.


### PR DESCRIPTION
This PR builds on https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/174. It adds Moses and Glenn as maintainers to puppetlabs-puppet_agent, in addition to the existing maintainers. 