### PR TITLE
(maint) Pin stdlib module to 4.12

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -120,7 +120,7 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 4.13.0"},
     {"name":"puppetlabs-transition","version_requirement":">= 0.1.0 < 0.2.0"},
     {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0 < 2.0.0"},
     {"name":"puppetlabs-apt","version_requirement":">= 2.0.1 < 3.0.0"}


### PR DESCRIPTION
The 4.13 release of the puppetlabs-stdlib module deprecates many
functions, breaking all of the tests in the puppet_agent module. Until
we can update the tests to handle the deprecations, we need to stay on
4.12.