### PR TITLE
(MODULES-3962) Pin stdlib module to 4.12

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,8 @@
 fixtures:
   forge_modules:
-    stdlib: "puppetlabs/stdlib"
+    stdlib:
+      repo: "puppetlabs/stdlib"
+      ref: "4.12.0"
     transition: "puppetlabs/transition"
     inifile: "puppetlabs/inifile"
     apt: "puppetlabs/apt"


### PR DESCRIPTION
The 4.13 release of the puppetlabs-stdlib module deprecates many
functions, breaking all of the tests in the puppet_agent module. Until
we can update the tests to handle the deprecations, we need to stay on
4.12 for testing.