### PR TITLE
(Modules-3970) Update puppet windows agent download url schema

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -118,7 +118,7 @@ class puppet_agent (
       if $is_pe {
         $_package_file_name = "${package_name}-${_arch}.msi"
       } elsif $package_version != undef {
-        $_package_file_name = "${package_name}-${_arch}-${package_version}.msi"
+        $_package_file_name = "${package_name}-${package_version}-${_arch}.msi"
       } else {
         $_package_file_name = "${package_name}-${_arch}-latest.msi"
       }

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe 'puppet_agent' do
         describe 'default source' do
           it {
             is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                             /msiexec.exe \/qn \/norestart \/i "https:\/\/downloads.puppetlabs.com\/windows\/puppet-agent-#{values[:expect_arch]}-#{package_version}\.msi"/)
+                             /msiexec.exe \/qn \/norestart \/i "https:\/\/downloads.puppetlabs.com\/windows\/puppet-agent-#{package_version}-#{values[:expect_arch]}\.msi"/)
             is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/\/l\*vx "C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer\.log"/)
           }
           it {
@@ -188,7 +188,7 @@ RSpec.describe 'puppet_agent' do
           }
           it {
             is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(
-                             /msiexec.exe \/qn \/norestart \/i "https:\/\/downloads.puppetlabs.com\/windows\/puppet-agent-x86-#{package_version}\.msi"/
+                             /msiexec.exe \/qn \/norestart \/i "https:\/\/downloads.puppetlabs.com\/windows\/puppet-agent-#{package_version}-x86.msi"/
                            )
           }
         end


### PR DESCRIPTION
Hey there,

At some point the url schema for Windows agents in the repo was updated to `https://downloads.puppetlabs.com/windows/puppet-agent-${version}-${arch}.msi`, but the module is still looking for agent packages at `https://downloads.puppetlabs.com/windows/puppet-agent-${arch}-${version}.msi`

This updates the filename to point to the correct url.

Please let me know if this needs anything else.

Thanks! ❤️ 