### PR TITLE
(maint) Update supported platforms based on available packages

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -64,13 +64,15 @@
         "12.04",
         "14.04",
         "15.04",
-        "15.10"
+        "15.10",
+        "16.04"
       ]
     },
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "22"
+        "22",
+        "23"
       ]
     },
     {


### PR DESCRIPTION
Since the last release, Ubuntu 16.04 and Fedora 23 packages have been
made available for puppet-agent. Update the metadata to reflect that
upgrades on those platforms should be supported.