### PR TITLE
(MODULES-4030) Always prepare package

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ group :test do
   gem 'json', '~> 1.8.3' # avoid trying to pull a newer version with Ruby 1.8.7
   gem 'metadata-json-lint', '~> 0.0'
   gem 'rspec-puppet-facts', '~> 1.3'
+  gem 'semantic_puppet', '0.1.3'
 end
 
 group :system_tests do

--- a/manifests/prepare/package.pp
+++ b/manifests/prepare/package.pp
@@ -12,9 +12,9 @@ class puppet_agent::prepare::package(
 ) {
   assert_private()
 
-  # Guard this so that we do not perform expensive checksum logic on the master
-  # for the large puppet-agent file if we have already upgraded.
-  if $puppet_agent::params::master_agent_version != $::aio_agent_version {
+  # As it is currently written, this will only work if the `pe_build_version()` function
+  # is available.
+  if $puppet_agent::is_pe {
     $pe_server_version = pe_build_version()
 
     if $::osfamily == 'windows' {
@@ -40,12 +40,13 @@ class puppet_agent::prepare::package(
     }
 
     file { $local_package_file_path:
-      ensure  => present,
-      owner   => $::puppet_agent::params::user,
-      group   => $::puppet_agent::params::group,
-      mode    => $mode,
-      source  => $source,
-      require => File[$::puppet_agent::params::local_packages_dir],
+      ensure   => present,
+      owner    => $::puppet_agent::params::user,
+      group    => $::puppet_agent::params::group,
+      mode     => $mode,
+      source   => $source,
+      require  => File[$::puppet_agent::params::local_packages_dir],
+      checksum => sha256lite,
     }
   }
 }


### PR DESCRIPTION
Prior to this commit we attempted to "save" the master from having to
perform checksum logic on the puppet-agent tarball by only attempting
to checksum if the master_agent_version != aio_agent version. Which
would be true if
A) The agent was pre-aio (< 3.8)
B) The agent needed to be upgraded
but not true if the agent was already up to date previous to the
puppet_agent module being installed. If it was already up to date,
this prepare step would not occur, and the module would later attempt
to install using a tarball that had not been copied over.

This commit removes the master_agent_version != aio_agent version
check and replaces it with just checking for `is_pe`, since we
depend on the `pe_build_version` function. It also specifies
the `sha256lite` checksum method should be used. This seems like a
decent compromise to both save the puppetserver work as well as
make reasoning about this module easier (if the prepare class is
included, then the agent will be prepared on disk.)