### PR TITLE
(MODULES-4092) Install solaris 10 package per-zone

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -41,9 +41,10 @@ class puppet_agent::install(
 
     $_unzipped_package_name = regsubst($package_file_name, '\.gz$', '')
     $_package_options = {
-      adminfile => '/opt/puppetlabs/packages/solaris-noask',
-      source    => "/opt/puppetlabs/packages/${_unzipped_package_name}",
-      require   => Class['puppet_agent::install::remove_packages'],
+      adminfile       => '/opt/puppetlabs/packages/solaris-noask',
+      source          => "/opt/puppetlabs/packages/${_unzipped_package_name}",
+      require         => Class['puppet_agent::install::remove_packages'],
+      install_options => '-G',
     }
   } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '11' and $old_packages {
     # Updating from PE 3.x requires removing all the old packages before installing the puppet-agent package.

--- a/spec/classes/puppet_agent_osfamily_solaris_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_solaris_spec.rb
@@ -353,6 +353,7 @@ describe 'puppet_agent' do
         is_expected.to contain_package('puppet-agent').with_adminfile('/opt/puppetlabs/packages/solaris-noask')
         is_expected.to contain_package('puppet-agent').with_ensure('present')
         is_expected.to contain_package('puppet-agent').with_source("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.i386.pkg")
+        is_expected.to contain_package('puppet-agent').with_install_options('-G')
       end
     end
 
@@ -449,6 +450,7 @@ describe 'puppet_agent' do
         is_expected.to contain_package('puppet-agent').with_adminfile('/opt/puppetlabs/packages/solaris-noask')
         is_expected.to contain_package('puppet-agent').with_ensure('present')
         is_expected.to contain_package('puppet-agent').with_source("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.sparc.pkg")
+        is_expected.to contain_package('puppet-agent').with_install_options('-G')
       end
     end
   end


### PR DESCRIPTION
Solaris 10 packaging, when combined with zones, is super weird. The
Puppet Enterprise frictionless install has historically made sure that
the agent is installed per-zone. However, the `puppet_agent` module
did not. This leads to conflicts when upgrading agents - once the
Global zone is updated, trying to upgrade the other zones will fail,
since the `puppet-agent` package is "already installed".

This changes solaris 10 packaging to be per-zone, which matches how we
have historically done that deployment.