### PR TITLE
(maint) Fix config for Jenkins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,14 @@ script: bundle exec rake test
 matrix:
   include:
     - rvm: 1.8.7
-      env: PUPPET_VERSION="~> 3.7.5"
+      env: PUPPET_GEM_VERSION="~> 3.7.5"
     - rvm: 1.8.7
-      env: PUPPET_VERSION="~> 3.8.1"
+      env: PUPPET_GEM_VERSION="~> 3.8.1"
     - rvm: 1.9.3
-      env: PUPPET_VERSION="~> 3.8.1"
+      env: PUPPET_GEM_VERSION="~> 3.8.1"
     - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 3.8.1"
-    - rvm: 2.1.6
-      env: PUPPET_VERSION="~> 4.0.0"
+      env: PUPPET_GEM_VERSION="~> 3.8.1"
+    - rvm: 2.1.9
+      env: PUPPET_GEM_VERSION="~> 4.0.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 4.8.0"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ By default the tests use a baseline version of Puppet.
 If you have Ruby 2.x or want a specific version of Puppet,
 you must set an environment variable such as:
 
-    export PUPPET_VERSION="~> 3.2.0"
+    export PUPPET_GEM_VERSION="~> 3.2.0"
 
 Install the dependencies like so...
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 group :test do
   gem 'rake', '~> 10.4'
-  gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.8'
+  gem 'puppet', ENV['PUPPET_GEM_VERSION'] || '~> 4'
   gem 'rspec', '< 3.2.0' # https://github.com/rspec/rspec-core/issues/1864
   gem 'rspec-puppet', '~> 2.2'
   gem 'puppetlabs_spec_helper', '~> 0.10'

--- a/manifests/prepare/puppet_config.pp
+++ b/manifests/prepare/puppet_config.pp
@@ -43,7 +43,7 @@ class puppet_agent::prepare::puppet_config (
     }
 
     # When upgrading to 1.4.x or later remove pluginsync
-    if (($package_version == undef and $old_packages) or (versioncmp($package_version, '1.4.0') >= 0))
+    if (($package_version == undef and $old_packages) or (versioncmp("${package_version}", '1.4.0') >= 0))
         and !defined(Ini_setting["${section}/pluginsync"]) {
       $removed_settings = $_removed_settings + ['pluginsync']
     } else {

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -118,7 +118,7 @@ describe 'puppet_agent' do
             it { is_expected.to contain_class('puppet_agent') }
             it { is_expected.to contain_class('puppet_agent::params') }
             it { is_expected.to contain_class('puppet_agent::prepare') }
-            it { is_expected.to contain_class('puppet_agent::install').that_requires('puppet_agent::prepare') }
+            it { is_expected.to contain_class('puppet_agent::install').that_requires('Class[puppet_agent::prepare]') }
 
             if facts[:osfamily] == 'RedHat'
               if facts[:operatingsystem] == 'Fedora'


### PR DESCRIPTION
Module config got out-of-sync with expectations in our Jenkins setup.
Fix it to use PUPPET_GEM_VERSION to select Puppet version for testing,
and change the default to a more recent version of Puppet.