### PR TITLE
(maint) Only use sha256lite when we are already on AIO

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development, :test do
   gem 'metadata-json-lint', '~> 0.0'
   gem 'rspec-puppet-facts', '~> 1.3'
   gem 'semantic_puppet', '0.1.3'
-  gem 'puppet-blacksmith', '>= 3.4.0',      :require => false, :platforms => 'ruby'
+  gem 'puppet-blacksmith', '>= 3.4.0', :require => false, :platforms => 'ruby' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('1.9.3')
 end
 
 group :system_tests do

--- a/manifests/prepare/package.pp
+++ b/manifests/prepare/package.pp
@@ -39,6 +39,15 @@ class puppet_agent::prepare::package(
       $mode = '0644'
     }
 
+    # When running against a puppet 3 agent, we want to use the
+    # default checksum method, due to old bugs when specifying custom
+    # checksums. For puppet 4, we can use sha256lite and avoid some
+    # extra processing time.
+    $checksum = $::aio_agent_version ? {
+      undef   => undef,
+      default => sha256lite,
+    }
+
     file { $local_package_file_path:
       ensure   => present,
       owner    => $::puppet_agent::params::user,
@@ -46,7 +55,7 @@ class puppet_agent::prepare::package(
       mode     => $mode,
       source   => $source,
       require  => File[$::puppet_agent::params::local_packages_dir],
-      checksum => sha256lite,
+      checksum => $checksum
     }
   }
 }


### PR DESCRIPTION
Puppet 3 does not handle custom file checksums correctly. We can only
use sha256lite on puppet 4.