### PR TITLE
(maint) Bump release data in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.3.1] - 2016-11-16
+## [1.3.1] - 2016-11-17
 
 ### Summary
 This is a bug-fix release


### PR DESCRIPTION
We discovered a bug at the last minute and couldn't ship on the
16th. Time to try again.

[skip-ci]