### PR TITLE
Add missing custom fact common_appdata on Windows

### DIFF
--- a/lib/facter/common_appdata.rb
+++ b/lib/facter/common_appdata.rb
@@ -1,0 +1,9 @@
+Facter.add(:common_appdata) do
+  setcode {
+    if Dir.const_defined? 'COMMON_APPDATA' then
+      Dir::COMMON_APPDATA.gsub(/\\\s/, " ").gsub(/\//, '\\')
+    elsif not ENV['ProgramData'].nil?
+      ENV['ProgramData'].gsub(/\\\s/, " ").gsub(/\//, '\\')
+    end
+  }
+end


### PR DESCRIPTION
When trying to use this module on my Windows 10 Pro (1607) node it failed with the following error:

```
Running Puppet agent on demand ...
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for foobar.example.com
Error: Failed to apply catalog: Parameter path failed on File[\Puppetlabs]: File paths must be fully qualified, not '\Puppetlabs' at /etc/puppetlabs/code/environments/testing/modules/puppet_agent/manifests/prepare.pp:42
```

The problematic code in `prepare.pp`...

```
  if !defined(File[$::puppet_agent::params::local_puppet_dir]) {
    file { $::puppet_agent::params::local_puppet_dir:
      ensure => directory,
    }
```

...depends on the variable `$common_appdata`, which is used in `params.pp`...

```
      $local_puppet_dir = windows_native_path("${::common_appdata}/Puppetlabs")
      $local_packages_dir = windows_native_path("${local_puppet_dir}/packages")
```

...but this variable isn't available on my system(s). I don't know which module _should_ provide this fact, but it's apparently not installed in my environment. Thus I suggest to add this custom fact to this module.