### PR TITLE
(FM-5839) Ensure server is set for all actions

### DIFF
--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -123,10 +123,10 @@ describe 'puppet_agent class' do
     it 'should work idempotently with no errors' do
       with_puppet_running_on(master, server_opts, master.tmpdir('puppet')) do
         # Run it twice and test for idempotency
-        on default, puppet("agent --test --server #{master}"), { :acceptable_exit_codes => [0,2] }
+        on default, puppet("agent --test"), { :acceptable_exit_codes => [0,2] }
         configure_agent_on default, true
         # We're after idempotency so allow exit code 0 only
-        on default, puppet("agent --test --server #{master}"), { :acceptable_exit_codes => [0] }
+        on default, puppet("agent --test"), { :acceptable_exit_codes => [0] }
       end
     end
 
@@ -162,10 +162,10 @@ describe 'puppet_agent class' do
     it 'should work idempotently with no errors' do
       with_puppet_running_on(master, server_opts, master.tmpdir('puppet')) do
         # Run it twice and test for idempotency
-        on default, puppet("agent --test --server #{master}"), { :acceptable_exit_codes => [0,2] }
+        on default, puppet("agent --test"), { :acceptable_exit_codes => [0,2] }
         configure_agent_on default, true
         # We're after idempotency so allow exit code 0 only
-        on default, puppet("agent --test --server #{master}"), { :acceptable_exit_codes => [0] }
+        on default, puppet("agent --test"), { :acceptable_exit_codes => [0] }
       end
     end
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -82,11 +82,11 @@ unless ENV['MODULE_provision'] == 'no'
   end
 end
 
-def parser_opts
+def parser_opts(master_fqdn)
   # Configuration only needed on 3.x master
   {
     :main => {:stringify_facts => false, :parser => 'future', :color => 'ansi'},
-    :agent => {:stringify_facts => false, :cfacter => true, :ssldir => '$vardir/ssl'},
+    :agent => {:stringify_facts => false, :cfacter => true, :ssldir => '$vardir/ssl', :server => master_fqdn},
   }
 end
 
@@ -103,7 +103,7 @@ def setup_puppet_on(host, opts = {})
   configure_defaults_on host, 'foss'
   install_puppet_on host, :version => ENV['PUPPET_CLIENT_VERSION'] || '3.8.6'
 
-  configure_puppet_on(host, parser_opts)
+  configure_puppet_on(host, parser_opts(master.to_s))
 
   if opts[:mcollective]
     install_package host, 'mcollective'


### PR DESCRIPTION
Previously some runs would communicate with the default `puppet`
address. Set configuration so that all communication uses the test
server.