### PR TITLE
(MODULES-4207) Optionally move puppetres.dll on Windows upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ spec/fixtures
 vendor
 log
 tmp
+Gemfile.local
+Gemfile.lock

--- a/README.markdown
+++ b/README.markdown
@@ -151,6 +151,13 @@ The directory the puppet agent should be installed to. This is only applicable f
   install_dir => 'D:\Program Files\Puppet Labs'
 ```
 
+##### `msi_move_locked_files`
+
+This is only applicable for Windows operating systems. There may be instances where file locks cause unncessary service restarts.  By setting to true, the module will move files prior to installation that are known to cause file locks. By default this is set to false.
+
+``` puppet
+  msi_move_locked_files => true
+```
 
 ## Limitations
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,18 +35,23 @@
 #   The directory the puppet agent should be installed to. This is only applicable for
 #   windows operating systems. This only applies when upgrading the agent to a new
 #   version; it will not cause re-installation of the same version to a new location.
+# [msi_move_locked_files]
+#   This is only applicable for Windows operating systems. There may be instances where
+#   file locks cause unncessary service restarts.  By setting to true, the module
+#   will move files prior to installation that are known to cause file locks.
 #
 class puppet_agent (
-  $arch            = $::architecture,
-  $collection      = 'PC1',
-  $is_pe           = $::puppet_agent::params::_is_pe,
-  $manage_repo     = true,
-  $package_name    = $::puppet_agent::params::package_name,
-  $package_version = $::puppet_agent::params::package_version,
-  $service_names   = $::puppet_agent::params::service_names,
-  $source          = $::puppet_agent::params::_source,
-  $install_dir     = $::puppet_agent::params::install_dir,
-  $disable_proxy   = false,
+  $arch                  = $::architecture,
+  $collection            = 'PC1',
+  $is_pe                 = $::puppet_agent::params::_is_pe,
+  $manage_repo           = true,
+  $package_name          = $::puppet_agent::params::package_name,
+  $package_version       = $::puppet_agent::params::package_version,
+  $service_names         = $::puppet_agent::params::service_names,
+  $source                = $::puppet_agent::params::_source,
+  $install_dir           = $::puppet_agent::params::install_dir,
+  $disable_proxy         = false,
+  $msi_move_locked_files = false,
 ) inherits ::puppet_agent::params {
 
   validate_re($arch, ['^x86$','^x64$','^i386$','^i86pc$','^amd64$','^x86_64$','^power$','^sun4[uv]$','PowerPC_POWER'])

--- a/manifests/windows/install.pp
+++ b/manifests/windows/install.pp
@@ -6,8 +6,9 @@
 #
 class puppet_agent::windows::install(
   $package_file_name,
-  $source            = $::puppet_agent::source,
-  $install_dir       = undef,
+  $source                = $::puppet_agent::source,
+  $install_dir           = undef,
+  $msi_move_locked_files = $::puppet_agent::msi_move_locked_files,
   ) {
   assert_private()
 

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -211,6 +211,29 @@ RSpec.describe 'puppet_agent' do
           }
         end
       end
+      context 'msi_move_locked_files =>' do
+        describe 'default' do
+          it {
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').without_content(/Move puppetres\.dll/)
+          }          
+        end
+        describe 'specify false' do
+          let(:params) { global_params.merge(
+            {:msi_move_locked_files => false,})
+          }
+          it {
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').without_content(/Move puppetres\.dll/)
+          }          
+        end
+        describe 'specify true' do
+          let(:params) { global_params.merge(
+            {:msi_move_locked_files => true,})
+          }
+          it {
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/Move puppetres\.dll/)
+          }          
+        end
+      end
     end
     context 'rubyplatform' do
       facts = {

--- a/templates/install_puppet.bat.erb
+++ b/templates/install_puppet.bat.erb
@@ -40,6 +40,34 @@ REM This may fail on agents without pxp-agent, but since this is not
 REM run interactively and the next command sets ERRORLEVEL, it's OK.
 net stop pxp-agent
 
+<% if @msi_move_locked_files %>
+REM Move puppetres.dll to avoid file locks and service restarts (MODULES-4207)
+
+REM Puppet-Agent, less than 1.6.0, location
+SET PUPPETRES=<%= @env_windows_installdir %>\misc\puppetres.dll
+SET RANDFILE=%TEMP%\puppetres-%RANDOM%-1.DLL
+IF EXIST "%PUPPETRES%" (
+  MOVE /Y "%PUPPETRES%" "%RANDFILE%"
+  DEL /Q "%RANDFILE%"
+
+  IF EXIST "%PUPPETRES%" (
+    ECHO *** WARNING - Unable to move %PUPPETRES%
+  )
+)
+
+REM Puppet-Agent, 1.6.0 and above, location
+SET "PUPPETRES=<%= @env_windows_installdir %>\puppet\bin\puppetres.dll"
+SET RANDFILE=%TEMP%\puppetres-%RANDOM%-2.DLL
+IF EXIST "%PUPPETRES%" (
+  MOVE /Y "%PUPPETRES%" "%RANDFILE%"
+  DEL /Q "%RANDFILE%"
+
+  IF EXIST "%PUPPETRES%" (
+    ECHO *** WARNING - Unable to move %PUPPETRES%
+  )
+)
+<% end %>
+
 start /wait msiexec.exe /qn /norestart /i "<%= @_msi_location %>" /l*vx "<%= @_logfile %>" PUPPET_MASTER_SERVER="<%= @_puppet_master %>" PUPPET_AGENT_ENVIRONMENT="%environment%" <% unless @install_dir.to_s.empty? -%>INSTALLDIR="<%= @install_dir %>"<% end -%>
 
 :End


### PR DESCRIPTION
During investigation into network stack restarts on Windows (https://tickets.puppetlabs.com/browse/PA-663),
it was found that a file lock on puppetres.dll was causing MSI to trigger an
unforseen service restart. This commit adds an installation option to the
puppet_agent module called `msi_move_locked_files` which premptively moves files
that can cause locks, prior to the upgrade, so that the upgrade can complete
without a service restart.

- [X] Add spec tests
- [X] ~~Add acceptance tests~~
- [X] Update README

Acceptance tests will be moved to another ticket due to complexity.