### PR TITLE
Use getvar for facts that doesn't exist in my environment

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,7 +77,7 @@ class puppet_agent (
     }
 
     $aio_upgrade_required = ($is_pe == false and $_expected_package_version != undef) or
-    (getvar('::aio_agent_version') != undef and $_expected_package_version != undef and
+      (getvar('::aio_agent_version') != undef and $_expected_package_version != undef and
         versioncmp("${::aio_agent_version}", "${_expected_package_version}") < 0)
 
     if $::architecture == 'x86' and $arch == 'x64' {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -77,7 +77,7 @@ class puppet_agent (
     }
 
     $aio_upgrade_required = ($is_pe == false and $_expected_package_version != undef) or
-      ($::aio_agent_version != undef and $_expected_package_version != undef and
+    (getvar('::aio_agent_version') != undef and $_expected_package_version != undef and
         versioncmp("${::aio_agent_version}", "${_expected_package_version}") < 0)
 
     if $::architecture == 'x86' and $arch == 'x64' {

--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -73,7 +73,7 @@ class puppet_agent::prepare(
         }
         contain puppet_agent::prepare::mco_server_config
       }
-      if getvar('::mco_server_config') {
+      if getvar('::mco_client_config') {
         class { 'puppet_agent::prepare::mco_client_config':
           before => Class[$_osfamily_class],
         }

--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -67,13 +67,13 @@ class puppet_agent::prepare(
       }
 
       # The mco_*_config facts will return the location of mcollective config (or nil), prefering PE over FOSS.
-      if $::mco_server_config {
+      if getvar('::mco_server_config') {
         class { 'puppet_agent::prepare::mco_server_config':
           before => Class[$_osfamily_class],
         }
         contain puppet_agent::prepare::mco_server_config
       }
-      if $::mco_client_config {
+      if getvar('::mco_server_config') {
         class { 'puppet_agent::prepare::mco_client_config':
           before => Class[$_osfamily_class],
         }


### PR DESCRIPTION
After fixing those 3 facts puppet module started to work with strict_variables set to true