### PR TITLE
(MODULES-4241) Add custom fact puppet_agent_appdata

### DIFF
--- a/lib/facter/puppet_agent_appdata.rb
+++ b/lib/facter/puppet_agent_appdata.rb
@@ -1,0 +1,9 @@
+Facter.add(:puppet_agent_appdata) do
+  setcode do
+    if Dir.const_defined? 'COMMON_APPDATA' then
+      Dir::COMMON_APPDATA.gsub(/\\\s/, " ").gsub(/\//, '\\')
+    elsif not ENV['ProgramData'].nil?
+      ENV['ProgramData'].gsub(/\\\s/, " ").gsub(/\//, '\\')
+    end
+  end
+end

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,7 +56,7 @@ class puppet_agent::params {
     'windows' : {
       $service_names = ['puppet', 'mcollective']
 
-      $local_puppet_dir = windows_native_path("${::common_appdata}/Puppetlabs")
+      $local_puppet_dir = windows_native_path("${::puppet_agent_appdata}/Puppetlabs")
       $local_packages_dir = windows_native_path("${local_puppet_dir}/packages")
 
       $confdir = $::puppet_confdir

--- a/spec/classes/puppet_agent_osfamily_windows_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_windows_spec.rb
@@ -25,14 +25,14 @@ describe 'puppet_agent' do
     describe "supported Windows #{arch} environment" do
       let(:appdata) { 'C:\ProgramData' }
       let(:facts) {{
-        :is_pe          => true,
-        :osfamily       => 'windows',
-        :architecture   => arch,
-        :servername     => 'master.example.vm',
-        :clientcert     => 'foo.example.vm',
-        :puppet_confdir => "#{appdata}\\Puppetlabs\\puppet\\etc",
-        :mco_confdir    => "#{appdata}\\Puppetlabs\\mcollective\\etc",
-        :common_appdata => appdata,
+        :is_pe                => true,
+        :osfamily             => 'windows',
+        :architecture         => arch,
+        :servername           => 'master.example.vm',
+        :clientcert           => 'foo.example.vm',
+        :puppet_confdir       => "#{appdata}\\Puppetlabs\\puppet\\etc",
+        :mco_confdir          => "#{appdata}\\Puppetlabs\\mcollective\\etc",
+        :puppet_agent_appdata => appdata,
       }}
 
       it { is_expected.to contain_file("#{appdata}\\Puppetlabs") }

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'puppet_agent' do
         :mco_confdir => "#{values[:appdata]}\\Puppetlabs\\mcollective\\etc",
         :puppet_agent_pid => 42,
         :system32 => 'C:\windows\sysnative',
-        :common_appdata => values[:appdata],
+        :puppet_agent_appdata => values[:appdata],
       }
 
       let(:facts) { facts }


### PR DESCRIPTION
Module params depended on `::common_appdata` being defined, which exists
in PE but not necessarily other environments. Add a new custom fact - so
names don't conflict - to cover this case.