### PR TITLE
(MODULES-4214) Add additional installation parameters during upgrade

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -151,6 +151,14 @@ The directory the puppet agent should be installed to. This is only applicable f
   install_dir => 'D:\Program Files\Puppet Labs'
 ```
 
+##### `install_options`
+
+An array of additional options to pass when installing puppet-agent. Each option in the array can either be a string or a hash. Each option will automatically be quoted when passed to the install command. With Windows packages, note that file paths in an install option must use backslashes. (Since install options are passed directly to the installation command, forward slashes won't be automatically converted like they are in `file` resources.) Note also that backslashes in double-quoted strings _must_ be escaped and backslashes in single-quoted strings _can_ be escaped.
+
+``` puppet
+  install_options => ['PUPPET_AGENT_ACCOUNT_DOMAIN=ExampleCorp','PUPPET_AGENT_ACCOUNT_USER=bob','PUPPET_AGENT_ACCOUNT_PASSWORD=password']
+```
+
 ##### `msi_move_locked_files`
 
 This is only applicable for Windows operating systems. There may be instances where file locks cause unncessary service restarts.  By setting to true, the module will move files prior to installation that are known to cause file locks. By default this is set to false.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,14 @@
 #   The directory the puppet agent should be installed to. This is only applicable for
 #   windows operating systems. This only applies when upgrading the agent to a new
 #   version; it will not cause re-installation of the same version to a new location.
+# [install_options]
+#   An array of additional options to pass when installing puppet-agent. Each option in
+#   the array can either be a string or a hash. Each option will automatically be quoted
+#   when passed to the install command. With Windows packages, note that file paths in an
+#   install option must use backslashes. (Since install options are passed directly to
+#   the installation command, forward slashes won't be automatically converted like they
+#   are in `file` resources.) Note also that backslashes in double-quoted strings _must_
+#   be escaped and backslashes in single-quoted strings _can_ be escaped.
 # [msi_move_locked_files]
 #   This is only applicable for Windows operating systems. There may be instances where
 #   file locks cause unncessary service restarts.  By setting to true, the module
@@ -51,6 +59,7 @@ class puppet_agent (
   $source                = $::puppet_agent::params::_source,
   $install_dir           = $::puppet_agent::params::install_dir,
   $disable_proxy         = false,
+  $install_options       = $::puppet_agent::params::install_options,
   $msi_move_locked_files = false,
 ) inherits ::puppet_agent::params {
 
@@ -140,6 +149,7 @@ class puppet_agent (
       package_file_name => $_package_file_name,
       package_version   => $_package_version,
       install_dir       => $install_dir,
+      install_options   => $install_options,
     }
 
     contain '::puppet_agent::prepare'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,6 +29,7 @@ class puppet_agent::params {
 
   $package_name = 'puppet-agent'
   $install_dir = undef
+  $install_options = []
 
   case $::osfamily {
     'RedHat', 'Debian', 'Suse', 'Solaris', 'Darwin', 'AIX': {

--- a/manifests/windows/install.pp
+++ b/manifests/windows/install.pp
@@ -8,6 +8,7 @@ class puppet_agent::windows::install(
   $package_file_name,
   $source                = $::puppet_agent::source,
   $install_dir           = undef,
+  $install_options       = [],
   $msi_move_locked_files = $::puppet_agent::msi_move_locked_files,
   ) {
   assert_private()

--- a/spec/classes/puppet_agent_osfamily_solaris_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_solaris_spec.rb
@@ -353,7 +353,7 @@ describe 'puppet_agent' do
         is_expected.to contain_package('puppet-agent').with_adminfile('/opt/puppetlabs/packages/solaris-noask')
         is_expected.to contain_package('puppet-agent').with_ensure('present')
         is_expected.to contain_package('puppet-agent').with_source("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.i386.pkg")
-        is_expected.to contain_package('puppet-agent').with_install_options('-G')
+        is_expected.to contain_package('puppet-agent').with_install_options( ['-G'] )
       end
     end
 
@@ -450,7 +450,7 @@ describe 'puppet_agent' do
         is_expected.to contain_package('puppet-agent').with_adminfile('/opt/puppetlabs/packages/solaris-noask')
         is_expected.to contain_package('puppet-agent').with_ensure('present')
         is_expected.to contain_package('puppet-agent').with_source("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.sparc.pkg")
-        is_expected.to contain_package('puppet-agent').with_install_options('-G')
+        is_expected.to contain_package('puppet-agent').with_install_options( ['-G'] )
       end
     end
   end

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -110,6 +110,21 @@ describe 'puppet_agent' do
         end
 
         [{}, {:service_names => []}].each do |params|
+          context "puppet_agent class with install_options" do
+            let(:params) { global_params.merge(
+              {:install_options => ['OPTION1=value1','OPTION2=value2'],})
+            }
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_class('puppet_agent::install').with_install_options(['OPTION1=value1','OPTION2=value2']) }
+
+            # Note this should fail on Windows, but it doesn't get tested due to https://github.com/mcanevet/rspec-puppet-facts/issues/42
+            # Windows is not seen as a supported OS when `on_supported_os` is used :-(
+            it { is_expected.to contain_package('puppet-agent').with_install_options(['OPTION1=value1','OPTION2=value2']) }
+          end
+        end
+
+        [{}, {:service_names => []}].each do |params|
           context "puppet_agent class without any parameters" do
             let(:params) { params.merge(global_params) }
 

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -96,6 +96,17 @@ RSpec.describe 'puppet_agent' do
         end
       end
 
+      context 'install_options =>' do
+        describe 'OPTION1=value1 OPTION2=value2' do
+          let(:params) { global_params.merge(
+            {:install_options => ['OPTION1=value1','OPTION2=value2'],})
+          }
+          it {
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/msiexec.exe .+ OPTION1=value1 OPTION2=value2/)
+          }
+        end
+      end
+
       context 'source =>' do
         describe 'https://alterernate.com/puppet-agent.msi' do
           let(:params) { global_params.merge(

--- a/templates/install_puppet.bat.erb
+++ b/templates/install_puppet.bat.erb
@@ -68,7 +68,7 @@ IF EXIST "%PUPPETRES%" (
 )
 <% end %>
 
-start /wait msiexec.exe /qn /norestart /i "<%= @_msi_location %>" /l*vx "<%= @_logfile %>" PUPPET_MASTER_SERVER="<%= @_puppet_master %>" PUPPET_AGENT_ENVIRONMENT="%environment%" <% unless @install_dir.to_s.empty? -%>INSTALLDIR="<%= @install_dir %>"<% end -%> <% unless @_agent_startup_mode.to_s.empty? -%>PUPPET_AGENT_STARTUP_MODE="<%= @_agent_startup_mode %>"<% end -%>
+start /wait msiexec.exe /qn /norestart /i "<%= @_msi_location %>" /l*vx "<%= @_logfile %>" PUPPET_MASTER_SERVER="<%= @_puppet_master %>" PUPPET_AGENT_ENVIRONMENT="%environment%" <% unless @install_dir.to_s.empty? -%>INSTALLDIR="<%= @install_dir %>"<% end -%> <% unless @_agent_startup_mode.to_s.empty? -%>PUPPET_AGENT_STARTUP_MODE="<%= @_agent_startup_mode %>"<% end -%><% unless @install_options.to_s.empty? -%><%  @install_options.each do |option| -%> <%= option%><% end -%><% end -%>
 
 :End
 


### PR DESCRIPTION
Previously it was not possible to pass additional installation parameters during
an upgrade process.  In the case of MSI files this could be sensitive passwords
or other public MSI properties.  In the case of package resources, additional
options could not be added to the package resource.

This commit adds a parameter called `install_options` which mirrors the
`install_options` parameter from the package resource and then passes this down
so that it is invoked on installation (either by a package resource or in the
batch file to install the MSI)