### PR TITLE
(MODULES-3994) Manage services on Puppet 4

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -147,7 +147,7 @@ class puppet_agent (
 
     # On windows, our MSI handles the services
     # On PE AIO nodes, PE Agent nodegroup is managing the services
-    if $::osfamily != 'windows' and (!is_pe or versioncmp($::clientversion, '4.0.0') < 0) {
+    if $::osfamily != 'windows' and (!$is_pe or versioncmp($::clientversion, '4.0.0') < 0) {
       class { '::puppet_agent::service':
         require => Class['::puppet_agent::install'],
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,7 @@ class puppet_agent::params {
   # is no longer a "PE Puppet", and so that fact will no longer work.
   # Instead check both the `is_pe` fact as well as if a PE provided
   # function is available
-  $_is_pe = ($::is_pe or is_function_available('pe_compiling_server_version'))
+  $_is_pe = (getvar('::is_pe') or is_function_available('pe_compiling_server_version'))
 
   # In Puppet Enterprise, agent packages are provided by the master
   # with a default prefix of `/packages`.

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -139,13 +139,13 @@ describe 'puppet_agent' do
               it { is_expected.to contain_package('puppet-agent').with_ensure(package_version) }
             end
 
-            if Puppet.version < "4.0.0" && !params[:is_pe]
-              it { is_expected.to contain_class('puppet_agent::service').that_requires('puppet_agent::install') }
+            if Puppet.version < "4.0.0" || (os !~ /sles/ && os !~ /solaris/)
+              it { is_expected.to contain_class('puppet_agent::service').that_requires('Class[puppet_agent::install]') }
             end
 
             if params[:service_names].nil? &&
-              !(facts[:osfamily] == 'Solaris' and facts[:operatingsystemmajrelease] == '11') &&
-              Puppet.version < "4.0.0" && !params[:is_pe]
+              !(facts[:osfamily] == 'Solaris' && facts[:operatingsystemmajrelease] == '11') &&
+              (Puppet.version < "4.0.0" || os !~ /sles/)
               it { is_expected.to contain_service('puppet') }
               it { is_expected.to contain_service('mcollective') }
             else


### PR DESCRIPTION
Previously a bug in the logic including the puppet_agent::service class
prevented it from being applied on non-PE installs using Puppet 4. Fix
it so that services are now managed for non-PE installs under Puppet 4.