### PR TITLE
(maint) remove Moses as a maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -15,11 +15,6 @@
       "name": "Brandon High"
     },
     {
-      "github": "MosesMendoza",
-      "email": "moses@puppet.com",
-      "name": "Moses Mendoza"
-    },
-    {
       "github": "glennsarti",
       "email": "glenn.sarti@puppet.com",
       "name": "Glenn Sarti"


### PR DESCRIPTION
In reality I have not been able to contribute to this project and am fully
consumed maintaining Puppet. Remove me from the list of maintainers to reflect
reality.

Signed-off-by: Moses Mendoza <moses@puppet.com>