### PR TITLE
(maint) Remove require to vendored gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,6 @@ if Puppet.version.to_f < 4.0
 end
 
 require 'puppetlabs_spec_helper/rake_tasks'
-require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppet-syntax/tasks/puppet-syntax'
 


### PR DESCRIPTION
PUP-7114 moved the semantic vendored library which broke this require.
We shouldn't be referencing the vendored libraries at all since their
API's can change without warning (as has happened in the 4.9.0 version
of puppet).

Since nothing important uses this library in the Rakefile it is safe to
remove this line.