### PR TITLE
(MODULES-4241) Fix Windows acceptance

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -226,9 +226,9 @@ def teardown_puppet_on(host)
 #{clean_repo}
 file { ['/etc/puppet', '/etc/puppetlabs', '/etc/mcollective']: ensure => absent, force => true, backup => false }
 package { ['puppet-agent', 'puppet', 'mcollective', 'mcollective-client']: ensure => purged }
-    EOS
+EOS
+    on host, puppet('apply', '-e', "\"#{pp}\"", '--no-report')
   end
-  on host, puppet('apply', '-e', "\"#{pp}\"", '--no-report')
 end
 
 RSpec.configure do |c|


### PR DESCRIPTION
The work for enabling Windows acceptance apparently missed a run of
Puppet after the uninstall. It's not clear how this was missed, but the
new logic here makes sense.