### PR TITLE
(MODULES-4478) Fix `tr` invocation for some versions of RedHat

### DIFF
--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -71,7 +71,7 @@ class puppet_agent::osfamily::redhat(
   exec {  "import-${legacy_keyname}":
     path      => '/bin:/usr/bin:/sbin:/usr/sbin',
     command   => "rpm --import ${legacy_gpg_path}",
-    unless    => "rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < ${legacy_gpg_path}) | cut --characters=11-18 | tr [:upper:] [:lower:]`",
+    unless    => "rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < ${legacy_gpg_path}) | cut --characters=11-18 | tr '[:upper:]' '[:lower:]'`",
     require   => File[$legacy_gpg_path],
     logoutput => 'on_failure',
   }
@@ -88,7 +88,7 @@ class puppet_agent::osfamily::redhat(
   exec {  "import-${keyname}":
     path      => '/bin:/usr/bin:/sbin:/usr/sbin',
     command   => "rpm --import ${gpg_path}",
-    unless    => "rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < ${gpg_path}) | cut --characters=11-18 | tr [:upper:] [:lower:]`",
+    unless    => "rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < ${gpg_path}) | cut --characters=11-18 | tr '[:upper:]' '[:lower:]'`",
     require   => File[$gpg_path],
     logoutput => 'on_failure',
   }

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -23,7 +23,7 @@ describe 'puppet_agent' do
       it { is_expected.to contain_exec('import-GPG-KEY-puppetlabs').with({
         'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
         'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
-        'unless'    => 'rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs) | cut --characters=11-18 | tr [:upper:] [:lower:]`',
+        'unless'    => "rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs) | cut --characters=11-18 | tr '[:upper:]' '[:lower:]'`",
         'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs]',
         'logoutput' => 'on_failure',
       }) }
@@ -31,7 +31,7 @@ describe 'puppet_agent' do
       it { is_expected.to contain_exec('import-GPG-KEY-puppet').with({
         'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
         'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet',
-        'unless'    => 'rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet) | cut --characters=11-18 | tr [:upper:] [:lower:]`',
+        'unless'    => "rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet) | cut --characters=11-18 | tr '[:upper:]' '[:lower:]'`",
         'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet]',
         'logoutput' => 'on_failure',
       }) }


### PR DESCRIPTION
Prevents re-running exec to install GPG keys on RedHat systems where the
`tr` failed.

Closes #214.