### PR TITLE
(MODULES-4521) Update suse GPG file location

### DIFF
--- a/manifests/osfamily/suse.pp
+++ b/manifests/osfamily/suse.pp
@@ -16,10 +16,10 @@ class puppet_agent::osfamily::suse(
     }
     '11', '12': {
       # Import the GPG key
-      $legacy_keyname  = 'RPM-GPG-KEY-puppetlabs'
-      $legacy_gpg_path = "/etc/pki/rpm-gpg/${legacy_keyname}"
-      $keyname         = 'RPM-GPG-KEY-puppet'
-      $gpg_path        = "/etc/pki/rpm-gpg/${keyname}"
+      $legacy_keyname  = 'GPG-KEY-puppetlabs'
+      $legacy_gpg_path = "/etc/pki/rpm-gpg/RPM-${legacy_keyname}"
+      $keyname         = 'GPG-KEY-puppet'
+      $gpg_path        = "/etc/pki/rpm-gpg/RPM-${keyname}"
       $gpg_homedir     = '/root/.gnupg'
 
       file { ['/etc/pki', '/etc/pki/rpm-gpg']:

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -146,7 +146,7 @@ describe 'puppet_agent' do
             })
           end
 
-          it { is_expected.to contain_exec('import-RPM-GPG-KEY-puppet').with({
+          it { is_expected.to contain_exec('import-GPG-KEY-puppet').with({
             'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
             'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet',
             'unless'    => 'rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet) | cut --characters=11-18 | tr [:upper:] [:lower:])',
@@ -154,7 +154,7 @@ describe 'puppet_agent' do
             'logoutput' => 'on_failure',
           }) }
 
-          it { is_expected.to contain_exec('import-RPM-GPG-KEY-puppetlabs').with({
+          it { is_expected.to contain_exec('import-GPG-KEY-puppetlabs').with({
             'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
             'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
             'unless'    => 'rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs) | cut --characters=11-18 | tr [:upper:] [:lower:])',
@@ -175,7 +175,7 @@ describe 'puppet_agent' do
             'owner'  => '0',
             'group'  => '0',
             'mode'   => '0644',
-            'source' => 'puppet:///modules/puppet_agent/RPM-GPG-KEY-puppetlabs',
+            'source' => 'puppet:///modules/puppet_agent/GPG-KEY-puppetlabs',
           }) }
 
           it { is_expected.to contain_file('/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet').with({
@@ -183,7 +183,7 @@ describe 'puppet_agent' do
             'owner'  => '0',
             'group'  => '0',
             'mode'   => '0644',
-            'source' => 'puppet:///modules/puppet_agent/RPM-GPG-KEY-puppet',
+            'source' => 'puppet:///modules/puppet_agent/GPG-KEY-puppet',
           }) }
 
           context "with manage_repo enabled" do


### PR DESCRIPTION
This commit updates the file location for the GPG keys used on
the SLES. The key files have moved from `RPM-GPG-KEY-puppetlabs`
to `GPG-KEY-puppetlabs` previously. This commit simply brings this
location current for the SLES platform so that the keys can be
properly found.