### PR TITLE
(MODULES-4547) setting the package provider to sun for Solaris 10 hosts in case the …

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -43,6 +43,7 @@ class puppet_agent::install(
 
     $_unzipped_package_name = regsubst($package_file_name, '\.gz$', '')
     $_package_options = {
+      provider        => 'sun',
       adminfile       => '/opt/puppetlabs/packages/solaris-noask',
       source          => "/opt/puppetlabs/packages/${_unzipped_package_name}",
       require         => Class['puppet_agent::install::remove_packages'],


### PR DESCRIPTION
…default was changed


setting the package provider to sun for Solaris 10 hosts in case the default was changed.
our site default for the package provider on Solaris 10 hosts is 'pkgutil' and that causes this module to not work. since the sun provider works correctly for the puppet-agent package, i forced the package resource to set the provider to 'sun' even though it's the default for most sites.