### PR TITLE
Don't include apt

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -47,6 +47,8 @@ Your agents must be running Puppet 3 with `stringify_facts` set to 'false', or P
 
 Puppet 3.7 with future parser is required to compile this module, meaning it may be applied to masterless Puppet 3.7+, or earlier Puppet 3 agents connecting to a Puppet 3.7+ master.
 
+If you want debian repositories managed you must `include ::apt`.
+
 ### Beginning with puppet_agent
 
 Install the puppet_agent module with `puppet module install puppetlabs-puppet_agent`.

--- a/manifests/osfamily/debian.pp
+++ b/manifests/osfamily/debian.pp
@@ -5,8 +5,6 @@ class puppet_agent::osfamily::debian(
 
   if getvar('::puppet_agent::manage_repo') == true {
 
-    include ::apt
-
     if getvar('::puppet_agent::is_pe') == true {
       $pe_server_version = pe_build_version()
       $source = "${::puppet_agent::source}/${pe_server_version}/${::platform_tag}"


### PR DESCRIPTION
Using ```include ::apt``` breaks anyone specifying ```Class { 'apt':```