### PR TITLE
(MODULES-4732) Bump transition dependency to 0.1.1

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -123,7 +123,7 @@
   ],
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
-    {"name":"puppetlabs-transition","version_requirement":">= 0.1.0 < 0.2.0"},
+    {"name":"puppetlabs-transition","version_requirement":">= 0.1.1 < 0.2.0"},
     {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0 < 2.0.0"},
     {"name":"puppetlabs-apt","version_requirement":">= 2.0.1 < 3.0.0"}
   ]


### PR DESCRIPTION
This increases the minimum version requirement for the
puppetlabs-transition module from 0.1.0 to 0.1.1.

There was a very important bug fix in 0.1.1 that allows puppet-agent
to be upgraded on AIX servers. Prior versions were unable to
automatically update puppet-agent due to inconsistent state caching.

See: https://github.com/puppetlabs/puppetlabs-transition/pull/8