### PR TITLE
(maint) Pin fixtures to puppetlabs-apt 2.3.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,8 @@ fixtures:
       ref: "4.12.0"
     transition: "puppetlabs/transition"
     inifile: "puppetlabs/inifile"
-    apt: "puppetlabs/apt"
+    apt:
+      repo: "puppetlabs/apt"
+      ref: "2.3.0"
   symlinks:
     puppet_agent: "#{source_dir}"


### PR DESCRIPTION
puppetlabs-stdlib 4.13.0 introduced deprecation warnings about using
`validate_re`. The suggested replacement - `validate_legacy` is only
supported in Puppet 4.4+. This makes it a challenge to write and test a
module that needs to work with Puppet 4+. For now pin puppetlabs-apt to
use 2.3, to avoid requiring a newer version of stdlib as required in
puppetlabs-apt 2.4+.