### PR TITLE
(MODULES-4869) Pin apt module in spec fixtures

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,8 @@ fixtures:
       ref: "4.12.0"
     transition: "puppetlabs/transition"
     inifile: "puppetlabs/inifile"
-    apt: "puppetlabs/apt"
+    apt:
+      repo: "puppetlabs/apt"
+      ref: "2.4.0"
   symlinks:
     puppet_agent: "#{source_dir}"


### PR DESCRIPTION
Previously the test fixtures used the latest version of the apt puppet module
when running spec tests.  However as the apt module has no been updated with a
new major version (4.0) the puppet_agent metadata dependencies do not list that
version as compatible and therefore will not puppet_agent module citing
unresolved dependencies.  This commit adds a version pin to the apt module of
2.4, which was the last release in the 2.x series.  It is expected that once
the requirement for an older apt has elapsed, this version pin can be removed.