### PR TITLE
(maint) Make apt/transition soft dependencies

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -47,6 +47,8 @@ Your agents must be running Puppet 3 with `stringify_facts` set to 'false', or P
 
 Puppet 3.7 with future parser is required to compile this module, meaning it may be applied to masterless Puppet 3.7+, or earlier Puppet 3 agents connecting to a Puppet 3.7+ master.
 
+This module uses puppetlabs-stdlib and puppetlabs-inifile. It has soft dependencies on puppetlabs-apt (for Debian-based systems) and puppetlabs-transition (for Solaris).
+
 ### Beginning with puppet_agent
 
 Install the puppet_agent module with `puppet module install puppetlabs-puppet_agent`.

--- a/metadata.json
+++ b/metadata.json
@@ -127,8 +127,6 @@
   ],
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
-    {"name":"puppetlabs-transition","version_requirement":">= 0.1.1 < 0.2.0"},
-    {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0 < 3.0.0"},
-    {"name":"puppetlabs-apt","version_requirement":">= 2.0.1 < 3.0.0"}
+    {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0 < 3.0.0"}
   ]
 }


### PR DESCRIPTION
puppetlabs-apt is only used on Debian-based systems, and
puppetlabs-transition is only used on Solaris. Fixes #230.