### PR TITLE
(PA-1160) Add support for AIX 7.2

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,7 +122,11 @@ class puppet_agent (
     } elsif $::operatingsystem == 'Darwin' and $::macosx_productversion_major =~ /10\.[9,10,11]/ {
       $_package_file_name = "${puppet_agent::package_name}-${package_version}-1.osx${$::macosx_productversion_major}.dmg"
     } elsif $::operatingsystem == 'AIX' {
-      $aix_ver_number = regsubst($::platform_tag,'aix-(\d+\.\d+)-power','\1')
+      $_aix_ver_number = regsubst($::platform_tag,'aix-(\d+\.\d+)-power','\1')
+      $aix_ver_number = $_aix_ver_number ? {
+        /^7\.2$/ => '7.1',
+        default  => $_aix_ver_number,
+      }
       $_package_file_name = "${puppet_agent::package_name}-${package_version}-1.aix${aix_ver_number}.ppc.rpm"
     } elsif $::osfamily == 'windows' {
       $_arch = $::kernelmajversion ?{

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -33,10 +33,14 @@ class puppet_agent::install(
       logoutput => 'on_failure',
     }
 
+    $_install_options = $::operatingsystem ? {
+      'AIX'   => concat(['--ignoreos'],$install_options),
+      default => $install_options
+    }
     $_package_options = {
       provider        => 'rpm',
       source          => "/opt/puppetlabs/packages/${package_file_name}",
-      install_options => $install_options,
+      install_options => $_install_options,
     }
   } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '10' {
     contain puppet_agent::install::remove_packages

--- a/manifests/prepare/package.pp
+++ b/manifests/prepare/package.pp
@@ -23,6 +23,12 @@ class puppet_agent::prepare::package(
         'x86' => 'windows-i386',
       }
       $source = "puppet:///pe_packages/${pe_server_version}/${tag}/${package_file_name}"
+    } elsif $::operatingsystem == 'AIX' {
+      $tag = $::platform_tag ? {
+        'aix-7.2-power' => 'aix-7.1-power',
+        default         => $::platform_tag,
+      }
+      $source = "puppet:///pe_packages/${pe_server_version}/${tag}/${package_file_name}"
     } else {
       $source = "puppet:///pe_packages/${pe_server_version}/${::platform_tag}/${package_file_name}"
     }

--- a/spec/classes/puppet_agent_osfamily_aix_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_aix_spec.rb
@@ -28,7 +28,7 @@ describe 'puppet_agent' do
     :clientcert      => 'foo.example.vm',
   }
 
-  [['7.1', '8'], ['7.1', '7'], ['6.1', '7'], ['5.3', '7']].each do |aixver, powerver|
+  [['7.2', '7.1', '8'], ['7.1', '7.1', '8'], ['7.1', '7.1', '7'], ['6.1', '6.1', '7'], ['5.3', '5.3', '7']].each do |aixver, pkgver, powerver|
     context "aix #{aixver}" do
 
       let(:facts) do
@@ -38,7 +38,9 @@ describe 'puppet_agent' do
         })
       end
 
-      rpmname = "puppet-agent-#{package_version}-1.aix#{aixver}.ppc.rpm"
+      rpmname = "puppet-agent-#{package_version}-1.aix#{pkgver}.ppc.rpm"
+      tag = "aix-#{pkgver}-power"
+      source = "puppet:///pe_packages/4.0.0/#{tag}/#{rpmname}"
 
       if Puppet.version < "4.0.0"
         it { is_expected.to contain_file('/etc/puppetlabs/puppet') }
@@ -52,7 +54,10 @@ describe 'puppet_agent' do
 
       it { is_expected.to contain_file('/opt/puppetlabs') }
       it { is_expected.to contain_file('/opt/puppetlabs/packages') }
-      it { is_expected.to contain_file("/opt/puppetlabs/packages/#{rpmname}")}
+      it { is_expected.to contain_file("/opt/puppetlabs/packages/#{rpmname}").with({
+          'source' => source
+          })
+      }
 
       it { is_expected.to contain_class("puppet_agent::osfamily::aix") }
 


### PR DESCRIPTION
We did not add new packages for AIX 7.2. Instead, we use the AIX
7.1 packages. This adds the necessary logic to point AIX 7.2 at
the older packages.