### PR TITLE
puppet_stringify_facts fixes for Puppet 4

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,8 +4,7 @@
 # It sets variables according to platform.
 #
 class puppet_agent::params {
-
-  if $::puppet_stringify_facts {
+  if (versioncmp("${::clientversion}", '4.0.0') < 0 and $::puppet_stringify_facts == true) {
     fail('The puppet_agent class requires stringify_facts to be disabled')
   }
 

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -192,16 +192,18 @@ describe 'puppet_agent' do
     describe 'when puppet_stringify_facts evaluates as true ' do
       # Mock a supported agent but with puppet_stringify_facts set to true
       let(:facts) {{
-        :osfamily               => 'windows',
-        :operatingsystem        => '',
+        :osfamily               => 'RedHat',
+        :operatingsystem        => 'Fedora',
         :puppet_ssldir          => '/dev/null/ssl',
         :puppet_config          => '/dev/null/puppet.conf',
         :architecture           => 'i386',
         :puppet_stringify_facts => true,
       }}
       let(:params) { global_params }
-      
-      it { is_expected.to raise_error(Puppet::Error, /requires stringify_facts to be disabled/) }
+
+      if Puppet.version < '4.0.0'
+        it { is_expected.to raise_error(Puppet::Error, /requires stringify_facts to be disabled/) }
+      end
     end
-  end 
+  end
 end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -4,7 +4,6 @@ include RspecPuppetFacts
 
 RSpec.configure do |c|
   c.default_facts = {
-    :puppet_stringify_facts      => false,
     :aio_agent_version           => nil,
     :puppetversion               => nil,
     :lsbdistrelease              => nil,


### PR DESCRIPTION
Remove default value for Fact ::puppet_stringify_facts and allow Puppet version being tested to provide it (thus simulating it's non-existence in Puppet 4).

Fixing the logic around testing for $::puppet_stringify_facts in Puppet 4.