### PR TITLE
(maint) Include spec_helper so parallel specs succeed

### DIFF
--- a/spec/classes/coverage_spec.rb
+++ b/spec/classes/coverage_spec.rb
@@ -1,1 +1,3 @@
+require 'spec_helper'
+
 at_exit { RSpec::Puppet::Coverage.report! }


### PR DESCRIPTION
All spec files need to include spec_helper, or parallel specs runs will
fail.