### PR TITLE
(maint) Use http for RedHat repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This is a bug-fix release
 ### Bug fixes
 - The system package provider is explicitly selected on Solaris 10 for installing puppet-agent ([MODULES-4547](https://tickets.puppetlabs.com/browse/MODULES-4547))
 - `puppet lookup` and other operations with `strict_variables` enabled will now work with this module ([MODULES-5168](https://tickets.puppetlabs.com/browse/MODULES-5168))
+- Use HTTP instead of HTTPS for RedHat repositories. This is consistent with Puppet's repo packages, and continues to use GPG signing for security.
 
 ## [1.4.0] - 2017-06-12
 

--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -43,7 +43,7 @@ class puppet_agent::osfamily::redhat(
     $_sslclientcert_path = undef
     $_sslclientkey_path = undef
     $source = getvar('::puppet_agent::source') ? {
-      undef   => "https://yum.puppetlabs.com/${urlbit}/${pa_collection}/${::architecture}",
+      undef   => "http://yum.puppetlabs.com/${urlbit}/${pa_collection}/${::architecture}",
       default => getvar('::puppet_agent::source'),
     }
   }

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -67,7 +67,7 @@ describe 'puppet_agent' do
         }
         it { is_expected.not_to contain_yumrepo('puppetlabs-pepackages').with_ensure('absent') }
         it { is_expected.to contain_yumrepo('pc_repo').with({
-          'baseurl' => "https://yum.puppetlabs.com/#{urlbit}/PC1/x64",
+          'baseurl' => "http://yum.puppetlabs.com/#{urlbit}/PC1/x64",
           'enabled' => 'true',
             'gpgcheck' => '1',
             'gpgkey' => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs\n  file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet",


### PR DESCRIPTION
RedHat 5 uses an old OpenSSL version that can't connect to
www.puppetlabs.com using HTTPS. Use HTTP - which is what the repos setup
by Puppet's repo packages use - instead. That should still be secure
since we use signed packages and the GPG keys are included with this
module.