### PR TITLE
(maint) Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: ruby
+dist: precise
 sudo: false
 bundler_args: --without system_tests --full-index
 before_script: cat Gemfile.lock
@@ -16,8 +17,10 @@ matrix:
 #    - rvm: 1.9.3
 #      env: PUPPET_GEM_VERSION="~> 3.8.1"  FUTURE_PARSER="yes"
     - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.8.1"  FUTURE_PARSER="yes"
+      env: PUPPET_GEM_VERSION="~> 3.8"  FUTURE_PARSER="yes"
     - rvm: 2.1.9
       env: PUPPET_GEM_VERSION="~> 4.0.0"
-    - rvm: 2.3.1
-      env: PUPPET_GEM_VERSION="~> 4.8.0"
+    - rvm: 2.3.4
+      env: PUPPET_GEM_VERSION="~> 4.10"
+    - rvm: 2.3.4
+      env: PUPPET_GEM_VERSION="~> 5.0.1"

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "file_format": "This MAINTAINERS file format is described at http://pup.pt/maintainers",
-  "issues": "https://github.com/puppetlabs/puppetlabs-puppet_agent/issues",
+  "issues": "http://tickets.puppetlabs.com/browse/MODULES",
   "internal_list": "https://groups.google.com/a/puppet.com/forum/?hl=en#!forum/discuss-puppetlabs-puppet_agent-maintainers",
   "people": [
     {

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-puppet_agent",
   "project_page": "https://github.com/puppetlabs/puppetlabs-puppet_agent",
-  "issues_url": "http://tickets.puppetlabs.com/browse/PUP",
+  "issues_url": "http://tickets.puppetlabs.com/browse/MODULES",
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",


### PR DESCRIPTION
Travis CI switched from Precise to Trusty, but don't have Ruby 2.1
builds for Trusty. Pin to Precise so tests against Ruby 2.1 continue to
work.