### PR TITLE
(maint) Add pid file to Solaris upgrade

### DIFF
--- a/templates/solaris_install.sh.epp
+++ b/templates/solaris_install.sh.epp
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Mark install process starting
+pid_path="$(dirname ${BASH_SOURCE[0]})/puppet_agent_upgrade.pid"
+
+if [[ -f $pid_path ]]; then
+  rm -f $pid_path
+fi
+echo $$ > $pid_path
+
 # Wait for Puppet to exit
 puppet_pid=$1
 while $(kill -0 ${puppet_pid:?}); do
@@ -27,3 +35,8 @@ pkgadd -a <%= $adminfile %> -d <%= $sourcefile %> -G <%= $install_options.join('
 # Ensure services are running
 start_service puppet
 start_service mcollective
+
+# Mark upgrade complete
+if [[ -f $pid_path ]]; then
+  rm -f $pid_path
+fi


### PR DESCRIPTION
This makes it easier to test when the upgrade is still in-progress, and
mirrors how the Windows upgrade is handled. It's either this or we grep
ps for running upgrades. Currently used in upgrade acceptance tests.

This pattern - laying down a file in /tmp/puppet_agent_upgrade.pid -
should be followed for any scripts used to perform async upgrades to
maintain testability with our current test suite.