### PR TITLE
(MODULES-5633) Add support for Puppet 5 on Redhat osfamily

### DIFF
--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -3,8 +3,14 @@ class puppet_agent::osfamily::redhat(
 ) {
   assert_private()
 
+  $pa_collection = getvar('::puppet_agent::collection')
+
   if $::operatingsystem == 'Fedora' {
-    $urlbit = 'fedora/f$releasever'
+    if $pa_collection == 'PC1' {
+      $urlbit = 'fedora/f$releasever'
+    } else {
+      $urlbit = 'fedora/$releasever'
+    }
   }
   elsif $::operatingsystem == 'Amazon' {
     $urlbit = 'el/6'
@@ -12,8 +18,6 @@ class puppet_agent::osfamily::redhat(
   else {
     $urlbit = 'el/$releasever'
   }
-
-  $pa_collection = getvar('::puppet_agent::collection')
 
   if getvar('::puppet_agent::is_pe') == true {
     # In Puppet Enterprise, agent packages are served by the same server
@@ -42,8 +46,14 @@ class puppet_agent::osfamily::redhat(
     $_sslcacert_path = undef
     $_sslclientcert_path = undef
     $_sslclientkey_path = undef
+
+    if $pa_collection == 'PC1' {
+      $_default_source = "http://yum.puppetlabs.com/${urlbit}/${pa_collection}/${::architecture}"
+    } else {
+      $_default_source = "http://yum.puppetlabs.com/${pa_collection}/${urlbit}/${::architecture}"
+    }
     $source = getvar('::puppet_agent::source') ? {
-      undef   => "http://yum.puppetlabs.com/${urlbit}/${pa_collection}/${::architecture}",
+      undef   => $_default_source,
       default => getvar('::puppet_agent::source'),
     }
   }

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -89,6 +89,21 @@ describe 'puppet_agent' do
         it { is_expected.to contain_class("puppet_agent::osfamily::redhat") }
       end
 
+      context 'when installing a puppet5 project' do
+        let(:params)  {
+          {
+            :package_version => '5.2.0',
+            :collection => 'puppet5'
+          }
+        }
+        it { is_expected.to contain_yumrepo('pc_repo').with({
+          # We no longer expect the 'f' in fedora repos
+          'baseurl' => "http://yum.puppetlabs.com/puppet5/#{urlbit.gsub('/f','/')}/x64",
+          'enabled' => 'true',
+            'gpgcheck' => '1',
+            'gpgkey' => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs\n  file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet",
+        }) }
+      end
     end
   end
 


### PR DESCRIPTION
We made a couple of changes to how Yum repo paths are constructed
in puppet 5:

1) We now put the repo name (puppet5) before the OS name/version
2) We no longer put an extra 'f' in fedora repos

This updates the module to only use the old repo path
construction if the collection is 'PC1'. Otherwise, we use
the newer construction (under the assumption that we won't change
again for puppet 6)