### PR TITLE
fix dist tag on Amazon Linux (avoids issue when ensuring package version)

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -157,12 +157,14 @@ class puppet_agent::install(
   } elsif ($::osfamily == 'RedHat') and ($package_version != 'present') {
     # Workaround PUP-5802/PUP-5025
     if ($::operatingsystem == 'Fedora') {
-      $pkg_os_suffix = 'fedoraf'
+      $dist_tag = "fedoraf${::operatingsystemmajrelease}"
+    } elsif $::operatingsystem == 'Amazon' {
+      $dist_tag = 'el6'
     } else {
-      $pkg_os_suffix = 'el'
+      $dist_tag = "el${::operatingsystemmajrelease}"
     }
     package { $::puppet_agent::package_name:
-      ensure          => "${package_version}-1.${pkg_os_suffix}${::operatingsystemmajrelease}",
+      ensure          => "${package_version}-1.${dist_tag}",
       install_options => $install_options,
     }
   } elsif ($::osfamily == 'Debian') and ($package_version != 'present') {

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -178,6 +178,17 @@ describe 'puppet_agent' do
         it { is_expected.not_to contain_yumrepo('pc_repo')}
       end
 
+      context 'with explicit package version' do
+        let(:params)  {
+          {
+            :manage_repo => false,
+            :package_version => package_version
+          }
+        }
+        it { is_expected.to contain_package('puppet-agent').with_ensure("1.2.5-1.el#{osmajor}") }
+
+      end
+
       it { is_expected.to contain_class("puppet_agent::osfamily::redhat") }
     end
   end


### PR DESCRIPTION
While the EL6 packages work for Amazon Linux (https://github.com/puppetlabs/puppetlabs-puppet_agent/blob/master/manifests/osfamily/redhat.pp#L15-L16), I get this error when ensuring a package version.

This PR fixes that.

```
Error: Could not update: Failed to update to version 5.1.0-1.el2017, got version 5.1.0-1.el6 instead
Error: /Stage[main]/Puppet_agent::Install/Package[puppet-agent]/ensure: change from '5.1.0-1.el6' to '5.1.0-1.el2017' failed: Could not update: Failed to update to version 5.1.0-1.el2017, got version 5.1.0-1.el6 instead
```