### PR TITLE
Make management of /etc/pki directory optional

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,7 @@ class puppet_agent (
   $arch                  = $::architecture,
   $collection            = 'PC1',
   $is_pe                 = $::puppet_agent::params::_is_pe,
+  $manage_pki_dir        = true,
   $manage_repo           = true,
   $package_name          = $::puppet_agent::params::package_name,
   $package_version       = $::puppet_agent::params::package_version,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,10 @@
 #   The Puppet Collection to track. Defaults to 'PC1'.
 # [is_pe]
 #   Install from Puppet Enterprise repos. Enabled if communicating with a PE master.
+# [manage_pki_dir]
+#   Whether or not to manage the /etc/pki directory.  Defaults to true.
+#   Managing the /etc/pki directory inside the puppet_agent module can be problematic for 
+#   organizations that manage gpg keys and settings in other modules.
 # [manage_repo]
 #   Boolean to determine whether to configure repositories
 #   This is intended to provide the ability to disable configuring a local repo

--- a/manifests/osfamily/debian.pp
+++ b/manifests/osfamily/debian.pp
@@ -70,8 +70,10 @@ class puppet_agent::osfamily::debian(
     $keyname = 'GPG-KEY-puppet'
     $gpg_path = "/etc/pki/deb-gpg/${keyname}"
 
-    file { ['/etc/pki', '/etc/pki/deb-gpg']:
-      ensure => directory,
+    if getvar('::puppet_agent::manage_pki_dir') == true {
+      file { ['/etc/pki', '/etc/pki/deb-gpg']:
+        ensure => directory,
+      }
     }
 
     file { $legacy_gpg_path:

--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -65,8 +65,10 @@ class puppet_agent::osfamily::redhat(
   $gpg_keys = "file://${legacy_gpg_path}
   file://${gpg_path}"
 
-  file { ['/etc/pki', '/etc/pki/rpm-gpg']:
-    ensure => directory,
+  if getvar('::puppet_agent::manage_pki_dir') == true {
+    file { ['/etc/pki', '/etc/pki/rpm-gpg']:
+      ensure => directory,
+    }
   }
 
   file { $legacy_gpg_path:

--- a/manifests/osfamily/suse.pp
+++ b/manifests/osfamily/suse.pp
@@ -22,8 +22,10 @@ class puppet_agent::osfamily::suse(
       $gpg_path        = "/etc/pki/rpm-gpg/RPM-${keyname}"
       $gpg_homedir     = '/root/.gnupg'
 
-      file { ['/etc/pki', '/etc/pki/rpm-gpg']:
-        ensure => directory,
+      if getvar('::puppet_agent::manage_pki_dir') == true {
+        file { ['/etc/pki', '/etc/pki/rpm-gpg']:
+          ensure => directory,
+        }
       }
 
       file { $gpg_path:

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -36,10 +36,19 @@ describe 'puppet_agent' do
         'logoutput' => 'on_failure',
       }) }
 
-      ['/etc/pki', '/etc/pki/rpm-gpg'].each do |path|
-        it { is_expected.to contain_file(path).with({
-          'ensure' => 'directory',
-        }) }
+      context 'with manage_pki_dir => true' do
+        ['/etc/pki', '/etc/pki/rpm-gpg'].each do |path|
+          it { is_expected.to contain_file(path).with({
+            'ensure' => 'directory',
+          }) }
+        end
+      end
+
+      context 'with manage_pki_dir => false' do
+        let(:params) {{ :manage_pki_dir => 'false' }}
+        ['/etc/pki', '/etc/pki/rpm-gpg'].each do |path|
+          it { is_expected.not_to contain_file(path) }
+        end
       end
 
       it { is_expected.to contain_file('/etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs').with({

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -143,10 +143,19 @@ describe 'puppet_agent' do
             'logoutput' => 'on_failure',
           }) }
 
-          ['/etc/pki', '/etc/pki/rpm-gpg'].each do |path|
-            it { is_expected.to contain_file(path).with({
-              'ensure' => 'directory',
-            }) }
+          context 'with manage_pki_dir => true' do
+            ['/etc/pki', '/etc/pki/rpm-gpg'].each do |path|
+              it { is_expected.to contain_file(path).with({
+                'ensure' => 'directory',
+              }) }
+            end
+          end
+
+          context 'with manage_pki_dir => false' do
+            let(:params) {{ :manage_pki_dir => 'false' }}
+            ['/etc/pki', '/etc/pki/rpm-gpg'].each do |path|
+              it { is_expected.not_to contain_file(path) }
+            end
           end
 
           it { is_expected.to contain_class("puppet_agent::osfamily::suse") }


### PR DESCRIPTION
Managing the /etc/pki directory inside the puppet_agent module can be problematic for organizations that manage gpg keys and settings in other modules.  Adding a manage_pki_dir parameter that defaults to true allows some flexibility to the end users.