### PR TITLE
(MODULES-5622) Add REINSTALLMODE for win install

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -179,7 +179,9 @@ The directory the puppet agent should be installed to. This is only applicable f
 
 ##### `install_options`
 
-An array of additional options to pass when installing puppet-agent. Each option in the array can either be a string or a hash. Each option will automatically be quoted when passed to the install command. With Windows packages, note that file paths in an install option must use backslashes. (Since install options are passed directly to the installation command, forward slashes won't be automatically converted like they are in `file` resources.) Note also that backslashes in double-quoted strings _must_ be escaped and backslashes in single-quoted strings _can_ be escaped.
+An array of additional options to pass when installing puppet-agent. Each option in the array can either be a string or a hash. Each option will automatically be quoted when passed to the install command. 
+
+With Windows packages, note that file paths in an install option must use backslashes. (Since install options are passed directly to the installation command, forward slashes won't be automatically converted like they are in `file` resources.) Note also that backslashes in double-quoted strings _must_ be escaped and backslashes in single-quoted strings _can_ be escaped. The default value for Windows packages is `REINSTALLMODE="maus"`.
 
 ``` puppet
   install_options => ['PUPPET_AGENT_ACCOUNT_DOMAIN=ExampleCorp','PUPPET_AGENT_ACCOUNT_USER=bob','PUPPET_AGENT_ACCOUNT_PASSWORD=password']

--- a/manifests/windows/install.pp
+++ b/manifests/windows/install.pp
@@ -22,6 +22,11 @@ class puppet_agent::windows::install(
     $_https_source = "https://downloads.puppetlabs.com/windows/${package_file_name}"
   }
 
+  $_install_options = $install_options ? {
+    []      => ['REINSTALLMODE="amus"'],
+    default => $install_options
+  }
+
   $_source = $source ? {
     undef          => $_https_source,
     /^[a-zA-Z]:/ => windows_native_path($source),

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -104,6 +104,17 @@ RSpec.describe 'puppet_agent' do
           it {
             is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/msiexec.exe .+ OPTION1=value1 OPTION2=value2/)
           }
+          it {
+            is_expected.not_to contain_file('C:\tmp\install_puppet.bat').with_content(/msiexec.exe .+ REINSTALLMODE="amus"/)
+          }
+        end
+      end
+
+      context 'Default INSTALLMODE Option' do
+        describe 'REINSTALLMODE=amus' do
+          it {
+            is_expected.to contain_file('C:\tmp\install_puppet.bat').with_content(/msiexec.exe .+ REINSTALLMODE="amus"/)
+          }
         end
       end
 

--- a/templates/install_puppet.bat.erb
+++ b/templates/install_puppet.bat.erb
@@ -68,7 +68,7 @@ IF EXIST "%PUPPETRES%" (
 )
 <% end %>
 
-start /wait msiexec.exe /qn /norestart /i "<%= @_msi_location %>" /l*vx "<%= @_logfile %>" PUPPET_MASTER_SERVER="<%= @_puppet_master %>" PUPPET_AGENT_ENVIRONMENT="%environment%" <% unless @install_dir.to_s.empty? -%>INSTALLDIR="<%= @install_dir %>"<% end -%> <% unless @_agent_startup_mode.to_s.empty? -%>PUPPET_AGENT_STARTUP_MODE="<%= @_agent_startup_mode %>"<% end -%><% unless @install_options.to_s.empty? -%><%  @install_options.each do |option| -%> <%= option%><% end -%><% end -%>
+start /wait msiexec.exe /qn /norestart /i "<%= @_msi_location %>" /l*vx "<%= @_logfile %>" PUPPET_MASTER_SERVER="<%= @_puppet_master %>" PUPPET_AGENT_ENVIRONMENT="%environment%" <% unless @install_dir.to_s.empty? -%>INSTALLDIR="<%= @install_dir %>"<% end -%> <% unless @_agent_startup_mode.to_s.empty? -%>PUPPET_AGENT_STARTUP_MODE="<%= @_agent_startup_mode %>"<% end -%><% unless @_install_options.to_s.empty? -%><%  @_install_options.each do |option| -%> <%= option%><% end -%><% end -%>
 
 :End
 


### PR DESCRIPTION
Set REINSTALLMODE for Puppet Agent Upgrade/Downgrade defaulting to
"amus" which forces all files to be replaced regardless of version or
checksum.