### PR TITLE
(MODULES-5944) Fixes failure for stringify_facts

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,7 @@
 # It sets variables according to platform.
 #
 class puppet_agent::params {
-  if (versioncmp("${::clientversion}", '4.0.0') < 0 and $::puppet_stringify_facts == true) {
+  if (versioncmp("${::clientversion}", '4.0.0') < 0 and str2bool($::puppet_stringify_facts) == true) {
     fail('The puppet_agent class requires stringify_facts to be disabled')
   }
 

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -191,18 +191,21 @@ describe 'puppet_agent' do
   context 'stringify_facts is set to true' do
     describe 'when puppet_stringify_facts evaluates as true ' do
       # Mock a supported agent but with puppet_stringify_facts set to true
-      let(:facts) {{
-        :osfamily               => 'RedHat',
-        :operatingsystem        => 'Fedora',
-        :puppet_ssldir          => '/dev/null/ssl',
-        :puppet_config          => '/dev/null/puppet.conf',
-        :architecture           => 'i386',
-        :puppet_stringify_facts => true,
-      }}
-      let(:params) { global_params }
+      # check for both boolean true and string true
+      [ true, 'true' ].each do |truthiness|
+        let(:facts) {{
+          :osfamily               => 'RedHat',
+          :operatingsystem        => 'Fedora',
+          :puppet_ssldir          => '/dev/null/ssl',
+          :puppet_config          => '/dev/null/puppet.conf',
+          :architecture           => 'i386',
+          :puppet_stringify_facts => truthiness,
+        }}
+        let(:params) { global_params }
 
-      if Puppet.version < '4.0.0'
-        it { is_expected.to raise_error(Puppet::Error, /requires stringify_facts to be disabled/) }
+        if Puppet.version < '4.0.0'
+          it { is_expected.to raise_error(Puppet::Error, /requires stringify_facts to be disabled/) }
+        end
       end
     end
   end


### PR DESCRIPTION
* The code to check that stringify_facts was true,
assumed that the fact itself would be a boolean
* Ironically, if it’s true... the fact is a string!
* We can fix this by simply adding a str2bool
* Adds extra unit test to check both cases