### PR TITLE
(PE-22810) Removed _client_cert_verification

### DIFF
--- a/manifests/osfamily/debian.pp
+++ b/manifests/osfamily/debian.pp
@@ -32,19 +32,10 @@ class puppet_agent::osfamily::debian(
         "Acquire::http::proxy::${source_host} DIRECT;",
       ]
 
-      # Xenial has some sort of change that seems to have broke client cert
-      # verification in APT. While it is nice to have client cert verification,
-      # it is not strictly necessary since really all that we want to verify is
-      # that there isn't a MITM on the route to the master.
-      if ($::operatingsystem == 'Ubuntu' and $::lsbdistcodename == 'xenial') {
-        $_apt_settings = concat(
-          $_ca_cert_verification,
-          $_proxy_host)
-      } else {
-        $_apt_settings = concat(
-          $_ca_cert_verification,
-          $_proxy_host)
-      }
+      $_apt_settings = concat(
+        $_ca_cert_verification,
+        $_proxy_host)
+
 
       apt::setting { 'conf-pc_repo':
         content  => $_apt_settings.join(''),

--- a/manifests/osfamily/debian.pp
+++ b/manifests/osfamily/debian.pp
@@ -25,10 +25,6 @@ class puppet_agent::osfamily::debian(
       # For debian based platforms, in order to add SSL verification, you need to add a
       # configuration file specific to just the sources host
       $source_host = uri_host_from_string($source)
-      $_client_cert_verification = [
-        "Acquire::https::${source_host}::SslCert \"${_sslclientcert_path}\";",
-        "Acquire::https::${source_host}::SslKey \"${_sslclientkey_path}\";",
-      ]
       $_ca_cert_verification = [
         "Acquire::https::${source_host}::CaInfo \"${_sslcacert_path}\";",
       ]
@@ -47,7 +43,6 @@ class puppet_agent::osfamily::debian(
       } else {
         $_apt_settings = concat(
           $_ca_cert_verification,
-          $_client_cert_verification,
           $_proxy_host)
       }
 

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -137,8 +137,6 @@ describe 'puppet_agent' do
 
       apt_settings = [
         "Acquire::https::master.example.vm::CaInfo \"/etc/puppetlabs/puppet/ssl/certs/ca.pem\";",
-        "Acquire::https::master.example.vm::SslCert \"/etc/puppetlabs/puppet/ssl/certs/foo.example.vm.pem\";",
-        "Acquire::https::master.example.vm::SslKey \"/etc/puppetlabs/puppet/ssl/private_keys/foo.example.vm.pem\";",
         "Acquire::http::proxy::master.example.vm DIRECT;",
       ]
       it { is_expected.to contain_apt__setting('conf-pc_repo').with({


### PR DESCRIPTION
The private key is not world readable and apt now runs as an
 unpriveledged user. This means apt can no longer read the private
 key. We don't validate the client so we're removing the usage of the
 private key to communicate with master.