### PR TITLE
(MODULES-5979) Use rpm upgrade for puppet-agent upgrades

### DIFF
--- a/spec/classes/puppet_agent_osfamily_aix_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_aix_spec.rb
@@ -13,7 +13,7 @@ describe 'puppet_agent' do
   end
 
   package_version = '1.2.5'
-  package_ensure = 'present'
+  package_ensure = Puppet.version < "4.0.0" ? 'present' : package_version
   let(:params) do
     {
       :package_version => package_version
@@ -45,11 +45,11 @@ describe 'puppet_agent' do
       if Puppet.version < "4.0.0"
         it { is_expected.to contain_file('/etc/puppetlabs/puppet') }
         it { is_expected.to contain_file('/etc/puppetlabs/puppet/puppet.conf') }
-      end
 
-      it do
-        is_expected.to contain_exec('replace puppet.conf removed by package removal').with_command('cp /etc/puppetlabs/puppet/puppet.conf.rpmsave /etc/puppetlabs/puppet/puppet.conf')
-        is_expected.to contain_exec('replace puppet.conf removed by package removal').with_creates('/etc/puppetlabs/puppet/puppet.conf')
+        it do
+          is_expected.to contain_exec('replace puppet.conf removed by package removal').with_command('cp /etc/puppetlabs/puppet/puppet.conf.rpmsave /etc/puppetlabs/puppet/puppet.conf')
+          is_expected.to contain_exec('replace puppet.conf removed by package removal').with_creates('/etc/puppetlabs/puppet/puppet.conf')
+        end
       end
 
       it { is_expected.to contain_file('/opt/puppetlabs') }
@@ -96,15 +96,11 @@ describe 'puppet_agent' do
          'pe-ruby-ldap',
         ].each do |package|
           it do
-            if Puppet.version < "4.0.0"
-            else
-              is_expected.to contain_transition("remove #{package}").with(
-                :attributes => {
-                  'ensure' => 'absent',
-                  'uninstall_options' => '--nodeps',
-                  'provider' => 'rpm',
-                })
-            end
+            is_expected.to contain_package(package).with({
+              'ensure' => 'absent',
+              'uninstall_options' => '--nodeps',
+              'provider' => 'rpm',
+            })
           end
         end
       end

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -62,13 +62,6 @@ describe 'puppet_agent' do
         })
       end
 
-      it { is_expected.to contain_class("puppet_agent::prepare::package") }
-
-      it do
-        is_expected.to contain_exec('replace puppet.conf removed by package removal').with_command('cp /etc/puppetlabs/puppet/puppet.conf.rpmsave /etc/puppetlabs/puppet/puppet.conf')
-        is_expected.to contain_exec('replace puppet.conf removed by package removal').with_creates('/etc/puppetlabs/puppet/puppet.conf')
-      end
-
       it { is_expected.to contain_file('/opt/puppetlabs') }
       it { is_expected.to contain_file('/opt/puppetlabs/packages') }
       it do
@@ -79,7 +72,14 @@ describe 'puppet_agent' do
       it { is_expected.to contain_class("puppet_agent::osfamily::suse") }
 
       if Puppet.version < "4.0.0"
+        it { is_expected.to contain_class("puppet_agent::prepare::package") }
 
+        it do
+          is_expected.to contain_exec('replace puppet.conf removed by package removal').with_command('cp /etc/puppetlabs/puppet/puppet.conf.rpmsave /etc/puppetlabs/puppet/puppet.conf')
+          is_expected.to contain_exec('replace puppet.conf removed by package removal').with_creates('/etc/puppetlabs/puppet/puppet.conf')
+        end
+
+        it { is_expected.to contain_class("puppet_agent::install::remove_packages") }
         [
           'pe-augeas',
           'pe-mcollective-common',
@@ -106,31 +106,12 @@ describe 'puppet_agent' do
             is_expected.to contain_package(package).with_provider('rpm')
           end
         end
+        it { is_expected.to contain_package('puppet-agent').with_ensure('present') }
       else
-        context 'aio_agent_version is out of date' do
-          let(:facts) do
-            facts.merge({
-              :operatingsystemmajrelease => '10',
-              :platform_tag              => "sles-10-x86_64",
-              :architecture              => "x86_64",
-              :aio_agent_version         => '1.0.0'
-            })
-          end
-
-          it { is_expected.to contain_class("puppet_agent::install::remove_packages") }
-          it do
-            is_expected.to contain_transition('remove puppet-agent').with_attributes(
-              'ensure' => 'absent',
-              'uninstall_options' => '--nodeps',
-              'provider' => 'rpm')
-          end
-        end
-
-        it { is_expected.not_to contain_transition("remove puppet-agent") }
+        it { is_expected.to contain_package('puppet-agent').with_ensure('1.2.5') }
       end
 
       it do
-        is_expected.to contain_package('puppet-agent').with_ensure('present')
         is_expected.to contain_package('puppet-agent').with_provider('rpm')
         is_expected.to contain_package('puppet-agent').with_source('/opt/puppetlabs/packages/puppet-agent-1.2.5-1.sles10.x86_64.rpm')
       end


### PR DESCRIPTION
When upgrading from a puppet-agent package, use rpm to do an inplace
upgrade rather than the previous method of uninstalling the old package
before installing the new one. This avoids an issue when upgrading
Puppet 5 installs where the upgrade run tries to use files that have
been uninstalled.