### PR TITLE
(maint) Disable PuppetLint i18n check

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,7 @@ PuppetLint.configuration.send('disable_class_inherits_from_params_class')
 PuppetLint.configuration.send('disable_documentation')
 PuppetLint.configuration.send('disable_single_quote_string_with_variables')
 PuppetLint.configuration.send('disable_only_variable_string')
+PuppetLint.configuration.send('disable_check_i18n')
 
 desc 'Generate pooler nodesets'
 task :gen_nodeset do


### PR DESCRIPTION
While we support Puppet 3, we can't use puppetlabs-translate as it uses
Puppet 4 functions. Disable the i18n check in PuppetLint that requires
messages to be decorated with the translation function.