### PR TITLE
ensure compatibility to puppetlabs/apt > 3.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -129,6 +129,6 @@
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
     {"name":"puppetlabs-transition","version_requirement":">= 0.1.1 < 0.2.0"},
     {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0 < 3.0.0"},
-    {"name":"puppetlabs-apt","version_requirement":">= 2.0.1 < 3.0.0"}
+    {"name":"puppetlabs-apt","version_requirement":">= 2.0.1 <= 4.1.0"}
   ]
 }

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -5,6 +5,12 @@ describe 'puppet_agent' do
     :lsbdistid => 'Debian',
     :osfamily => 'Debian',
     :lsbdistcodename => 'wheezy',
+    :os => {
+      'name' => 'Debian',
+      'release' => {
+        'full' => '6.0',
+      },
+    },
     :operatingsystem => 'Debian',
     :architecture => 'x64',
       :servername   => 'master.example.vm',
@@ -87,6 +93,12 @@ describe 'puppet_agent' do
           :platform_tag => 'ubuntu-1604-x86_64',
           :operatingsystem => 'Ubuntu',
           :lsbdistcodename => 'xenial',
+          :os => {
+            'name' => 'Ubuntu',
+            'release' => {
+              'full' => '16.04',
+            },
+          },
         })
       }
 


### PR DESCRIPTION
According to ticket 6280 (https://tickets.puppetlabs.com/browse/MODULES-6280):
This PR updates the maximal compatible version of puppetlabs/apt to 4.1.0.
Unit tests were successful (with updated .fixtures.yml)