### PR TITLE
support puppet 5 on windows

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,8 +90,7 @@ class puppet_agent (
       $_expected_package_version = $package_version
     }
 
-    $aio_upgrade_required = ($is_pe == false and $_expected_package_version != undef) or
-      (getvar('::aio_agent_version') != undef and $_expected_package_version != undef and
+    $aio_upgrade_required = (getvar('::aio_agent_version') != undef and $_expected_package_version != undef and
         versioncmp("${::aio_agent_version}", "${_expected_package_version}") < 0)
 
     if $::architecture == 'x86' and $arch == 'x64' {

--- a/manifests/windows/install.pp
+++ b/manifests/windows/install.pp
@@ -19,7 +19,12 @@ class puppet_agent::windows::install(
     $_https_source = "https://pm.puppetlabs.com/puppet-agent/${_pe_server_version}/${_agent_version}/repos/windows/${package_file_name}"
   }
   else {
-    $_https_source = "https://downloads.puppetlabs.com/windows/${package_file_name}"
+    if $::puppet_agent::collection == 'puppet5' {
+      $_https_source = "https://downloads.puppetlabs.com/windows/puppet5/${package_file_name}"
+    }
+    else {
+      $_https_source = "https://downloads.puppetlabs.com/windows/${package_file_name}"
+    }
   }
 
   $_install_options = $install_options ? {

--- a/metadata.json
+++ b/metadata.json
@@ -130,6 +130,6 @@
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
     {"name":"puppetlabs-transition","version_requirement":">= 0.1.1 < 0.2.0"},
     {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0 < 3.0.0"},
-    {"name":"puppetlabs-apt","version_requirement":">= 2.0.1 <= 4.1.0"}
+    {"name":"puppetlabs-apt","version_requirement":">= 2.0.1"}
   ]
 }


### PR DESCRIPTION
Currently, the module looks at a download url that only contains puppet 3 and puppet 4 packages.  This extra condition helps support puppet 5 packages if puppet_agent::collection is set to puppet5.