### PR TITLE
 (PE-23563) Stop MCO and Puppet prior to MSI install 

### DIFF
--- a/templates/install_puppet.bat.erb
+++ b/templates/install_puppet.bat.erb
@@ -39,8 +39,9 @@ REM sets its startup type, which prevents installs from proceeding.
 REM This may fail on agents without pxp-agent, but since this is not
 REM run interactively and the next command sets ERRORLEVEL, it's OK.
 net stop pxp-agent
-REM Same for the Marionette Collective Service
+REM Same for the Marionette Collective Service and Puppet Agent service
 net stop mcollective
+net stop puppet
 
 <% if @msi_move_locked_files %>
 REM Move puppetres.dll to avoid file locks and service restarts (MODULES-4207)

--- a/templates/install_puppet.bat.erb
+++ b/templates/install_puppet.bat.erb
@@ -39,6 +39,8 @@ REM sets its startup type, which prevents installs from proceeding.
 REM This may fail on agents without pxp-agent, but since this is not
 REM run interactively and the next command sets ERRORLEVEL, it's OK.
 net stop pxp-agent
+REM Same for the Marionette Collective Service
+net stop mcollective
 
 <% if @msi_move_locked_files %>
 REM Move puppetres.dll to avoid file locks and service restarts (MODULES-4207)

--- a/templates/install_puppet.bat.erb
+++ b/templates/install_puppet.bat.erb
@@ -43,6 +43,9 @@ REM Same for the Marionette Collective Service and Puppet Agent service
 net stop mcollective
 net stop puppet
 
+REM Log the current user token privileges for debugging
+whoami /all
+
 <% if @msi_move_locked_files %>
 REM Move puppetres.dll to avoid file locks and service restarts (MODULES-4207)
 


### PR DESCRIPTION
Previously it was possible to get into a strange race condition where the MSI
was able to propertly stop the MCollective and Puppet service prior to upgrade.  This
PR attempts to stop the mco and puppet services prior to the MSI being invoked, giving
the service more time to stop correctly.

This PR also adds some helpful information into the installation log for use during debugging failed installations.