### PR TITLE
(MODULES-6688) Use travis for CI testing, instead of Jenkins

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -8,6 +8,40 @@
 .travis.yml:
   unmanaged: true
 
+# Requires the bundler_args to be supported.
+# .travis.yml:
+#   dist: trusty
+#   script: 'bundle exec rake $CHECK'
+#   before_install:
+#     - bundle -v
+#     - rm Gemfile.lock || true
+#     - gem update --system
+#     - gem --version
+#     - bundle -v
+#   docker_sets:
+#   includes:
+#     # Disabling 1.8.7 as it no longer plays nice
+#     # - rvm: 1.8.7
+#     #   env: PUPPET_GEM_VERSION="~> 3.7.5"
+#     # - rvm: 1.8.7
+#     #   env: PUPPET_GEM_VERSION="~> 3.8.1"
+#     # Disabling as puppet-module-gems only supports ruby >= 2.1.X
+#     # - rvm: 1.9.3
+#     #   env: PUPPET_GEM_VERSION="~> 3.8.1"  FUTURE_PARSER="yes"
+
+#     - rvm: 2.4.1
+#       env: CHECK="validate lint"
+#     - rvm: 2.1.0
+#       env: PUPPET_GEM_VERSION="~> 3.8" FUTURE_PARSER="yes" CHECK=spec
+#     - rvm: 2.1.5
+#       env: PUPPET_GEM_VERSION="~> 4.0.0" CHECK=spec
+#     - rvm: 2.1.9
+#       env: PUPPET_GEM_VERSION="4.7.1" HIERA_GEM_VERSION="3.2.2" CHECK=spec
+#     - rvm: 2.1.9
+#       env: PUPPET_GEM_VERSION="~> 4.10" CHECK=spec
+#     - rvm: 2.4.1
+#       env: PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
+
 appveyor.yml:
   unmanaged: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,32 @@
 ---
-language: ruby
-dist: trusty
 sudo: false
-bundler_args: --without system_tests --full-index
-before_script: cat Gemfile.lock
-before_install: rm Gemfile.lock || true
-script: bundle exec rake validate lint spec
+dist: trusty
+language: ruby
+cache: bundler
+script: bundle exec rake $CHECK
+# Note - Bundler args are currently not supported in modsync
+bundler_args: --without system_tests
+before_install:
+  # Additional instructions
+  - bundle -v
+  - rm Gemfile.lock || true
+  - gem update --system
+  - gem --version
+  - bundle -v
 matrix:
+  fast_finish: true
   include:
-# Disabling 1.8.7 as it no longer plays nice
-#     - rvm: 1.8.7
-#       env: PUPPET_GEM_VERSION="~> 3.7.5"
-#     - rvm: 1.8.7
-#       env: PUPPET_GEM_VERSION="~> 3.8.1"
-# Disabling as puppet-module-gems only supports ruby >= 2.1.X
-#    - rvm: 1.9.3
-#      env: PUPPET_GEM_VERSION="~> 3.8.1"  FUTURE_PARSER="yes"
-    - rvm: 2.1.0
-      env: PUPPET_GEM_VERSION="~> 3.8"  FUTURE_PARSER="yes"
-    - rvm: 2.1.9
-      env: PUPPET_GEM_VERSION="~> 4.0.0"
-    - rvm: 2.3.4
-      env: PUPPET_GEM_VERSION="~> 4.10"
-    - rvm: 2.3.4
-      env: PUPPET_GEM_VERSION="~> 5.0.1"
+  - rvm: 2.4.1
+    env: CHECK="validate lint"
+  - rvm: 2.1.0
+    env: PUPPET_GEM_VERSION="~> 3.8" FUTURE_PARSER="yes" CHECK=spec
+  - rvm: 2.1.5
+    env: PUPPET_GEM_VERSION="~> 4.0.0" CHECK=spec
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="4.7.1" HIERA_GEM_VERSION="3.2.2" CHECK=spec
+  - rvm: 2.1.9
+    env: PUPPET_GEM_VERSION="~> 4.10" CHECK=spec
+  - rvm: 2.4.1
+    env: PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
+notifications:
+  email: false


### PR DESCRIPTION
Previously the module was tested in both Travis and private Jenkins CI systems
however this is no longer required.  This commit moves the spec tests that
are tested in Jenkins and moves them to Travis;
* Only test puppet agent and ruby combinations that are installed in AIO installs
* Split out validate and lint checking to only happen once per job not for all
  matrix cells
* Now tests on Puppet latest 3.8, first 4.0, latest 4.7.x, 4.10.x and 5.x gems
* The Hiera Gem needs to be set on Puppet 4.7.1 as it has incompatibilites with
  later hiera gem versions (4.4.2)
* Brings the Travis CI config file into a similar format as that used by the PDK
  to make migration easier later.
* The Travis file needs to remain unmanaged until it supports setting the
  bundler_args setting