### PR TITLE
(MODULES-6604) normalize windows source parameter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -89,7 +89,9 @@ The Puppet Collection to track. Defaults to `PC1`.
 
 ##### `is_pe`
 
-Install from Puppet Enterprise repos. Enabled if communicating with a PE master.
+Install from repositories hosted on your Puppet Enterprise master. Defaults to true when using a PE master.
+
+When installing from repositories hosted on your PE master, verify that you have have added `pe_repo::platform` classes for each of your agent platforms to the PE Master group. For more information, review [Upgrading agents](https://puppet.com/docs/pe/latest/upgrading/upgrading_agents.html#upgrade-nix-or-windows-agents-using-the-puppet-agent-module)
 
 ##### `manage_repo`
 
@@ -111,14 +113,18 @@ An array of services to start, normally `puppet` and `mcollective`. If the array
 
 ##### `source`
 
-Alternate source from which you wish to download the latest version of Puppet. On the Windows operating system this is the absolute path to the MSI file to install, for example:
+Alternate source from which to download packages. For Windows agents, this may be a `http`, `https`, or `puppet` url, or an absolute path. 
+For example:
 ``` puppet
   source => 'C:/packages/puppet-agent-1.7.0-x64.msi'
 ```
 
+Note: https sources do not support self-signed certificates.
+
 ##### `install_dir`
 
-The directory the puppet agent should be installed to. This is only applicable for Windows operating systems and when upgrading the agent to a new version; it will not cause re-installation of the same version to a new location. This must use backslashes for the path separator, and be an absolute path, for example:
+The directory the puppet agent should be installed to. This is only applicable for Windows operating systems and when upgrading the agent to a new version; it will not cause re-installation of the same version to a new location. This must use backslashes for the path separator, and be an absolute path. 
+For example:
 ``` puppet
   install_dir => 'D:\Program Files\Puppet Labs'
 ```
@@ -128,15 +134,15 @@ The directory the puppet agent should be installed to. This is only applicable f
 An array of additional options to pass when installing puppet-agent. Each option in the array can be either a string or a hash. Each option is automatically quoted when passed to the install command.
 
 With Windows packages, note that file paths in `install_options` must use backslashes. (Since install options are passed directly to the installation command, forward slashes aren't automatically converted like they are in `file` resources.) Backslashes in double-quoted strings _must_ be escaped, while backslashes in single-quoted strings _can_ be escaped. The default value for Windows packages is `REINSTALLMODE="maus"`.
-
+For example:
 ``` puppet
   install_options => ['PUPPET_AGENT_ACCOUNT_DOMAIN=ExampleCorp','PUPPET_AGENT_ACCOUNT_USER=bob','PUPPET_AGENT_ACCOUNT_PASSWORD=password']
 ```
 
 ##### `msi_move_locked_files`
 
-This is only applicable for Windows operating systems. There may be instances where file locks cause unncessary service restarts.  By setting to true, the module will move files prior to installation that are known to cause file locks. By default this is set to false.
-
+This is only applicable for Windows operating systems. There may be instances where file locks cause unncessary service restarts. By setting to true, the module will move files prior to installation that are known to cause file locks. By default this is set to false.
+For example:
 ``` puppet
   msi_move_locked_files => true
 ```
@@ -152,7 +158,7 @@ Mac OS X Open Source packages are currently not supported.
 In addition, there are several known issues with Windows:
 
 * To upgrade the agent by executing `puppet agent -t` interactively in a console, you must close the console and wait for the upgrade to finish before attempting to use the `puppet` command again.
-* MSI installation failures do not produce any error. If the install fails, puppet_agent continues to be applied to the agent. If this happens, you'll need to examine the MSI log file to determine the failure's cause. You can find the location of the log file in the debug output from either a puppet apply or an agent run; the log file name follows the pattern `puppet-<timestamp>-installer.log`.
+* MSI installation failures do not generate Puppet errors. If the install fails, the `puppet_agent` class continues to be applied to the agent. If this happens, you will need to examine the MSI installer log file to determine the failure's cause. You can find the location of the log file in the debug output from either a `puppet apply` or `puppet agent` run; the file name follows the pattern `puppet-<timestamp>-installer.log`.
 * On Windows Server 2003, only x86 is supported, and the `arch` parameter is ignored. If you try to force an upgrade to x64, Puppet installs the x86 version with no error message.
 * On Windows Server 2003 with Puppet Enterprise, the default download location is unreachable. You can work around this issue by specifying an alternate download URL in the `source` parameter.
 

--- a/README.markdown
+++ b/README.markdown
@@ -21,13 +21,11 @@
 
 ## Overview
 
-A module for upgrading Puppet agents. Supports upgrading from Puppet 4 puppet-agent packages to later versions.
+A module for upgrading Puppet agents. Supports upgrading from Puppet 4+ puppet-agent packages to later versions.
 
 ## Module Description
 
-The puppet_agent module installs the Puppet Collection 1 repo (as a default, and on systems that support repositories); migrates configuration required by Puppet to new locations used by puppet-agent; and installs the puppet-agent package, removing the previous Puppet installation. When starting from Puppet 3, it will upgrade to the latest Puppet open-source release, or to the latest puppet-agent package supported by your PE installation.
-
-If a package_version parameter is provided, it will ensure that puppet-agent version is installed. The package_version parameter is required to perform upgrades starting from a puppet-agent (Puppet 4) package.
+The puppet_agent module installs the Puppet Collection 1 repo (as a default, and on systems that support repositories); migrates configuration required by Puppet to new locations used by puppet-agent; and installs the puppet-agent package, removing the previous Puppet installation.
 
 This module expects Puppet to be installed from packages.
 
@@ -43,33 +41,7 @@ This module expects Puppet to be installed from packages.
 
 ### Setup requirements
 
-Your agents must be running Puppet 3 with `stringify_facts` set to 'false', or Puppet 4+. Agents should already be pointed at a master running Puppet Server 2.1 or greater, and thus successfully applying catalogs compiled with the Puppet 4 language.
-
-To compile this module, you must use Puppet 3.7 with future parser or newer, meaning it can be applied to masterless Puppet 3.7 or newer, or earlier Puppet 3 agents connecting to a Puppet 3.7 or newer master.
-
-#### Configuring `stringify_facts`
-
-On systems running Puppet 3.x, you can configure the `stringify_facts` settings with either a dedicated Puppet class or the [`puppet_conf`](https://forge.puppet.com/puppetlabs/puppet_conf) task module.
-
-For example, this class can configure the settings:
-
-```puppet
-include ::puppet_agent::prepare::stringify_facts
-```
-
-This [Puppet Enterprise task](https://puppet.com/docs/pe/2017.3/orchestrator/puppet_tasks_overview.html) can also configure the settings:
-
-```bash
-puppet task run puppet_conf action=set section=main setting=stringify_facts value=false --nodes example-38-box.vm
-```
-
-This [bolt task](https://puppet.com/docs/bolt/0.x/bolt.html) can also configure the settings over SSH/WinRM:
-
-```bash
-bolt task run puppet_conf action=set section=main setting=stringify_facts value=false --nodes example-38-box.vm
-```
-
-> *Warning:* `stringify_facts` was [deprecated in Puppet 3.8](https://docs.puppet.com/puppet/3.8/deprecated_settings.html#stringifyfacts--true) and [removed in Puppet 5](https://puppet.com/docs/puppet/5.3/upgrade_major_pre.html#stop-stringifying-facts-and-check-for-breakage).
+Your agents must be running Puppet 4+. Agents should already be pointed at a master running Puppet Server 2.1 or greater, and thus successfully applying catalogs compiled with the Puppet 4 language.
 
 ### Beginning with puppet_agent
 
@@ -77,39 +49,15 @@ Install the puppet_agent module with `puppet module install puppetlabs-puppet_ag
 
 ## Usage
 
-### Puppet 3 Upgrades
-
-Add the class to agents you want to upgrade:
-
-~~~puppet
-include ::puppet_agent
-~~~
-
-This installs the latest released version of Puppet from Puppet Collection 1.
-
-To upgrade with this module, first stand up a Puppet Server 2.1 master---which supports backward compatibility with Puppet 3 agents---and point the agent you want to upgrade at that master. Once you've confirmed the agent runs successfully against the new master, and thus the Puppet 4 language, apply the class to the agent and confirm that it checks back in after a successful upgrade. Further details on upgrading are available [here](http://docs.puppetlabs.com/puppet/4.2/reference/upgrade_major_pre.html).
-
-As part of preparing the agent for Puppet 4, the module performs several significant steps:
-* Copies SSL files (based on their location settings: ssldir, certdir, privatedir, privatekeydir, publickeydir, requestdir) to new Puppet 4 defaults, and restore those settings to default in puppet.conf.
-* Resets non-deprecated settings to defaults: disable_warnings, vardir, rundir, libdir, confdir, ssldir, and classfile.
-* Resets logfile in MCollective's server.cfg and client.cfg.
-* Adds new libdir and plugin.yaml locations to MCollective's server.cfg and client.cfg.
-
-> **Note:** The upgrade does not change several config options. Anything else that's been explicitly configured will not be changed to reflect new default locations in Puppet 4. Some of these options are:
-* Puppet's logdir
-* MCollective's logfile
-
-### Puppet 4 Upgrades
-
 Add the class to agents you want to upgrade, specifying the desired puppet-agent version:
 
 ~~~puppet
 class {'::puppet_agent':
-  package_version => '1.4.0',
+  package_version => '1.7.0',
 }
 ~~~
 
-This will ensure the version `1.4.0` of the puppet-agent package is installed. For version `1.4.0` and later, it will also remove the deprecated `pluginsync` setting from `puppet.conf`, unless explicitly managed elsewhere.
+This will ensure the version `1.7.0` of the puppet-agent package is installed.
 
 ## Reference
 
@@ -155,9 +103,7 @@ The package to upgrade to, i.e., `puppet-agent`. Currently, the default and only
 
 ##### `package_version`
 
-The package version to upgrade to. When upgrading from Puppet < 4.0, defaults to the puppet master's latest supported version
-if compiled with A PE master or undef otherwise (meaning get the latest Open Source release). Explicitly specify a version to
-upgrade from puppet-agent packages (implying Puppet >= 4.0).
+The package version to upgrade to.
 
 ##### `service_names`
 
@@ -201,7 +147,7 @@ Mac OS X Open Source packages are currently not supported.
 
 ### Known issues
 
-* In masterless environments, modules installed manually on individual agents cannot be found after upgrading to Puppet 4.x. You should reinstall these modules on the agents with `puppet module install`.
+* In masterless environments, modules installed manually on individual agents cannot be found after upgrading to Puppet 4+. You should reinstall these modules on the agents with `puppet module install`.
 
 In addition, there are several known issues with Windows:
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -141,7 +141,7 @@ class puppet_agent (
       }
 
       if $is_pe {
-        $_package_file_name = "${package_name}-${_arch}.msi"
+        $_package_file_name = "${package_name}-${package_version}-${_arch}.msi"
       } elsif $package_version != undef {
         $_package_file_name = "${package_name}-${package_version}-${_arch}.msi"
       } else {
@@ -154,6 +154,7 @@ class puppet_agent (
     class { '::puppet_agent::prepare':
       package_file_name => $_package_file_name,
       package_version   => $package_version,
+      source            => $source,
     }
     -> class { '::puppet_agent::install':
       package_file_name => $_package_file_name,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,7 +7,7 @@
 # [package_file_name]
 #   The puppet-agent package file name.
 #   (see puppet_agent::prepare::package_file_name)
-# [version]
+# [package_version]
 #   The puppet-agent version to install.
 #
 class puppet_agent::install(
@@ -136,21 +136,19 @@ class puppet_agent::install(
   } elsif $::osfamily == 'windows' {
     # Prevent re-running the batch install
     if $old_packages or $puppet_agent::aio_upgrade_required {
-      if $::puppet_agent::is_pe == true and empty($::puppet_agent::source) {
-        $local_package_file_path = windows_native_path("${::puppet_agent::params::local_packages_dir}/${package_file_name}")
+      if versioncmp("${::clientversion}", '4.4.0') == -1 and $::puppet_agent::prepare::package::_source =~ /^https?:/ {
         class { 'puppet_agent::windows::install':
-          package_file_name => $package_file_name,
-          source            => $local_package_file_path,
+          package_file_name => $::puppet_agent::prepare::package::_staged,
           install_dir       => $install_dir,
-          require           => File[$local_package_file_path],
           install_options   => $install_options,
+          require           => Exec['download_puppet-agent.msi'],
         }
       } else {
         class { 'puppet_agent::windows::install':
-          package_file_name => $package_file_name,
-          source            => $::puppet_agent::source,
+          package_file_name => $::puppet_agent::prepare::package::_staged,
           install_dir       => $install_dir,
           install_options   => $install_options,
+          require           => File['download_puppet-agent.msi'],
         }
       }
     }

--- a/manifests/osfamily/windows.pp
+++ b/manifests/osfamily/windows.pp
@@ -1,11 +1,15 @@
 class puppet_agent::osfamily::windows(
   $package_file_name = undef,
+  $package_version   = undef,
+  $source            = undef,
 ) {
   assert_private()
 
-  if !empty($package_file_name) and $::puppet_agent::is_pe == true {
+  if !empty($package_file_name) {
     class { 'puppet_agent::prepare::package':
       package_file_name => $package_file_name,
+      package_version   => $package_version,
+      source            => $source,
     }
     contain puppet_agent::prepare::package
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,12 +15,20 @@ class puppet_agent::params {
   # function is available
   $_is_pe = (getvar('::is_pe') or is_function_available('pe_compiling_server_version'))
 
-  # In Puppet Enterprise, agent packages are provided by the master
-  # with a default prefix of `/packages`.
-  if $::osfamily != 'windows' {
-    $_source = $_is_pe ? {
-      true    => "https://${::servername}:8140/packages",
-      default => undef,
+  # In Puppet Enterprise, agent packages are sourced from the master via 'https://'
+  # or via 'puppet://pe_packages' depending upon the agent operating system.
+
+  $pe_repo_puppet = 'puppet:///pe_packages'
+  $packages_https = 'https://downloads.puppetlabs.com'
+
+  if $_is_pe {
+    case $::osfamily {
+      'windows': {
+        $_source = undef
+      }
+      default: {
+        $_source = "https://${::servername}:8140/packages"
+      }
     }
   } else {
     $_source = undef

--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -8,12 +8,15 @@
 #   The file name, with platform and version, of the puppet-agent package to be
 #   downloaded and installed.  Older systems and package managers may require
 #   us to manually download the puppet-agent package.
-# [version]
+# [package_version]
 #   The puppet-agent version to install.
+# [source]
+#   The location to find packages.
 #
 class puppet_agent::prepare(
   $package_file_name = undef,
-  $package_version = undef,
+  $package_version   = undef,
+  $source            = undef,
 ){
   include puppet_agent::params
   $_windows_client = downcase($::osfamily) == 'windows'
@@ -87,9 +90,16 @@ class puppet_agent::prepare(
   # the osfamily of the client being configured.
 
   case $::osfamily {
-    'redhat', 'debian', 'windows', 'solaris', 'aix', 'suse', 'darwin': {
+    'redhat', 'debian', 'solaris', 'aix', 'suse', 'darwin': {
       class { $_osfamily_class:
         package_file_name => $package_file_name,
+      }
+    }
+    'windows': {
+      class { $_osfamily_class:
+        package_file_name => $package_file_name,
+        package_version   => $package_version,
+        source            => $source,
       }
       contain $_osfamily_class
     }

--- a/manifests/prepare/package.pp
+++ b/manifests/prepare/package.pp
@@ -4,64 +4,106 @@
 # package is downloaded locally for installation.  This is used on platforms
 # without package managers capable of working with a remote https repository.
 #
+# === Parameters
+#
 # [package_file_name]
-#   The puppet-agent package file to retrieve from the master.
+#   The puppet-agent package file name to download.
+# [package_version]
+#   The puppet-agent version to install.
+# [source]
+#   The location to find packages.
 #
 class puppet_agent::prepare::package(
   $package_file_name,
+  $package_version    = undef,
+  $source             = undef,
 ) {
   assert_private()
 
-  # As it is currently written, this will only work if the `pe_build_version()` function
-  # is available.
-  if getvar('puppet_agent::is_pe') == true {
-    $pe_server_version = pe_build_version()
+  file { $::puppet_agent::params::local_packages_dir:
+    ensure => directory,
+  }
 
-    if $::osfamily == 'windows' {
-      $tag = $::puppet_agent::arch ? {
-        'x64' => 'windows-x86_64',
-        'x86' => 'windows-i386',
-      }
-      $source = "puppet:///pe_packages/${pe_server_version}/${tag}/${package_file_name}"
-    } elsif $::operatingsystem == 'AIX' {
+  # When running against a Puppet 3.x agent use the default checksum method,
+  # due to old bugs when specifying custom checksums. 
+  # For Puppet 4+, use sha256lite and avoid extra processing time.
+  $checksum = $::aio_agent_version ? {
+    undef   => undef,
+    default => sha256lite,
+  }
+
+  if getvar('puppet_agent::is_pe') == true and $::osfamily != 'windows' {
+    $pe_server_version = pe_build_version()
+    if $::osfamily == 'AIX' {
       $tag = $::platform_tag ? {
         'aix-7.2-power' => 'aix-7.1-power',
         default         => $::platform_tag,
       }
-      $source = "puppet:///pe_packages/${pe_server_version}/${tag}/${package_file_name}"
+      $_source = "${::puppet_agent::params::pe_repo_puppet}/${pe_server_version}/${tag}/${package_file_name}"
     } else {
-      $source = "puppet:///pe_packages/${pe_server_version}/${::platform_tag}/${package_file_name}"
+      $_source = "${::puppet_agent::params::pe_repo_puppet}/${pe_server_version}/${::platform_tag}/${package_file_name}"
     }
-
-    file { $::puppet_agent::params::local_packages_dir:
-      ensure => directory,
-    }
-
-    if $::osfamily =~ /windows/ {
-      $local_package_file_path = windows_native_path("${::puppet_agent::params::local_packages_dir}/${package_file_name}")
-      $mode = undef
-    } else {
-      $local_package_file_path = "${::puppet_agent::params::local_packages_dir}/${package_file_name}"
-      $mode = '0644'
-    }
-
-    # When running against a puppet 3 agent, we want to use the
-    # default checksum method, due to old bugs when specifying custom
-    # checksums. For puppet 4, we can use sha256lite and avoid some
-    # extra processing time.
-    $checksum = $::aio_agent_version ? {
-      undef   => undef,
-      default => sha256lite,
-    }
-
-    file { $local_package_file_path:
+    $_staged = "${::puppet_agent::params::local_packages_dir}/${package_file_name}"
+    file { $_staged:
       ensure   => present,
       owner    => $::puppet_agent::params::user,
       group    => $::puppet_agent::params::group,
-      mode     => $mode,
-      source   => $source,
+      mode     => '0644',
+      source   => $_source,
       require  => File[$::puppet_agent::params::local_packages_dir],
       checksum => $checksum
     }
   }
+
+  # Whether or not is_pe, download remote packages on Windows ...
+  if $::osfamily == 'windows' {
+    if getvar('puppet_agent::is_pe') == true and $source == undef {
+      $pe_server_version = pe_build_version()
+      $tag = $::puppet_agent::arch ? {
+        'x86'   => 'windows-i386',
+        default => 'windows-x86_64',
+      }
+      # On the master, the package version is in the directory name rather than the file name.
+      $pe_repo_package_file_name = delete($package_file_name, "-${package_version}")
+      # Use pe_repo_puppet to avoid file source https self-signed certificate errors with pe_repo.
+      $_source = "${::puppet_agent::params::pe_repo_puppet}/${pe_server_version}/${tag}-${package_version}/${pe_repo_package_file_name}"
+      $_staged = windows_native_path("${::puppet_agent::params::local_packages_dir}/${package_file_name}")
+    } else {
+      # The source may be a prefix or a fully-qualified file.
+      if $source and $source =~ /(.*)[\/\\](.*?\.msi)$/ {
+        $prefix = $1
+        $file = $2
+      } else {
+        $prefix = $source
+        $file = $package_file_name
+      }
+      $_source = $source ? {
+        undef        => "${::puppet_agent::params::packages_https}/windows/${package_file_name}",
+        /^[a-zA-Z]:/ => windows_native_path("${prefix}/${file}"),
+        /^\\\\./     => windows_native_path("${prefix}/${file}"),
+        default      => "${prefix}/${file}",
+      }
+      $_staged = windows_native_path("${::puppet_agent::params::local_packages_dir}/${file}")
+    }
+    if versioncmp("${::clientversion}", '4.4.0') == -1 and $_source =~ /^https?:/ {
+      # Use --insecure to ignore self-signed certificate errors.
+      exec { 'download_puppet-agent.msi':
+        command => "curl --fail --silent --show-error --output ${_staged} --url ${_source}",
+        creates => $_staged,
+        path    => $::path,
+        require => File[$::puppet_agent::params::local_packages_dir],
+      }
+    } else {
+      file { 'download_puppet-agent.msi':
+        ensure   => present,
+        path     => $_staged,
+        owner    => $::puppet_agent::params::user,
+        group    => $::puppet_agent::params::group,
+        source   => $_source,
+        require  => File[$::puppet_agent::params::local_packages_dir],
+        checksum => $checksum
+      }
+    }
+  }
+
 }

--- a/manifests/windows/install.pp
+++ b/manifests/windows/install.pp
@@ -6,45 +6,19 @@
 #
 class puppet_agent::windows::install(
   $package_file_name,
-  $source                = $::puppet_agent::source,
   $install_dir           = undef,
   $install_options       = [],
   $msi_move_locked_files = $::puppet_agent::msi_move_locked_files,
   ) {
   assert_private()
 
-  if $::puppet_agent::is_pe {
-    $_agent_version = $puppet_agent::params::master_agent_version
-    $_pe_server_version = pe_build_version()
-    $_https_source = "https://pm.puppetlabs.com/puppet-agent/${_pe_server_version}/${_agent_version}/repos/windows/${package_file_name}"
-  }
-  else {
-    $_https_source = "https://downloads.puppetlabs.com/windows/${package_file_name}"
-  }
-
   $_install_options = $install_options ? {
     []      => ['REINSTALLMODE="amus"'],
     default => $install_options
   }
 
-  $_source = $source ? {
-    undef          => $_https_source,
-    /^[a-zA-Z]:/ => windows_native_path($source),
-    default        => $source,
-  }
-
-  $_msi_location = $_source ? {
-    /^puppet:/ => windows_native_path("${::env_temp_variable}/puppet-agent.msi"),
-    default    => $_source,
-  }
-
   $_installbat = windows_native_path("${::env_temp_variable}/install_puppet.bat")
-  if $_source =~ /^puppet:/ {
-    file{ $_msi_location:
-      source => $_source,
-      before => File["${_installbat}"],
-    }
-  }
+  $_msi_location = $package_file_name
 
   $_cmd_location = $::rubyplatform ? {
     /i386/  => 'C:\\Windows\\system32\\cmd.exe',
@@ -60,8 +34,10 @@ class puppet_agent::windows::install(
   $_timestamp = strftime('%Y_%m_%d-%H_%M')
   $_logfile = windows_native_path("${::env_temp_variable}/puppet-${_timestamp}-installer.log")
   $_puppet_master = $::puppet_master_server
-  notice ("Puppet upgrade log file at ${_logfile}")
-  debug ("Installing puppet from ${_msi_location}")
+
+  debug ("Installing/Upgrading Puppet Agent via: ${package_file_name}")
+  notice ("Puppet Agent MSI installer log file: ${_logfile}")
+
   file { "${_installbat}":
     ensure  => file,
     content => template('puppet_agent/install_puppet.bat.erb')
@@ -72,7 +48,7 @@ class puppet_agent::windows::install(
   }
 
   # PUP-5480/PE-15037 Cache dir loses inheritable SYSTEM perms
-  exec { 'fix inheritable SYSTEM perms':
+  exec { 'Reset inheritable SYSTEM permissions after MSIEXEC':
     command => "${::system32}\\icacls.exe \"${::puppet_client_datadir}\" /grant \"SYSTEM:(OI)(CI)(F)\"",
     unless  => "${::system32}\\icacls.exe \"${::puppet_client_datadir}\" | findstr \"SYSTEM:(OI)(CI)(F)\"",
     require => Exec['install_puppet.bat'],

--- a/spec/classes/puppet_agent_osfamily_windows_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_windows_spec.rb
@@ -41,8 +41,8 @@ describe 'puppet_agent' do
       it { is_expected.to contain_file("#{appdata}\\Puppetlabs") }
       it { is_expected.to contain_file("#{appdata}\\Puppetlabs\\packages") }
       it {
-        is_expected.to contain_file("#{appdata}\\Puppetlabs\\packages\\puppet-agent-#{arch}.msi").with(
-          'source' => "puppet:///pe_packages/#{pe_version}/windows-#{tag}/puppet-agent-#{arch}.msi"
+        is_expected.to contain_file('download_puppet-agent.msi').with(
+          'source' => "puppet:///pe_packages/#{pe_version}/windows-#{tag}-#{package_version}/puppet-agent-#{arch}.msi"
         )
       }
     end


### PR DESCRIPTION
Standardizes source as a prefix on Windows to match Linux.
Downloads/prepares/stages remote source files before passing them to msiexec.
Standardizes location of downloaded files to be the local packages directory.
Saves downloaded files with package version.