### PR TITLE
(PA-1887) Fix osfamily::darwin OSX version regex

### DIFF
--- a/manifests/osfamily/darwin.pp
+++ b/manifests/osfamily/darwin.pp
@@ -3,7 +3,7 @@ class puppet_agent::osfamily::darwin(
 ) {
   assert_private()
 
-  if $::macosx_productversion_major !~ '10\.[9,10,11]' {
+  if $::macosx_productversion_major !~ /^10\.(9|10|11|12|13)/ {
     fail("${::macosx_productname} ${::maxosx_productversion_major} not supported")
   }
 

--- a/spec/classes/puppet_agent_osfamily_darwin_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_darwin_spec.rb
@@ -50,7 +50,7 @@ describe 'puppet_agent' do
 
   describe 'supported environment' do
     context "when running a supported OSX" do
-      ["osx-10.9-x86_64", "osx-10.10-x86_64", "osx-10.11-x86_64"].each do |tag|
+      ["osx-10.9-x86_64", "osx-10.10-x86_64", "osx-10.11-x86_64", "osx-10.12-x86_64", "osx-10.13-x86_64"].each do |tag|
         context "on #{tag} with no aio_version" do
           let(:osmajor) { tag.split('-')[1] }
 


### PR DESCRIPTION
The previous regex used a character class instead of a union to
match the major Mac OSX product version, which would match values
such as "10.14", "10.15". This meant that the puppet_agent module
would think these are supported platforms, and proceed further with
the installation (failing at a different point, which would produce
a harder-to-read error message). This commit fixes things so that
non-supported Mac OSX platforms correctly fail in the osfamily::darwin
class with a readable error message.