### PR TITLE
EXPECTED TO FAIL: tests are not correctly checking package_version

### DIFF
--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -122,6 +122,7 @@ describe 'puppet_agent' do
 
             it { is_expected.to compile.with_all_deps }
             it { expect { catalogue }.not_to raise_error }
+            it { is_expected.to contain_class('puppet-agent').with_package_version(version) }
           end
         end
 


### PR DESCRIPTION
It appears that for some reason, the value being provided to the class under test for the package_version parameter does not in fact get set to each of the values in the test array. Instead, the last value listed is passed to the class under test repeatedly, the number of times that there are elements in the array of strings that are expected to be valid package versions.

This can be demonstrated several ways; besides my expectation on the parameter value that the puppet-agent class receives, you could also add values like `1.3.5banana` (from the array of versions expected to be invalid) to the array of versions expected to be valid, in any position but the last one, and see that the tests do not fail as they should.

I've spent several hours fidgeting and trying to determine why this is the case, but I am unfamiliar with ruby and the underlying issue probably requires a deep knowledge of ruby and/or this testing framework. I need to move on, but wanted to bring to the maintainers' attention that the test suite is not actually checking all the inputs it appears to be checking.