### PR TITLE
(MODULES-6708) Pin inifile module to <= 2.1.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,7 +4,9 @@ fixtures:
       repo: "puppetlabs/stdlib"
       ref: "4.12.0"
     transition: "puppetlabs/transition"
-    inifile: "puppetlabs/inifile"
+    inifile: 
+      repo: "puppetlabs/inifile"
+      ref: "2.1.0"
     apt:
       repo: "puppetlabs/apt"
       ref: "2.3.0"

--- a/metadata.json
+++ b/metadata.json
@@ -129,7 +129,7 @@
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
     {"name":"puppetlabs-transition","version_requirement":">= 0.1.1 < 0.2.0"},
-    {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0 < 3.0.0"},
+    {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0 <= 2.1.0"},
     {"name":"puppetlabs-apt","version_requirement":">= 2.0.1 <= 4.1.0"}
   ]
 }


### PR DESCRIPTION
 - To support older platforms with older Ruby versions that are being
   upgraded from, pin back to an older version of inifile that doesn't
   introduce incompatibilities with older Ruby runtime versions.

   In version 2.2.0 of the inifile module, Ruby 2.0+ constructs for
   named arguments were introduced which will break this modules
   behavior.

   Guard against that so that tests may pass.