### PR TITLE
(MODULES-6717) Configure 1.x branch for last 3.8 compatible release

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,8 +3,11 @@ fixtures:
     stdlib:
       repo: "puppetlabs/stdlib"
       ref: "4.12.0"
-    transition: "puppetlabs/transition"
-    inifile: "puppetlabs/inifile"
+    transition:
+      repo: "puppetlabs/transition"
+    inifile:
+      repo: "puppetlabs/inifile"
+      ref: "2.1.0"
     apt:
       repo: "puppetlabs/apt"
       ref: "2.3.0"

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,71 +1,78 @@
 ---
-.gitignore:
-  paths:
-    - '.*.sw?'
+  .gitignore:
+    paths:
+      - '.*.sw?'
 
-# The Travis and Appveyor configurations for puppet_agent don't fit
-# in the module_sync model yet
-.travis.yml:
-  unmanaged: true
+  # The Travis and Appveyor configurations for puppet_agent don't fit
+  # in the module_sync model yet
+  .travis.yml:
+    unmanaged: true
 
-# Requires the bundler_args to be supported.
-# .travis.yml:
-#   dist: trusty
-#   script: 'bundle exec rake $CHECK'
-#   before_install:
-#     - bundle -v
-#     - rm Gemfile.lock || true
-#     - gem update --system
-#     - gem --version
-#     - bundle -v
-#   docker_sets:
-#   includes:
-#     # Disabling 1.8.7 as it no longer plays nice
-#     # - rvm: 1.8.7
-#     #   env: PUPPET_GEM_VERSION="~> 3.7.5"
-#     # - rvm: 1.8.7
-#     #   env: PUPPET_GEM_VERSION="~> 3.8.1"
-#     # Disabling as puppet-module-gems only supports ruby >= 2.1.X
-#     # - rvm: 1.9.3
-#     #   env: PUPPET_GEM_VERSION="~> 3.8.1"  FUTURE_PARSER="yes"
+  # Requires the bundler_args to be supported.
+  # .travis.yml:
+  #   dist: trusty
+  #   script: 'bundle exec rake $CHECK'
+  #   before_install:
+  #     - bundle -v
+  #     - rm Gemfile.lock || true
+  #     - gem update --system
+  #     - gem --version
+  #     - bundle -v
+  #   docker_sets:
+  #   includes:
+  #     # Disabling 1.8.7 as it no longer plays nice
+  #     # - rvm: 1.8.7
+  #     #   env: PUPPET_GEM_VERSION="~> 3.7.5"
+  #     # - rvm: 1.8.7
+  #     #   env: PUPPET_GEM_VERSION="~> 3.8.1"
+  #     # Disabling as puppet-module-gems only supports ruby >= 2.1.X
+  #     # - rvm: 1.9.3
+  #     #   env: PUPPET_GEM_VERSION="~> 3.8.1"  FUTURE_PARSER="yes"
 
-#     - rvm: 2.4.1
-#       env: CHECK="validate lint"
-#     - rvm: 2.1.0
-#       env: PUPPET_GEM_VERSION="~> 3.8" FUTURE_PARSER="yes" CHECK=spec
-#     - rvm: 2.1.5
-#       env: PUPPET_GEM_VERSION="~> 4.0.0" CHECK=spec
-#     - rvm: 2.1.9
-#       env: PUPPET_GEM_VERSION="4.7.1" HIERA_GEM_VERSION="3.2.2" CHECK=spec
-#     - rvm: 2.1.9
-#       env: PUPPET_GEM_VERSION="~> 4.10" CHECK=spec
-#     - rvm: 2.4.1
-#       env: PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
+  #     - rvm: 2.4.1
+  #       env: CHECK="validate lint"
+  #     - rvm: 2.1.0
+  #       env: PUPPET_GEM_VERSION="~> 3.8" FUTURE_PARSER="yes" CHECK=spec
+  #     - rvm: 2.1.5
+  #       env: PUPPET_GEM_VERSION="~> 4.0.0" CHECK=spec
+  #     - rvm: 2.1.9
+  #       env: PUPPET_GEM_VERSION="4.7.1" HIERA_GEM_VERSION="3.2.2" CHECK=spec
+  #     - rvm: 2.1.9
+  #       env: PUPPET_GEM_VERSION="~> 4.10" CHECK=spec
+  #     - rvm: 2.4.1
+  #       env: PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
 
-appveyor.yml:
-  unmanaged: true
+  Gemfile:
+    optional:
+      ':development':
+        # Ping rspec-puppet 2.6.9 until https://github.com/rodjek/rspec-puppet/issues/663 is fixed
+        - gem: 'rspec-puppet'
+          version: '2.6.9'
 
-# The default.yml file should not be updated yet as it doesn't fit
-# in the module_sync model yet
-'spec/acceptance/nodesets/default.yml':
-  unmanaged: true
+  appveyor.yml:
+    unmanaged: true
 
-Rakefile:
-  extra_disabled_lint_checks:
-  - 'disable_140chars'
-  - 'disable_puppet_url_without_modules'
-  - 'disable_class_inherits_from_params_class'
-  - 'disable_documentation'
-  - 'disable_single_quote_string_with_variables'
-  - 'disable_only_variable_string'
+  # The default.yml file should not be updated yet as it doesn't fit
+  # in the module_sync model yet
+  'spec/acceptance/nodesets/default.yml':
+    unmanaged: true
 
-.gitattributes:
-  # Currently the only ERB template is for the Windows install
-  # batch file and should always be CRLF
-  exclude:
-  - "*.erb"
+  Rakefile:
+    extra_disabled_lint_checks:
+    - 'disable_140chars'
+    - 'disable_puppet_url_without_modules'
+    - 'disable_class_inherits_from_params_class'
+    - 'disable_documentation'
+    - 'disable_single_quote_string_with_variables'
+    - 'disable_only_variable_string'
 
-NOTICE:
-  copyright_holders:
-    - name: 'Puppet, Inc.'
-      begin: 2015
+  .gitattributes:
+    # Currently the only ERB template is for the Windows install
+    # batch file and should always be CRLF
+    exclude:
+    - "*.erb"
+
+  NOTICE:
+    copyright_holders:
+      - name: 'Puppet, Inc.'
+        begin: 2015

--- a/Gemfile
+++ b/Gemfile
@@ -49,16 +49,17 @@ group :development do
   gem "json_pure", '<= 2.0.1',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
   gem "fast_gettext", '1.1.0',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
   gem "fast_gettext",                                     :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
+  gem "rspec-puppet", "2.6.9",                            :require => false
 end
 
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}",                            :require => false, :platforms => "ruby"
   gem "puppet-module-win-system-r#{minor_version}",                              :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')                  
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')
   gem "beaker-pe",                                                               :require => false
-  gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])                
+  gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
-  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
+  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')
   gem "puppet-blacksmith", '~> 3.4',                                             :require => false
 end
 

--- a/metadata.json
+++ b/metadata.json
@@ -130,6 +130,6 @@
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
     {"name":"puppetlabs-transition","version_requirement":">= 0.1.1 < 0.2.0"},
     {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0 < 3.0.0"},
-    {"name":"puppetlabs-apt","version_requirement":">= 2.0.1 <= 4.1.0"}
+    {"name":"puppetlabs-apt","version_requirement":">= 2.0.1 < 3.0.0"}
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -129,7 +129,7 @@
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
     {"name":"puppetlabs-transition","version_requirement":">= 0.1.1 < 0.2.0"},
-    {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0 < 3.0.0"},
+    {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0 <= 2.1.0"},
     {"name":"puppetlabs-apt","version_requirement":">= 2.0.1 < 3.0.0"}
   ]
 }

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -5,12 +5,6 @@ describe 'puppet_agent' do
     :lsbdistid => 'Debian',
     :osfamily => 'Debian',
     :lsbdistcodename => 'wheezy',
-    :os => {
-      'name' => 'Debian',
-      'release' => {
-        'full' => '6.0',
-      },
-    },
     :operatingsystem => 'Debian',
     :architecture => 'x64',
       :servername   => 'master.example.vm',
@@ -93,12 +87,6 @@ describe 'puppet_agent' do
           :platform_tag => 'ubuntu-1604-x86_64',
           :operatingsystem => 'Ubuntu',
           :lsbdistcodename => 'xenial',
-          :os => {
-            'name' => 'Ubuntu',
-            'release' => {
-              'full' => '16.04',
-            },
-          },
         })
       }
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -30,10 +30,10 @@ end
 def install_modules_on(host)
   install_ca_certs_on(host)
   puppet_module_install_on(host, :source => PROJ_ROOT, :module_name => 'puppet_agent')
-  on host, puppet('module', 'install', 'puppetlabs-stdlib'), {:acceptable_exit_codes => [0]}
-  on host, puppet('module', 'install', 'puppetlabs-inifile'), {:acceptable_exit_codes => [0]}
-  on host, puppet('module', 'install', 'puppetlabs-apt'), {:acceptable_exit_codes => [0]}
-  on host, puppet('module', 'install', 'puppetlabs-transition'), {:acceptable_exit_codes => [0]}
+  on host, puppet('module', 'install', 'puppetlabs-stdlib', '--version', '4.12.0'), {:acceptable_exit_codes => [0]}
+  on host, puppet('module', 'install', 'puppetlabs-inifile', '--version', '2.1.0'), {:acceptable_exit_codes => [0]}
+  on host, puppet('module', 'install', 'puppetlabs-apt', '--version', '2.3.0'), {:acceptable_exit_codes => [0]}
+  on host, puppet('module', 'install', 'puppetlabs-transition', '--version', '0.1.1'), {:acceptable_exit_codes => [0]}
 end
 
 unless ENV['BEAKER_provision'] == 'no'
@@ -210,7 +210,7 @@ def teardown_puppet_on(host)
   # the machine after each run.
   case host['platform']
     when /debian|ubuntu/
-      on host, '/opt/puppetlabs/bin/puppet module install puppetlabs-apt', {:acceptable_exit_codes => [0, 1]}
+      on host, '/opt/puppetlabs/bin/puppet module install puppetlabs-apt --version 2.3.0', {:acceptable_exit_codes => [0, 1]}
       clean_repo = "include apt\napt::source { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"
     when /fedora|el|centos/
       clean_repo = "yumrepo { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,5 +1,6 @@
 require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
+require 'beaker/ca_cert_helper'
 require 'erb'
 
 def stop_firewall_on(host)
@@ -27,11 +28,12 @@ def activemq_host
 end
 
 def install_modules_on(host)
+  install_ca_certs_on(host)
   puppet_module_install_on(host, :source => PROJ_ROOT, :module_name => 'puppet_agent')
-  on host, puppet('module', 'install', 'puppetlabs-stdlib'), {:acceptable_exit_codes => [0, 1]}
-  on host, puppet('module', 'install', 'puppetlabs-inifile'), {:acceptable_exit_codes => [0, 1]}
-  on host, puppet('module', 'install', 'puppetlabs-apt'), {:acceptable_exit_codes => [0, 1]}
-  on host, puppet('module', 'install', 'puppetlabs-transition'), {:acceptable_exit_codes => [0, 1]}
+  on host, puppet('module', 'install', 'puppetlabs-stdlib'), {:acceptable_exit_codes => [0]}
+  on host, puppet('module', 'install', 'puppetlabs-inifile'), {:acceptable_exit_codes => [0]}
+  on host, puppet('module', 'install', 'puppetlabs-apt'), {:acceptable_exit_codes => [0]}
+  on host, puppet('module', 'install', 'puppetlabs-transition'), {:acceptable_exit_codes => [0]}
 end
 
 unless ENV['BEAKER_provision'] == 'no'


### PR DESCRIPTION
* Reverts commits not compatible with Puppet 3.8
* Pins dependent modules to Puppet 3.8 compatible versions
* Installs CA certs required on Windows for downloading from the Forge.