### PR TITLE
(MODULES-6717) Mergeback 1.x to Master and remove Puppet 3.8

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,8 +3,11 @@ fixtures:
     stdlib:
       repo: "puppetlabs/stdlib"
       ref: "4.12.0"
-    transition: "puppetlabs/transition"
-    inifile: "puppetlabs/inifile"
+    transition:
+      repo: "puppetlabs/transition"
+    inifile:
+      repo: "puppetlabs/inifile"
+      ref: "2.1.0"
     apt:
       repo: "puppetlabs/apt"
       ref: "2.3.0"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,7 @@ fixtures:
   forge_modules:
     stdlib:
       repo: "puppetlabs/stdlib"
-      ref: "4.12.0"
+      ref: "4.16.0"
     transition:
       repo: "puppetlabs/transition"
     inifile:
@@ -10,6 +10,6 @@ fixtures:
       ref: "2.1.0"
     apt:
       repo: "puppetlabs/apt"
-      ref: "2.3.0"
+      ref: "4.1.0"
   symlinks:
     puppet_agent: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -10,6 +10,6 @@ fixtures:
       ref: "2.1.0"
     apt:
       repo: "puppetlabs/apt"
-      ref: "4.1.0"
+      ref: "4.4.0"
   symlinks:
     puppet_agent: "#{source_dir}"

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,71 +1,78 @@
 ---
-.gitignore:
-  paths:
-    - '.*.sw?'
+  .gitignore:
+    paths:
+      - '.*.sw?'
 
-# The Travis and Appveyor configurations for puppet_agent don't fit
-# in the module_sync model yet
-.travis.yml:
-  unmanaged: true
+  # The Travis and Appveyor configurations for puppet_agent don't fit
+  # in the module_sync model yet
+  .travis.yml:
+    unmanaged: true
 
-# Requires the bundler_args to be supported.
-# .travis.yml:
-#   dist: trusty
-#   script: 'bundle exec rake $CHECK'
-#   before_install:
-#     - bundle -v
-#     - rm Gemfile.lock || true
-#     - gem update --system
-#     - gem --version
-#     - bundle -v
-#   docker_sets:
-#   includes:
-#     # Disabling 1.8.7 as it no longer plays nice
-#     # - rvm: 1.8.7
-#     #   env: PUPPET_GEM_VERSION="~> 3.7.5"
-#     # - rvm: 1.8.7
-#     #   env: PUPPET_GEM_VERSION="~> 3.8.1"
-#     # Disabling as puppet-module-gems only supports ruby >= 2.1.X
-#     # - rvm: 1.9.3
-#     #   env: PUPPET_GEM_VERSION="~> 3.8.1"  FUTURE_PARSER="yes"
+  # Requires the bundler_args to be supported.
+  # .travis.yml:
+  #   dist: trusty
+  #   script: 'bundle exec rake $CHECK'
+  #   before_install:
+  #     - bundle -v
+  #     - rm Gemfile.lock || true
+  #     - gem update --system
+  #     - gem --version
+  #     - bundle -v
+  #   docker_sets:
+  #   includes:
+  #     # Disabling 1.8.7 as it no longer plays nice
+  #     # - rvm: 1.8.7
+  #     #   env: PUPPET_GEM_VERSION="~> 3.7.5"
+  #     # - rvm: 1.8.7
+  #     #   env: PUPPET_GEM_VERSION="~> 3.8.1"
+  #     # Disabling as puppet-module-gems only supports ruby >= 2.1.X
+  #     # - rvm: 1.9.3
+  #     #   env: PUPPET_GEM_VERSION="~> 3.8.1"  FUTURE_PARSER="yes"
 
-#     - rvm: 2.4.1
-#       env: CHECK="validate lint"
-#     - rvm: 2.1.0
-#       env: PUPPET_GEM_VERSION="~> 3.8" FUTURE_PARSER="yes" CHECK=spec
-#     - rvm: 2.1.5
-#       env: PUPPET_GEM_VERSION="~> 4.0.0" CHECK=spec
-#     - rvm: 2.1.9
-#       env: PUPPET_GEM_VERSION="4.7.1" HIERA_GEM_VERSION="3.2.2" CHECK=spec
-#     - rvm: 2.1.9
-#       env: PUPPET_GEM_VERSION="~> 4.10" CHECK=spec
-#     - rvm: 2.4.1
-#       env: PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
+  #     - rvm: 2.4.1
+  #       env: CHECK="validate lint"
+  #     - rvm: 2.1.0
+  #       env: PUPPET_GEM_VERSION="~> 3.8" FUTURE_PARSER="yes" CHECK=spec
+  #     - rvm: 2.1.5
+  #       env: PUPPET_GEM_VERSION="~> 4.0.0" CHECK=spec
+  #     - rvm: 2.1.9
+  #       env: PUPPET_GEM_VERSION="4.7.1" HIERA_GEM_VERSION="3.2.2" CHECK=spec
+  #     - rvm: 2.1.9
+  #       env: PUPPET_GEM_VERSION="~> 4.10" CHECK=spec
+  #     - rvm: 2.4.1
+  #       env: PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
 
-appveyor.yml:
-  unmanaged: true
+  Gemfile:
+    optional:
+      ':development':
+        # Ping rspec-puppet 2.6.9 until https://github.com/rodjek/rspec-puppet/issues/663 is fixed
+        - gem: 'rspec-puppet'
+          version: '2.6.9'
 
-# The default.yml file should not be updated yet as it doesn't fit
-# in the module_sync model yet
-'spec/acceptance/nodesets/default.yml':
-  unmanaged: true
+  appveyor.yml:
+    unmanaged: true
 
-Rakefile:
-  extra_disabled_lint_checks:
-  - 'disable_140chars'
-  - 'disable_puppet_url_without_modules'
-  - 'disable_class_inherits_from_params_class'
-  - 'disable_documentation'
-  - 'disable_single_quote_string_with_variables'
-  - 'disable_only_variable_string'
+  # The default.yml file should not be updated yet as it doesn't fit
+  # in the module_sync model yet
+  'spec/acceptance/nodesets/default.yml':
+    unmanaged: true
 
-.gitattributes:
-  # Currently the only ERB template is for the Windows install
-  # batch file and should always be CRLF
-  exclude:
-  - "*.erb"
+  Rakefile:
+    extra_disabled_lint_checks:
+    - 'disable_140chars'
+    - 'disable_puppet_url_without_modules'
+    - 'disable_class_inherits_from_params_class'
+    - 'disable_documentation'
+    - 'disable_single_quote_string_with_variables'
+    - 'disable_only_variable_string'
 
-NOTICE:
-  copyright_holders:
-    - name: 'Puppet, Inc.'
-      begin: 2015
+  .gitattributes:
+    # Currently the only ERB template is for the Windows install
+    # batch file and should always be CRLF
+    exclude:
+    - "*.erb"
+
+  NOTICE:
+    copyright_holders:
+      - name: 'Puppet, Inc.'
+        begin: 2015

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,6 @@ matrix:
   include:
   - rvm: 2.4.1
     env: CHECK="validate lint"
-  - rvm: 2.1.0
-    env: PUPPET_GEM_VERSION="~> 3.8" FUTURE_PARSER="yes" CHECK=spec
-  - rvm: 2.1.5
-    env: PUPPET_GEM_VERSION="~> 4.0.0" CHECK=spec
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="4.7.1" HIERA_GEM_VERSION="3.2.2" CHECK=spec
   - rvm: 2.1.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.6.0] - 2018-03-21
+
+### Summary
+This is the last release that will support Puppet 3.x
+
+### Features
+- Make management of /etc/pki directory optional ([MODULES-6068](https://tickets.puppetlabs.com/browse/MODULES-6068))
+- OSX 10.13 is now supported
+- RHEL 7 AArch64 is now supported
+
+### Bug fixes
+- Fix version tag on Amazon Linux ([MODULES-5637](https://tickets.puppetlabs.com/browse/MODULES-5637))
+- Stop all services prior to upgrading on Windows ([PE-23563](https://tickets.puppetlabs.com/browse/PE-23563))
+- Output token privileges for current user on Windows
+- Update testing matrix
+- Pin resources for Puppet 3.x compatibility ([MODULES-6708](https://tickets.puppetlabs.com/browse/MODULES-6708), [MODULES-6717](https://tickets.puppetlabs.com/browse/MODULES-6717))
+- Pin rspec-puppet to 2.6 due to bug in rspec-puppet ([MODULES-6717](https://tickets.puppetlabs.com/browse/MODULES-6717))
+
 ## [1.5.0] - 2017-11-29
 
 ### Summary
@@ -88,7 +106,7 @@ Carried-over from prior releases:
 ## [1.3.0] - 2016-10-19
 
 ### Summary
-The addition of several OS support features and a considerable amount of compatibility and bug fixes. 
+The addition of several OS support features and a considerable amount of compatibility and bug fixes.
 
 ### Known issues
 Carried-over from prior releases:
@@ -163,7 +181,7 @@ in some environments.
 ## [1.1.0] - 2016-03-01
 
 ### Summary
-The addition of several OS support features and a considerable amount of compatibility and bug fixes. 
+The addition of several OS support features and a considerable amount of compatibility and bug fixes.
 
 ### Known issues
 While this release adds considerable features and bug fixes the following areas are known issues and require more work:

--- a/Gemfile
+++ b/Gemfile
@@ -49,16 +49,17 @@ group :development do
   gem "json_pure", '<= 2.0.1',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
   gem "fast_gettext", '1.1.0',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
   gem "fast_gettext",                                     :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
+  gem "rspec-puppet", "2.6.9",                            :require => false
 end
 
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}",                            :require => false, :platforms => "ruby"
   gem "puppet-module-win-system-r#{minor_version}",                              :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')                  
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')
   gem "beaker-pe",                                                               :require => false
-  gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])                
+  gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
-  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
+  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')
   gem "puppet-blacksmith", '~> 3.4',                                             :require => false
 end
 

--- a/README.markdown
+++ b/README.markdown
@@ -21,7 +21,7 @@
 
 ## Overview
 
-A module for upgrading Puppet agents. Supports upgrading from Puppet 3 packages and puppet-agent packages, to puppet-agent packages (i.e. Puppet 4).
+A module for upgrading Puppet agents. Supports upgrading from Puppet 4 puppet-agent packages to later versions.
 
 ## Module Description
 
@@ -30,8 +30,6 @@ The puppet_agent module installs the Puppet Collection 1 repo (as a default, and
 If a package_version parameter is provided, it will ensure that puppet-agent version is installed. The package_version parameter is required to perform upgrades starting from a puppet-agent (Puppet 4) package.
 
 This module expects Puppet to be installed from packages.
-
-Note: this is the last release that will support Puppet 3 and Ruby <2.1.
 
 ## Setup
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@
 #   Install from Puppet Enterprise repos. Enabled if communicating with a PE master.
 # [manage_pki_dir]
 #   Whether or not to manage the /etc/pki directory.  Defaults to true.
-#   Managing the /etc/pki directory inside the puppet_agent module can be problematic for 
+#   Managing the /etc/pki directory inside the puppet_agent module can be problematic for
 #   organizations that manage gpg keys and settings in other modules.
 # [manage_repo]
 #   Boolean to determine whether to configure repositories
@@ -53,22 +53,20 @@
 #   will move files prior to installation that are known to cause file locks.
 #
 class puppet_agent (
-  $arch                  = $::architecture,
-  $collection            = 'PC1',
-  $is_pe                 = $::puppet_agent::params::_is_pe,
-  $manage_pki_dir        = true,
-  $manage_repo           = true,
-  $package_name          = $::puppet_agent::params::package_name,
-  $package_version       = $::puppet_agent::params::package_version,
-  $service_names         = $::puppet_agent::params::service_names,
-  $source                = $::puppet_agent::params::_source,
-  $install_dir           = $::puppet_agent::params::install_dir,
-  $disable_proxy         = false,
-  $install_options       = $::puppet_agent::params::install_options,
-  $msi_move_locked_files = false,
+  Puppet_agent::Arch $arch = $::architecture,
+  $collection              = 'PC1',
+  $is_pe                   = $::puppet_agent::params::_is_pe,
+  $manage_pki_dir          = true,
+  $manage_repo             = true,
+  $package_name            = $::puppet_agent::params::package_name,
+  $package_version         = $::puppet_agent::params::package_version,
+  $service_names           = $::puppet_agent::params::service_names,
+  $source                  = $::puppet_agent::params::_source,
+  $install_dir             = $::puppet_agent::params::install_dir,
+  $disable_proxy           = false,
+  $install_options         = $::puppet_agent::params::install_options,
+  $msi_move_locked_files   = false,
 ) inherits ::puppet_agent::params {
-
-  validate_re($arch, ['^x86$','^x64$','^i386$','^i86pc$','^amd64$','^x86_64$','^power$','^sun4[uv]$', '^ppc64le$', '^aarch64$', 'PowerPC_POWER'])
 
   if $::osfamily == 'windows' and $install_dir != undef {
     validate_absolute_path($install_dir)

--- a/metadata.json
+++ b/metadata.json
@@ -131,6 +131,6 @@
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
     {"name":"puppetlabs-transition","version_requirement":">= 0.1.1 < 0.2.0"},
     {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0 <= 2.1.0"},
-    {"name":"puppetlabs-apt","version_requirement":">= 2.0.1 <= 4.1.0"}
+    {"name":"puppetlabs-apt","version_requirement":">= 4.4.0 < 5.0.0"}
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -131,6 +131,6 @@
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
     {"name":"puppetlabs-transition","version_requirement":">= 0.1.1 < 0.2.0"},
     {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0 <= 2.1.0"},
-    {"name":"puppetlabs-apt","version_requirement":">= 2.0.1 < 3.0.0"}
+    {"name":"puppetlabs-apt","version_requirement":">= 2.0.1 <= 4.1.0"}
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -124,7 +124,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.7.0 < 6.0.0"
+      "version_requirement": ">= 4.7.0 < 6.0.0"
     }
   ],
   "dependencies": [

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-puppet_agent",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": "puppetlabs",
   "summary": "Upgrades Puppet 3.7+ and All-In-One Puppet Agents",
   "license": "Apache-2.0",
@@ -103,7 +103,7 @@
     },
     {
       "operatingsystem": "AIX",
-      "operatingsystemmajrelease": [
+      "operatingsystemrelease": [
         "5.3",
         "6.1",
         "7.1",
@@ -116,7 +116,8 @@
         "10.9",
         "10.10",
         "10.11",
-        "10.12"
+        "10.12",
+        "10.13"
        ]
     }
   ],
@@ -129,7 +130,7 @@
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
     {"name":"puppetlabs-transition","version_requirement":">= 0.1.1 < 0.2.0"},
-    {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0 < 3.0.0"},
-    {"name":"puppetlabs-apt","version_requirement":">= 2.0.1 <= 4.1.0"}
+    {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0 <= 2.1.0"},
+    {"name":"puppetlabs-apt","version_requirement":">= 2.0.1 < 3.0.0"}
   ]
 }

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -5,12 +5,6 @@ describe 'puppet_agent' do
     :lsbdistid => 'Debian',
     :osfamily => 'Debian',
     :lsbdistcodename => 'wheezy',
-    :os => {
-      'name' => 'Debian',
-      'release' => {
-        'full' => '6.0',
-      },
-    },
     :operatingsystem => 'Debian',
     :architecture => 'x64',
       :servername   => 'master.example.vm',
@@ -93,12 +87,6 @@ describe 'puppet_agent' do
           :platform_tag => 'ubuntu-1604-x86_64',
           :operatingsystem => 'Ubuntu',
           :lsbdistcodename => 'xenial',
-          :os => {
-            'name' => 'Ubuntu',
-            'release' => {
-              'full' => '16.04',
-            },
-          },
         })
       }
 

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -5,6 +5,12 @@ describe 'puppet_agent' do
     :lsbdistid => 'Debian',
     :osfamily => 'Debian',
     :lsbdistcodename => 'wheezy',
+    :os => {
+      'name' => 'Debian',
+      'release' => {
+        'full' => '6.0',
+      },
+    },
     :operatingsystem => 'Debian',
     :architecture => 'x64',
       :servername   => 'master.example.vm',
@@ -87,6 +93,12 @@ describe 'puppet_agent' do
           :platform_tag => 'ubuntu-1604-x86_64',
           :operatingsystem => 'Ubuntu',
           :lsbdistcodename => 'xenial',
+          :os => {
+            'name' => 'Ubuntu',
+            'release' => {
+              'full' => '16.04',
+            },
+          },
         })
       }
 

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -9,6 +9,7 @@ describe 'puppet_agent' do
       'name' => 'Debian',
       'release' => {
         'full' => '6.0',
+        'major' => '6',
       },
     },
     :operatingsystem => 'Debian',

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -30,9 +30,9 @@ end
 def install_modules_on(host)
   install_ca_certs_on(host)
   puppet_module_install_on(host, :source => PROJ_ROOT, :module_name => 'puppet_agent')
-  on host, puppet('module', 'install', 'puppetlabs-stdlib', '--version', '4.12.0'), {:acceptable_exit_codes => [0]}
+  on host, puppet('module', 'install', 'puppetlabs-stdlib', '--version', '4.16.0'), {:acceptable_exit_codes => [0]}
   on host, puppet('module', 'install', 'puppetlabs-inifile', '--version', '2.1.0'), {:acceptable_exit_codes => [0]}
-  on host, puppet('module', 'install', 'puppetlabs-apt', '--version', '2.3.0'), {:acceptable_exit_codes => [0]}
+  on host, puppet('module', 'install', 'puppetlabs-apt', '--version', '4.1.0'), {:acceptable_exit_codes => [0]}
   on host, puppet('module', 'install', 'puppetlabs-transition', '--version', '0.1.1'), {:acceptable_exit_codes => [0]}
 end
 
@@ -210,7 +210,7 @@ def teardown_puppet_on(host)
   # the machine after each run.
   case host['platform']
     when /debian|ubuntu/
-      on host, '/opt/puppetlabs/bin/puppet module install puppetlabs-apt --version 2.3.0', {:acceptable_exit_codes => [0, 1]}
+      on host, '/opt/puppetlabs/bin/puppet module install puppetlabs-apt --version 4.1.0', {:acceptable_exit_codes => [0, 1]}
       clean_repo = "include apt\napt::source { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"
     when /fedora|el|centos/
       clean_repo = "yumrepo { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -32,7 +32,7 @@ def install_modules_on(host)
   puppet_module_install_on(host, :source => PROJ_ROOT, :module_name => 'puppet_agent')
   on host, puppet('module', 'install', 'puppetlabs-stdlib', '--version', '4.16.0'), {:acceptable_exit_codes => [0]}
   on host, puppet('module', 'install', 'puppetlabs-inifile', '--version', '2.1.0'), {:acceptable_exit_codes => [0]}
-  on host, puppet('module', 'install', 'puppetlabs-apt', '--version', '4.1.0'), {:acceptable_exit_codes => [0]}
+  on host, puppet('module', 'install', 'puppetlabs-apt', '--version', '4.4.0'), {:acceptable_exit_codes => [0]}
   on host, puppet('module', 'install', 'puppetlabs-transition', '--version', '0.1.1'), {:acceptable_exit_codes => [0]}
 end
 
@@ -210,7 +210,7 @@ def teardown_puppet_on(host)
   # the machine after each run.
   case host['platform']
     when /debian|ubuntu/
-      on host, '/opt/puppetlabs/bin/puppet module install puppetlabs-apt --version 4.1.0', {:acceptable_exit_codes => [0, 1]}
+      on host, '/opt/puppetlabs/bin/puppet module install puppetlabs-apt --version 4.4.0', {:acceptable_exit_codes => [0, 1]}
       clean_repo = "include apt\napt::source { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"
     when /fedora|el|centos/
       clean_repo = "yumrepo { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,5 +1,6 @@
 require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
+require 'beaker/ca_cert_helper'
 require 'erb'
 
 def stop_firewall_on(host)
@@ -27,11 +28,12 @@ def activemq_host
 end
 
 def install_modules_on(host)
+  install_ca_certs_on(host)
   puppet_module_install_on(host, :source => PROJ_ROOT, :module_name => 'puppet_agent')
-  on host, puppet('module', 'install', 'puppetlabs-stdlib'), {:acceptable_exit_codes => [0, 1]}
-  on host, puppet('module', 'install', 'puppetlabs-inifile'), {:acceptable_exit_codes => [0, 1]}
-  on host, puppet('module', 'install', 'puppetlabs-apt'), {:acceptable_exit_codes => [0, 1]}
-  on host, puppet('module', 'install', 'puppetlabs-transition'), {:acceptable_exit_codes => [0, 1]}
+  on host, puppet('module', 'install', 'puppetlabs-stdlib', '--version', '4.12.0'), {:acceptable_exit_codes => [0]}
+  on host, puppet('module', 'install', 'puppetlabs-inifile', '--version', '2.1.0'), {:acceptable_exit_codes => [0]}
+  on host, puppet('module', 'install', 'puppetlabs-apt', '--version', '2.3.0'), {:acceptable_exit_codes => [0]}
+  on host, puppet('module', 'install', 'puppetlabs-transition', '--version', '0.1.1'), {:acceptable_exit_codes => [0]}
 end
 
 unless ENV['BEAKER_provision'] == 'no'
@@ -208,7 +210,7 @@ def teardown_puppet_on(host)
   # the machine after each run.
   case host['platform']
     when /debian|ubuntu/
-      on host, '/opt/puppetlabs/bin/puppet module install puppetlabs-apt', {:acceptable_exit_codes => [0, 1]}
+      on host, '/opt/puppetlabs/bin/puppet module install puppetlabs-apt --version 2.3.0', {:acceptable_exit_codes => [0, 1]}
       clean_repo = "include apt\napt::source { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"
     when /fedora|el|centos/
       clean_repo = "yumrepo { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"

--- a/types/arch.pp
+++ b/types/arch.pp
@@ -1,0 +1,1 @@
+type Puppet_agent::Arch = Pattern[/^x86$/,/^x64$/,/^i386$/,/^i86pc$/,/^amd64$/,/^x86_64$/,/^power$/,/^sun4[uv]$/, /^ppc64le$/, /^aarch64$/, /PowerPC_POWER/]


### PR DESCRIPTION
This PR

* Merges back 1.x into master
* Un-reverts any commits that were revertted for Puppet 3.8.x support
* Modifies metadata and Travis to drop 3.8
* Update apt to 4.4.0 and remove deprecated functions

Other PRs will come along to extract further Puppet 3.8 functionality

The minimum targetted version is now 4.7.0 (The earliest LTS agent and Puppet 4 Data Types)