### PR TITLE
(maint) Update Stdlib dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -128,7 +128,7 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 4.6.0 < 5.0.0"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 4.16.0 < 5.0.0"},
     {"name":"puppetlabs-transition","version_requirement":">= 0.1.1 < 0.2.0"},
     {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0 <= 2.1.0"},
     {"name":"puppetlabs-apt","version_requirement":">= 4.4.0 < 5.0.0"}


### PR DESCRIPTION
Previously the Stdlib module was updated in the test fixtures to support the
Puppet 4 types however this was not updated in the metadata.json. (4d9b949df8).
This commit updates the metadata to match that of the minimum test fixtures.