### PR TITLE
(MODULES-5230) Do not manage PA version on PE infra nodes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,6 +78,8 @@ class puppet_agent (
     info('puppet_agent performs no actions if a package_version is not specified on Puppet 4')
   } elsif $package_version == undef and $is_pe {
     info("puppet_agent performs no actions if the master's agent version cannot be determed on PE 3.x")
+  } elsif $facts['pe_server_version'] != undef {
+    info('puppet_agent performs no actions on PE infrastructure nodes to prevent a mismatch between agent and PE components')
   } else {
     if $package_version != undef and $package_version !~ /^\d+\.\d+\.\d+([.-]?\d*|\.\d+\.g[0-9a-f]+)$/ {
       fail("invalid version ${package_version} requested")

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -76,6 +76,14 @@ describe 'puppet_agent' do
             it { is_expected.to contain_class('puppet_agent').with_package_version(nil) }
           end
         end
+
+        context 'On a PE infrastructure node puppet_agent does nothing' do
+          before(:each) do
+            facts['pe_server_version'] = '2016.2.2'
+          end
+          it { is_expected.to_not contain_class('puppet_agent::prepare') }
+          it { is_expected.to_not contain_class('puppet_agent::install') }
+        end
       end
     end
   end


### PR DESCRIPTION
Prior to this commit, we would manage the puppet-agent version
on any node that was classified with the puppet_agent class.

After this commit, we no check to see if the node is a PE infra
node and if so print a message saying we're not going to do anything
because PE infra nodes have a specific version of puppet-agent
on them for a reason.

You would not, for instance, want your compile master to get its
agent downgraded right after you completed an upgrade of your PE
installation.