### PR TITLE
(MODULES-4271) Update Windows OSes in metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -88,13 +88,11 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "Server 2003",
-        "Server 2003 R2",
         "Server 2008",
         "Server 2008 R2",
         "Server 2012",
         "Server 2012 R2",
-        "Vista",
+        "Server 2016",
         "7",
         "8",
         "8.1",


### PR DESCRIPTION
This commit removes Windows Operating Systems that are no longer supported and
adds Server 2016.