### PR TITLE
(MODULES-6915) Remove check for PE when calculating whether to upgrade

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,9 +90,10 @@ class puppet_agent (
       $_expected_package_version = $package_version
     }
 
-    $aio_upgrade_required = ($is_pe == false and $_expected_package_version != undef) or
-      (getvar('::aio_agent_version') != undef and $_expected_package_version != undef and
-        versioncmp("${::aio_agent_version}", "${_expected_package_version}") < 0)
+    $aio_upgrade_required = (getvar('::aio_agent_version') == undef) or
+      (getvar('::aio_agent_version') != undef and
+      $_expected_package_version != undef and
+      versioncmp("${::aio_agent_version}", "${_expected_package_version}") < 0)
 
     if $::architecture == 'x86' and $arch == 'x64' {
       fail('Unable to install x64 on a x86 system')

--- a/spec/classes/puppet_agent_osfamily_solaris_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_solaris_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe 'puppet_agent' do
+  package_version = '1.2.5.90.g93a35da'
+
   facts = {
     :osfamily                  => 'Solaris',
     :operatingsystem           => 'Solaris',
@@ -10,9 +12,8 @@ describe 'puppet_agent' do
     :clientcert                => 'foo.example.vm',
     :env_temp_variable         => '/tmp',
     :puppet_agent_pid          => 42,
+    :aio_agent_version         => package_version,
   }
-
-  package_version = '1.2.5.90.g93a35da'
   # Strips out strings in the version string on Solaris 11,
   # because pkg doesn't accept strings in version numbers. This
   # is how developer builds are labelled.

--- a/spec/classes/puppet_agent_osfamily_windows_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_windows_spec.rb
@@ -33,6 +33,9 @@ describe 'puppet_agent' do
         :puppet_confdir       => "#{appdata}\\Puppetlabs\\puppet\\etc",
         :mco_confdir          => "#{appdata}\\Puppetlabs\\mcollective\\etc",
         :puppet_agent_appdata => appdata,
+        :env_temp_variable => 'C:/tmp',
+        :puppet_agent_pid     => 42,
+        :aio_agent_version    => '1.0.0',
       }}
 
       it { is_expected.to contain_file("#{appdata}\\Puppetlabs") }


### PR DESCRIPTION
On FOSS Windows specifically, the agent would continue to upgrade on
every puppet run. This removes a code path that would behave differently
for PE vs. FOSS, and actually perform a version check.