### PR TITLE
(MODULES-7167) Prepare for 1.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.6.1] - 2018-05-18
+
+### Summary
+Minor bugfix release
+
+### Bug fixes
+- Do not manage PA version on PE infra nodes ([MODULES-5230](https://tickets.puppetlabs.com/browse/MODULES-5230))
+
 ## [1.6.0] - 2018-03-21
 
 ### Summary

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-puppet_agent",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": "puppetlabs",
   "summary": "Upgrades Puppet 3.7+ and All-In-One Puppet Agents",
   "license": "Apache-2.0",


### PR DESCRIPTION
This commit prepares the module for a version 1.6.1 release.

Note that this is targetted directly on the `1.x` branch not `release` as the 1.x branch is end-of-life