### PR TITLE
Enable support for inifile 2.2.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -7,7 +7,7 @@ fixtures:
       repo: "puppetlabs/transition"
     inifile:
       repo: "puppetlabs/inifile"
-      ref: "2.1.0"
+      ref: "2.2.2"
     apt:
       repo: "puppetlabs/apt"
       ref: "4.4.0"

--- a/metadata.json
+++ b/metadata.json
@@ -128,7 +128,7 @@
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.16.0 < 5.0.0"},
     {"name":"puppetlabs-transition","version_requirement":">= 0.1.1 < 0.2.0"},
-    {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0 <= 2.1.0"},
+    {"name":"puppetlabs-inifile","version_requirement":">= 1.2.0 <= 2.3.0"},
     {"name":"puppetlabs-apt","version_requirement":">= 4.4.0 < 5.0.0"}
   ]
 }


### PR DESCRIPTION
inifile 2.2 is backwards compatible with 2.1, and is working fine in my environments