### PR TITLE
[MODULES-4195] Install AIX 6.1 RPMs on all AIX versions for puppet6

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -130,9 +130,15 @@ class puppet_agent (
       $_package_file_name = "${puppet_agent::package_name}-${package_version}-1.osx${$::macosx_productversion_major}.dmg"
     } elsif $::operatingsystem == 'AIX' {
       $_aix_ver_number = regsubst($::platform_tag,'aix-(\d+\.\d+)-power','\1')
-      $aix_ver_number = $_aix_ver_number ? {
-        /^7\.2$/ => '7.1',
-        default  => $_aix_ver_number,
+      if $_aix_ver_number {
+        if $collection =~ /(PC1|puppet5)/ {
+          $aix_ver_number = $_aix_ver_number ? {
+            /^7\.2$/ => '7.1',
+            default  => $_aix_ver_number,
+          }
+        } else {
+          $aix_ver_number = '6.1'
+        }
       }
       $_package_file_name = "${puppet_agent::package_name}-${package_version}-1.aix${aix_ver_number}.ppc.rpm"
     } elsif $::osfamily == 'windows' {

--- a/manifests/prepare/package.pp
+++ b/manifests/prepare/package.pp
@@ -24,10 +24,16 @@ class puppet_agent::prepare::package(
       }
       $source = "puppet:///pe_packages/${pe_server_version}/${tag}/${package_file_name}"
     } elsif $::operatingsystem == 'AIX' {
-      $tag = $::platform_tag ? {
-        'aix-7.2-power' => 'aix-7.1-power',
-        default         => $::platform_tag,
+      if $::puppet_agent::collection =~ /(PC1|puppet5)/ {
+        $tag = $::platform_tag ? {
+          'aix-7.2-power' => 'aix-7.1-power',
+          default         => $::platform_tag,
+        }
+      } else {
+        # From puppet6 onward, AIX 6.1 packages are used for all AIX platforms
+        $tag = 'aix-6.1-power'
       }
+
       $source = "puppet:///pe_packages/${pe_server_version}/${tag}/${package_file_name}"
     } else {
       $source = "puppet:///pe_packages/${pe_server_version}/${::platform_tag}/${package_file_name}"

--- a/spec/classes/puppet_agent_osfamily_aix_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_aix_spec.rb
@@ -1,108 +1,132 @@
 require 'spec_helper'
 
-
 describe 'puppet_agent' do
-  before(:each) do
-    Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
-      "4.0.0"
-    end
-
-    Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
-      '1.2.5'
-    end
-  end
-
-  package_version = '1.2.5'
-  package_ensure = Puppet.version < "4.0.0" ? 'present' : package_version
-  let(:params) do
+  let(:common_facts) {
     {
-      :package_version => package_version
+      is_pe:           true,
+      osfamily:        'AIX',
+      operatingsystem: 'AIX',
+      servername:      'master.example.vm',
+      clientcert:      'foo.example.vm',
     }
-  end
-
-  facts = {
-    :is_pe           => true,
-    :osfamily        => 'AIX',
-    :operatingsystem => 'AIX',
-    :servername      => 'master.example.vm',
-    :clientcert      => 'foo.example.vm',
   }
 
-  [['7.2', '7.1', '8'], ['7.1', '7.1', '8'], ['7.1', '7.1', '7'], ['6.1', '6.1', '7'], ['5.3', '5.3', '7']].each do |aixver, pkgver, powerver|
-    context "aix #{aixver}" do
+  shared_examples 'aix' do |aixver, pkg_aixver, powerver|
+    let(:rpmname) {"puppet-agent-#{params[:package_version]}-1.aix#{pkg_aixver}.ppc.rpm"}
+    let(:tag) { "aix-#{pkg_aixver}-power" }
+    let(:source) { "puppet:///pe_packages/4.0.0/#{tag}/#{rpmname}" }
+    let(:facts) {
+      common_facts.merge({
+        architecture: "PowerPC_POWER#{powerver}",
+        platform_tag: "aix-#{aixver}-power",
+      })
+    }
 
-      let(:facts) do
-        facts.merge({
-          :architecture    => "PowerPC_POWER#{powerver}",
-          :platform_tag    => "aix-#{aixver}-power"
-        })
+    before(:each) do
+      Puppet::Parser::Functions.newfunction(:pe_build_version, type: :rvalue) { |_args| '4.0.0' }
+      Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, type: :rvalue) { |_args| 'x.y.z' }
+    end
+
+    if Puppet.version < "4.0.0"
+      it { is_expected.to contain_file('/etc/puppetlabs/puppet') }
+      it { is_expected.to contain_file('/etc/puppetlabs/puppet/puppet.conf') }
+
+      it do
+        is_expected.to contain_exec('replace puppet.conf removed by package removal').with_command('cp /etc/puppetlabs/puppet/puppet.conf.rpmsave /etc/puppetlabs/puppet/puppet.conf')
+        is_expected.to contain_exec('replace puppet.conf removed by package removal').with_creates('/etc/puppetlabs/puppet/puppet.conf')
       end
+    end
 
-      rpmname = "puppet-agent-#{package_version}-1.aix#{pkgver}.ppc.rpm"
-      tag = "aix-#{pkgver}-power"
-      source = "puppet:///pe_packages/4.0.0/#{tag}/#{rpmname}"
+    it { is_expected.to contain_file('/opt/puppetlabs') }
+    it { is_expected.to contain_file('/opt/puppetlabs/packages') }
+    it { is_expected.to contain_file("/opt/puppetlabs/packages/#{rpmname}").with({ 'source' => source })
+    }
 
-      if Puppet.version < "4.0.0"
-        it { is_expected.to contain_file('/etc/puppetlabs/puppet') }
-        it { is_expected.to contain_file('/etc/puppetlabs/puppet/puppet.conf') }
+    it { is_expected.to contain_class("puppet_agent::osfamily::aix") }
 
+    it { is_expected.to contain_class('Puppet_agent::Install').with({ 'package_file_name' => rpmname, }) }
+
+    it {
+      is_expected.to contain_package('puppet-agent').with({
+        'source'    => "/opt/puppetlabs/packages/#{rpmname}",
+        'ensure'    => Puppet.version < '4.0.0' ? 'present' : params[:package_version],
+        'provider'  => 'rpm',
+      })
+    }
+
+    if Puppet.version < "4.0.0"
+      [
+          'pe-augeas',
+          'pe-mcollective-common',
+          'pe-rubygem-deep-merge',
+          'pe-mcollective',
+          'pe-puppet-enterprise-release',
+          'pe-libldap',
+          'pe-libyaml',
+          'pe-ruby-stomp',
+          'pe-ruby-augeas',
+          'pe-ruby-shadow',
+          'pe-hiera',
+          'pe-facter',
+          'pe-puppet',
+          'pe-openssl',
+          'pe-ruby',
+          'pe-ruby-rgen',
+          'pe-virt-what',
+          'pe-ruby-ldap',
+      ].each do |package|
         it do
-          is_expected.to contain_exec('replace puppet.conf removed by package removal').with_command('cp /etc/puppetlabs/puppet/puppet.conf.rpmsave /etc/puppetlabs/puppet/puppet.conf')
-          is_expected.to contain_exec('replace puppet.conf removed by package removal').with_creates('/etc/puppetlabs/puppet/puppet.conf')
+          is_expected.to contain_package(package).with({
+           'ensure' => 'absent',
+           'uninstall_options' => '--nodeps',
+           'provider' => 'rpm',
+          })
         end
       end
+    end
+  end
 
-      it { is_expected.to contain_file('/opt/puppetlabs') }
-      it { is_expected.to contain_file('/opt/puppetlabs/packages') }
-      it { is_expected.to contain_file("/opt/puppetlabs/packages/#{rpmname}").with({
-          'source' => source
-          })
+  context 'with a PC1 collection' do
+    let(:params) {
+      {
+        package_version: '1.2.3',
+        collection: 'PC1',
       }
+    }
 
-      it { is_expected.to contain_class("puppet_agent::osfamily::aix") }
+    [['7.2', '7.1', '8'], ['7.1', '7.1', '8'], ['7.1', '7.1', '7'], ['6.1', '6.1', '7'], ['5.3', '5.3', '7']].each do |aixver, pkg_aixver, powerver|
+      context "aix #{aixver}" do
+        include_examples 'aix', aixver, pkg_aixver, powerver
+      end
+    end
+  end
 
-      it { is_expected.to contain_class('Puppet_agent::Install').with({
-           'package_file_name'     => rpmname,
-         })
+  context 'with a puppet5 collection' do
+    let(:params) {
+      {
+        package_version: '5.4.3',
+        collection: 'puppet5',
       }
+    }
 
-      it {
-        is_expected.to contain_package('puppet-agent').with({
-            'source'    => "/opt/puppetlabs/packages/#{rpmname}",
-            'ensure'    => package_ensure,
-            'provider'  => 'rpm'
-          })
+    [['7.2', '7.1', '8'], ['7.1', '7.1', '8'], ['7.1', '7.1', '7'], ['6.1', '6.1', '7'], ['5.3', '5.3', '7']].each do |aixver, pkg_aixver, powerver|
+      context "aix #{aixver}" do
+        include_examples 'aix', aixver, pkg_aixver, powerver
+      end
+    end
+  end
+
+  context 'with a puppet6 collection' do
+    let(:params) {
+      {
+        package_version: '6.0.0',
+        collection: 'puppet6',
       }
+    }
 
-      if Puppet.version < "4.0.0"
-        [
-         'pe-augeas',
-         'pe-mcollective-common',
-         'pe-rubygem-deep-merge',
-         'pe-mcollective',
-         'pe-puppet-enterprise-release',
-         'pe-libldap',
-         'pe-libyaml',
-         'pe-ruby-stomp',
-         'pe-ruby-augeas',
-         'pe-ruby-shadow',
-         'pe-hiera',
-         'pe-facter',
-         'pe-puppet',
-         'pe-openssl',
-         'pe-ruby',
-         'pe-ruby-rgen',
-         'pe-virt-what',
-         'pe-ruby-ldap',
-        ].each do |package|
-          it do
-            is_expected.to contain_package(package).with({
-              'ensure' => 'absent',
-              'uninstall_options' => '--nodeps',
-              'provider' => 'rpm',
-            })
-          end
-        end
+    [['7.2', '6.1', '8'], ['7.1', '6.1', '8'], ['7.1', '6.1', '7'], ['6.1', '6.1', '7']].each do |aixver, pkg_aixver, powerver|
+      context "aix #{aixver}" do
+        include_examples 'aix', aixver, pkg_aixver, powerver
       end
     end
   end


### PR DESCRIPTION
For puppet 6, we intend to provide AIX 6.1 packages for all supported
AIX platforms; Prior releases should keep the same behavior for AIX
platforms.