### PR TITLE
Added facts_upload task

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -15,6 +15,7 @@
     * [Public classes](#public-classes)
     * [Private classes](#private-classes)
     * [Parameters](#parameters)
+    * [Tasks](#tasks)
 6. [Limitations - OS compatibility, etc.](#limitations)
     * [Known issues](#known-issues)
 7. [Development - Guide for contributing to the module](#development)
@@ -194,6 +195,12 @@ This is only applicable for Windows operating systems. There may be instances wh
 ``` puppet
   msi_move_locked_files => true
 ```
+
+### Tasks
+
+#### `puppet_agent::facts_upload`
+
+Runs `puppet facts upload`, a feature added in [PUP-8232](https://tickets.puppetlabs.com/browse/PUP-8232) to allow updating of facts on demand, most useful when running agents in cached catalog mode.
 
 ## Limitations
 

--- a/tasks/facts_upload.json
+++ b/tasks/facts_upload.json
@@ -1,0 +1,4 @@
+{
+  "description": "Runs puppet facts upload. This uploads the latest facts to PuppetDB, useful for nodes that are running in cached catalog mode",
+  "input_method": "environment"
+}

--- a/tasks/facts_upload.rb
+++ b/tasks/facts_upload.rb
@@ -1,0 +1,37 @@
+#! /opt/puppetlabs/puppet/bin/ruby
+
+require 'puppet'
+require 'puppet/face'
+require 'json'
+
+# Read all the settings
+Puppet.initialize_settings
+
+# This stops the following error:
+# "Bad Request: The environment must be purely alphanumeric, not '*root*'
+Puppet::ApplicationSupport.push_application_context(Puppet::Util::RunMode[:user], :not_required)
+
+result = {}
+
+# Get the face
+facts = Puppet::Face.face?(:facts,:current)
+
+# Only try to upload the facts if the face exists
+if facts
+  # Maybe we should add error handling here, for now I'm just going to let it
+  # fail if it fails as PXP will pick up the exception anyway
+  if facts.respond_to? :upload
+    facts.upload
+    result['status']  = 'complete'
+    result['message'] = 'Facts uploaded'
+  else
+    result['status']  = 'skipped'
+    result['message'] = 'This agent does not have the "upload" action, possibly it is an old version. `puppet facts upload` was added in Puppet 5.5.0'
+  end
+else
+  result['status']  = 'skipped'
+  result['message'] = 'This agent does not have the "facts" face, possibly it is an old version. `puppet facts upload` was added in Puppet 5.5.0'
+end
+
+
+puts result.to_json


### PR DESCRIPTION
Adds the ability to run `puppet facts upload` via a task.

Tested on RHEL 7 but as it uses the face it should work on all OSes, would appreciate help testing on others.