### PR TITLE
(MODULES-4424) Add skip_if_unavailable to yumrepo resource

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,7 @@ class puppet_agent (
   $install_dir           = $::puppet_agent::params::install_dir,
   $disable_proxy         = false,
   $install_options       = $::puppet_agent::params::install_options,
+  $skip_if_unavailable   = 'absent',
   $msi_move_locked_files = false,
 ) inherits ::puppet_agent::params {
 

--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -4,6 +4,7 @@ class puppet_agent::osfamily::redhat(
   assert_private()
 
   $pa_collection = getvar('::puppet_agent::collection')
+  $skip_if_unavailable = getvar('::puppet_agent::skip_if_unavailable')
 
   if $::operatingsystem == 'Fedora' {
     if $pa_collection == 'PC1' {
@@ -111,15 +112,16 @@ class puppet_agent::osfamily::redhat(
       default => undef,
     }
     yumrepo { 'pc_repo':
-      baseurl       => $source,
-      descr         => "Puppet Labs ${pa_collection} Repository",
-      enabled       => true,
-      gpgcheck      => '1',
-      gpgkey        => "${gpg_keys}",
-      proxy         => $_proxy,
-      sslcacert     => $_sslcacert_path,
-      sslclientcert => $_sslclientcert_path,
-      sslclientkey  => $_sslclientkey_path,
+      baseurl             => $source,
+      descr               => "Puppet Labs ${pa_collection} Repository",
+      enabled             => true,
+      gpgcheck            => '1',
+      gpgkey              => "${gpg_keys}",
+      proxy               => $_proxy,
+      sslcacert           => $_sslcacert_path,
+      sslclientcert       => $_sslclientcert_path,
+      sslclientkey        => $_sslclientkey_path,
+      skip_if_unavailable => $skip_if_unavailable,
     }
   }
 }

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -159,6 +159,7 @@ describe 'puppet_agent' do
           'sslcacert' => '/etc/puppetlabs/puppet/ssl/certs/ca.pem',
           'sslclientcert' => '/etc/puppetlabs/puppet/ssl/certs/foo.example.vm.pem',
           'sslclientkey' => '/etc/puppetlabs/puppet/ssl/private_keys/foo.example.vm.pem',
+          'skip_if_unavailable' => 'absent',
         }) }
         describe 'disable proxy' do
           let(:params) {
@@ -170,6 +171,18 @@ describe 'puppet_agent' do
           }
           it {
             is_expected.to contain_yumrepo('pc_repo').with_proxy('_none_')
+          }
+        end
+        describe 'skip repo if unavailable' do
+          let(:params) {
+            {
+              :manage_repo => true,
+              :package_version => package_version,
+              :skip_if_unavailable => true,
+            }
+          }
+          it {
+            is_expected.to contain_yumrepo('pc_repo').with_skip_if_unavailable(true)
           }
         end
       end


### PR DESCRIPTION
The skip_if_unavailable yum option allows unrelated yum package
management to continue in the event that the agent repository
is unavailble for any reason. It is defaulted to 'absent', which means
the option is not set in the repository file.