### PR TITLE
(MODULES-5230) Use legacy fact variables

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -41,9 +41,36 @@
   #       env: PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
 
   Gemfile:
-    optional:
+    required:
       ':development':
-        # Ping rspec-puppet 2.6.9 until https://github.com/rodjek/rspec-puppet/issues/663 is fixed
+        # Gems built using puppet-module-gems utility
+        - gem: 'puppet-module-posix-default-r#{minor_version}'
+          platforms: 'ruby'
+        - gem: 'puppet-module-win-default-r#{minor_version}'
+          platforms:
+            - 'mswin'
+            - 'mingw'
+            - 'x64_mingw'
+        - gem: 'puppet-module-posix-dev-r#{minor_version}'
+          platforms: 'ruby'
+          version: '0.3.3'
+        - gem: 'puppet-module-win-dev-r#{minor_version}'
+          platforms:
+            - 'mswin'
+            - 'mingw'
+            - 'x64_mingw'
+          version: '0.0.7'
+        # json_pure 2.0.2 added a requirement on ruby >= 2. We pin to json_pure <= 2.0.1
+        # if using ruby 1.x
+        - gem: json_pure
+          version: '<= 2.0.1'
+          condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')"
+        - gem: fast_gettext
+          version: '1.1.0'
+          condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')"
+        - gem: fast_gettext
+          condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')"
+        # Pin rspec-puppet 2.6.9 until https://github.com/rodjek/rspec-puppet/issues/663 is fixed
         - gem: 'rspec-puppet'
           version: '2.6.9'
 

--- a/.sync.yml
+++ b/.sync.yml
@@ -31,6 +31,8 @@
 
   #     - rvm: 2.4.1
   #       env: CHECK="validate lint"
+  #     - rvm: 2.1.0
+  #       env: PUPPET_GEM_VERSION="~> 3.8" FUTURE_PARSER="yes" CHECK=spec
   #     - rvm: 2.1.5
   #       env: PUPPET_GEM_VERSION="~> 4.0.0" CHECK=spec
   #     - rvm: 2.1.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
   include:
   - rvm: 2.4.1
     env: CHECK="validate lint"
+  - rvm: 2.1.0
+    env: PUPPET_GEM_VERSION="~> 3.8" FUTURE_PARSER="yes" CHECK=spec
   - rvm: 2.1.5
     env: PUPPET_GEM_VERSION="~> 4.0.0" CHECK=spec
   - rvm: 2.1.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ matrix:
   - rvm: 2.4.1
     env: CHECK="validate lint"
   - rvm: 2.1.0
-    env: PUPPET_GEM_VERSION="~> 3.8" FUTURE_PARSER="yes" CHECK=spec
+    env: PUPPET_GEM_VERSION="~> 3.8" FUTURE_PARSER="yes" CHECK=spec BEAKER_VERSION="3.0"
   - rvm: 2.1.5
-    env: PUPPET_GEM_VERSION="~> 4.0.0" CHECK=spec
+    env: PUPPET_GEM_VERSION="~> 4.0.0" CHECK=spec BEAKER_VERSION="3.0"
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="4.7.1" HIERA_GEM_VERSION="3.2.2" CHECK=spec
   - rvm: 2.1.9

--- a/Gemfile
+++ b/Gemfile
@@ -42,14 +42,14 @@ minor_version = "#{ruby_version_segments[0]}.#{ruby_version_segments[1]}"
 #end
 
 group :development do
-  gem "puppet-module-posix-default-r#{minor_version}",    :require => false, :platforms => "ruby"
-  gem "puppet-module-win-default-r#{minor_version}",      :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
-  gem "puppet-module-posix-dev-r#{minor_version}",        :require => false, :platforms => "ruby"
-  gem "puppet-module-win-dev-r#{minor_version}", '0.0.7', :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
-  gem "json_pure", '<= 2.0.1',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
-  gem "fast_gettext", '1.1.0',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
-  gem "fast_gettext",                                     :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
-  gem "rspec-puppet", "2.6.9",                            :require => false
+  gem "puppet-module-posix-default-r#{minor_version}",      :require => false, :platforms => "ruby"
+  gem "puppet-module-win-default-r#{minor_version}",        :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
+  gem "puppet-module-posix-dev-r#{minor_version}", '0.3.3', :require => false, :platforms => "ruby"
+  gem "puppet-module-win-dev-r#{minor_version}", '0.0.7',   :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
+  gem "json_pure", '<= 2.0.1',                              :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+  gem "fast_gettext", '1.1.0',                              :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
+  gem "fast_gettext",                                       :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
+  gem "rspec-puppet", "2.6.9",                              :require => false
 end
 
 group :system_tests do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@
 #   Install from Puppet Enterprise repos. Enabled if communicating with a PE master.
 # [manage_pki_dir]
 #   Whether or not to manage the /etc/pki directory.  Defaults to true.
-#   Managing the /etc/pki directory inside the puppet_agent module can be problematic for 
+#   Managing the /etc/pki directory inside the puppet_agent module can be problematic for
 #   organizations that manage gpg keys and settings in other modules.
 # [manage_repo]
 #   Boolean to determine whether to configure repositories
@@ -79,7 +79,7 @@ class puppet_agent (
     info('puppet_agent performs no actions if a package_version is not specified on Puppet 4')
   } elsif $package_version == undef and $is_pe {
     info("puppet_agent performs no actions if the master's agent version cannot be determed on PE 3.x")
-  } elsif $facts['pe_server_version'] != undef {
+  } elsif defined('$::pe_server_version') {
     info('puppet_agent performs no actions on PE infrastructure nodes to prevent a mismatch between agent and PE components')
   } else {
     if $package_version != undef and $package_version !~ /^\d+\.\d+\.\d+([.-]?\d*|\.\d+\.g[0-9a-f]+)$/ {

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -77,7 +77,8 @@ describe 'puppet_agent' do
           end
         end
 
-        context 'On a PE infrastructure node puppet_agent does nothing' do
+        context 'On a PE infrastructure node puppet_agent does nothing', :if => Puppet.version >= '4.0.0' do
+          # The puppet version conditional is only required if the module supports Puppet 3.x
           before(:each) do
             facts['pe_server_version'] = '2016.2.2'
           end


### PR DESCRIPTION
Previously in commit a658766 the puppet_agent module was changed to not do
anything if ran on a Puppet Master.  However the fact used uses the "newer"
$facts variable which does not exist in Puppet 3.8, which the 1.x series
supports.  This commit changes the fact to the legacy variable name.  Note that
this commit should NOT be merged into the 2.x series as this no longer supports
3.x and therefore is not an issue.  This also updates the test to only work on Puppet 4.x due to the fact
not being mocked correctly in tests.

The other commits relate to re-enabling Puppet 3.x testing and pinning gems due to compatibility issues.