### PR TITLE
(MODULES-7480) Set default collection in params.pp using PE version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,7 +54,7 @@
 #
 class puppet_agent (
   $arch                  = $::architecture,
-  $collection            = 'PC1',
+  $collection            = $::puppet_agent::params::collection,
   $is_pe                 = $::puppet_agent::params::_is_pe,
   $manage_pki_dir        = true,
   $manage_repo           = true,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -107,6 +107,24 @@ class puppet_agent::params {
     $package_version = undef
   }
 
+  # Calculate the default collection
+  $_pe_version = $_is_pe ? {
+    true    => pe_build_version(),
+    default => undef
+  }
+  # Not PE or pe_version < 2018.1.3, use PC1
+  if ($_pe_version == undef or versioncmp("${_pe_version}", '2018.1.3') < 0) {
+    $collection = 'PC1'
+  }
+  # 2018.1.3 <= pe_version < 2018.2, use puppet5
+  elsif versioncmp("${_pe_version}", '2018.2') < 0 {
+    $collection = 'puppet5'
+  }
+  # pe_version >= 2018.2, use puppet6
+  else {
+    $collection = 'puppet6'
+  }
+
   $ssldir = "${confdir}/ssl"
   $config = "${confdir}/puppet.conf"
 

--- a/spec/classes/puppet_agent_params_spec.rb
+++ b/spec/classes/puppet_agent_params_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe 'puppet_agent::params' do
+  let(:facts) do
+    {
+      is_pe:           true,
+      clientversion:   '5.5.3',
+      osfamily:        'Debian',
+      operatingsystem: 'Debian',
+      servername:      'server',
+      # custom fact meant to be used only for tests in this file
+      custom_fact__pe_version: '2018.1.3'
+    }
+  end
+
+  before(:each) do
+    Puppet::Parser::Functions.newfunction(:pe_build_version, type: :rvalue, doc: '') do |args|
+      lookupvar('::custom_fact__pe_version')
+    end
+  end
+
+  context 'collection' do
+    # rspec-puppet lets us query the compiled catalog only, so we can only check if any specific resources
+    # have been declared. We cannot query for a class' variables, so we cannot query for the collection
+    # variable's value. But we can use a workaround by creating a notify resource whose message contains
+    # the value and query that instead since it will be added as part of the catalog. post_condition tells
+    # rspec-puppet to include this resource only after our class has been compiled, which is what we want.
+    let(:notify_title) { "check puppet_agent::params::collection's value" }
+    let(:post_condition) do
+      <<-NOTIFY_RESOURCE
+notify { "#{notify_title}":
+  message => "${::puppet_agent::params::collection}"
+}
+      NOTIFY_RESOURCE
+    end
+
+    def sets_collection_to(collection)
+      is_expected.to contain_notify(notify_title).with_message(collection)
+    end
+
+    context 'not in PE' do
+      let(:facts) { super().merge(is_pe: false, custom_fact__pe_version: '') }
+
+      it { sets_collection_to('PC1') }
+    end
+
+    context 'pe_version < 2018.1.3' do
+      let(:facts) { super().merge(custom_fact__pe_version: '2018.1.2') }
+
+      it { sets_collection_to('PC1') }
+    end
+
+    context 'pe_version == 2018.1.3' do
+      let(:facts) { super().merge(custom_fact__pe_version: '2018.1.3') }
+
+      it { sets_collection_to('puppet5') }
+    end
+
+    context '2018.1.3 < pe_version < 2018.2' do
+      let(:facts) { super().merge(custom_fact__pe_version: '2018.1.5') }
+
+      it { sets_collection_to('puppet5') }
+    end
+
+    context 'pe_version == 2018.2' do
+      let(:facts) { super().merge(custom_fact__pe_version: '2018.2') }
+
+      it { sets_collection_to('puppet6') }
+    end
+
+    context 'pe_version > 2018.2' do
+      let(:facts) { super().merge(custom_fact__pe_version: '2018.3') }
+
+      it { sets_collection_to('puppet6') }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,14 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
   end
 end
 
+RSpec.configure do |c|
+  c.before :each do
+    Puppet::Parser::Functions.newfunction(:pe_build_version, type: :rvalue, doc: '') do |args|
+      '2018.1.0'
+    end
+  end
+end
+
 # put local configuration and setup into spec_helper_local
 begin
   require 'spec_helper_local'


### PR DESCRIPTION
Previously, we'd hardcode the default collection to PC1 in the init.pp
manifest for both PE and non-PE environments. This has a couple of
issues:

* It's impossible to make decisions based on the collection in PE
  updates, so as we change package names and paths things get hairy.
* This is already seen with the fedora "f" in Puppet 6, and will soon be
  seen with the AIX unibuild
* In Irving.3, we switched to correctly shipping "puppet5" repos instead
  of "PC1". This means the module now MUST be aware of how PE versions
  map to collections.

This commit calculates the collection default in params.pp using the
following logic

* If we are in a non-PE environment OR our pe_version < 2018.1.3, use PC1
* Else if 2018.1.3 <= pe_version < 2018.2, use puppet5
* Else use puppet6 (pe_version >= 2018.2 here)