### PR TITLE
(PDK-1036) Unpin rspec-puppet from 2.6.9

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -72,9 +72,6 @@
           condition: "Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')"
         - gem: fast_gettext
           condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')"
-        # Pin rspec-puppet 2.6.9 until https://github.com/rodjek/rspec-puppet/issues/663 is fixed
-        - gem: 'rspec-puppet'
-          version: '2.6.9'
 
   appveyor.yml:
     unmanaged: true

--- a/.sync.yml
+++ b/.sync.yml
@@ -55,7 +55,6 @@
             - 'x64_mingw'
         - gem: 'puppet-module-posix-dev-r#{minor_version}'
           platforms: 'ruby'
-          version: '0.3.3'
         - gem: 'puppet-module-win-dev-r#{minor_version}'
           platforms:
             - 'mswin'

--- a/Gemfile
+++ b/Gemfile
@@ -42,13 +42,13 @@ minor_version = "#{ruby_version_segments[0]}.#{ruby_version_segments[1]}"
 #end
 
 group :development do
-  gem "puppet-module-posix-default-r#{minor_version}",      :require => false, :platforms => "ruby"
-  gem "puppet-module-win-default-r#{minor_version}",        :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
-  gem "puppet-module-posix-dev-r#{minor_version}", '0.3.3', :require => false, :platforms => "ruby"
-  gem "puppet-module-win-dev-r#{minor_version}", '0.0.7',   :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
-  gem "json_pure", '<= 2.0.1',                              :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
-  gem "fast_gettext", '1.1.0',                              :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
-  gem "fast_gettext",                                       :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
+  gem "puppet-module-posix-default-r#{minor_version}",    :require => false, :platforms => "ruby"
+  gem "puppet-module-win-default-r#{minor_version}",      :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
+  gem "puppet-module-posix-dev-r#{minor_version}",        :require => false, :platforms => "ruby"
+  gem "puppet-module-win-dev-r#{minor_version}", '0.0.7', :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
+  gem "json_pure", '<= 2.0.1',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+  gem "fast_gettext", '1.1.0',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
+  gem "fast_gettext",                                     :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
 end
 
 group :system_tests do

--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,6 @@ group :development do
   gem "json_pure", '<= 2.0.1',                              :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
   gem "fast_gettext", '1.1.0',                              :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
   gem "fast_gettext",                                       :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
-  gem "rspec-puppet", "2.6.9",                              :require => false
 end
 
 group :system_tests do


### PR DESCRIPTION
The bug that necessitated the pinning (rodjek/rspec-puppet#663) has been
resolved and this module can return to tracking the latest versions of
rspec-puppet again.