### PR TITLE
(BOLT-702) Install puppet agent on osx

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}",                            :require => false, :platforms => "ruby"
   gem "puppet-module-win-system-r#{minor_version}",                              :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.37')
   gem "beaker-pe",                                                               :require => false
   gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])

--- a/task_spec/spec/acceptance/nodesets/osx1011-64.yml
+++ b/task_spec/spec/acceptance/nodesets/osx1011-64.yml
@@ -1,0 +1,13 @@
+---
+HOSTS:
+  osx1011-64-1:
+    hypervisor: vmpooler
+    platform: osx-10.11-x86_64
+    packaging_platform: osx-10.11-x86_64
+    template: osx-1011-x86_64
+    roles:
+    - target
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/task_spec/spec/acceptance/nodesets/osx1012-64.yml
+++ b/task_spec/spec/acceptance/nodesets/osx1012-64.yml
@@ -1,0 +1,13 @@
+---
+HOSTS:
+  osx1012-64-1:
+    hypervisor: vmpooler
+    platform: osx-10.12-x86_64
+    packaging_platform: osx-10.12-x86_64
+    template: osx-1012-x86_64
+    roles:
+    - target
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/task_spec/spec/acceptance/nodesets/osx1013-64.yml
+++ b/task_spec/spec/acceptance/nodesets/osx1013-64.yml
@@ -1,0 +1,13 @@
+---
+HOSTS:
+  osx1013-64-1:
+    hypervisor: vmpooler
+    platform: osx-10.13-x86_64
+    packaging_platform: osx-10.13-x86_64
+    template: osx-1013-x86_64
+    roles:
+    - target
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -230,12 +230,6 @@ if test "x$platform" = "xsolaris2"; then
   export PATH
 fi
 
-checksum_mismatch() {
-  critical "Package checksum mismatch!"
-  report_bug
-  exit 1
-}
-
 unable_to_retrieve_package() {
   critical "Unable to retrieve a valid package!"
   report_bug
@@ -350,40 +344,6 @@ do_perl() {
   fi
 
   return 0
-}
-
-do_checksum() {
-  if exists sha256sum; then
-    checksum=`sha256sum $1 | awk '{ print $1 }'`
-    if test "x$checksum" != "x$2"; then
-      checksum_mismatch
-    else
-      info "Checksum compare with sha256sum succeeded."
-    fi
-  elif exists shasum; then
-    checksum=`shasum -a 256 $1 | awk '{ print $1 }'`
-    if test "x$checksum" != "x$2"; then
-      checksum_mismatch
-    else
-      info "Checksum compare with shasum succeeded."
-    fi
-  elif exists md5sum; then
-    checksum=`md5sum $1 | awk '{ print $1 }'`
-    if test "x$checksum" != "x$3"; then
-      checksum_mismatch
-    else
-      info "Checksum compare with md5sum succeeded."
-    fi
-  elif exists md5; then
-    checksum=`md5 $1 | awk '{ print $4 }'`
-    if test "x$checksum" != "x$3"; then
-      checksum_mismatch
-    else
-      info "Checksum compare with md5 succeeded."
-    fi
-  else
-    warn "Could not find a valid checksum program, pre-install shasum, md5sum or md5 in your O/S image to get valdation..."
-  fi
 }
 
 # do_download URL FILENAME


### PR DESCRIPTION
Support puppet-agent install on osx 11,12,13. Logic is based on https://github.com/puppetlabs/puppetlabs-pe_repo/blob/hoyt/templates/osx.bash.erb#L5