### PR TITLE
(BOLT-703) Install puppet agent on windows

### DIFF
--- a/task_spec/spec/acceptance/nodesets/windows10ent-32.yml
+++ b/task_spec/spec/acceptance/nodesets/windows10ent-32.yml
@@ -1,0 +1,14 @@
+---
+HOSTS:
+  windows10ent-32-2:
+    hypervisor: vmpooler
+    platform: windows-10ent-32
+    packaging_platform: windows-2012-x86
+    ruby_arch: x86
+    template: win-10-ent-i386
+    roles:
+    - target
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/task_spec/spec/acceptance/nodesets/windows10ent-64.yml
+++ b/task_spec/spec/acceptance/nodesets/windows10ent-64.yml
@@ -1,0 +1,14 @@
+---
+HOSTS:
+  windows10ent-64-1:
+    hypervisor: vmpooler
+    platform: windows-10ent-64
+    packaging_platform: windows-2012-x64
+    ruby_arch: x64
+    template: win-10-ent-x86_64
+    roles:
+    - target
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/tasks/install.json
+++ b/tasks/install.json
@@ -7,6 +7,7 @@
     }
   },
   "implementations": [
-    {"name": "install_shell.sh", "requirements": ["shell"]}
+    {"name": "install_shell.sh", "requirements": ["shell"]},
+    {"name": "install_powershell.ps1", "requirements": ["powershell"]}
   ]
 }

--- a/tasks/install_powershell.ps1
+++ b/tasks/install_powershell.ps1
@@ -1,0 +1,63 @@
+[CmdletBinding()]
+Param(
+	[String]$version
+)
+# If an error is encountered, the script will stop instead of the default of "Continue"
+$ErrorActionPreference = "Stop"
+
+if ((Get-WmiObject Win32_OperatingSystem).OSArchitecture -match '^32') {
+    $arch = "x86"
+} else {
+    $arch = "x64"
+}
+
+if ($version) {
+    $msi_source = "http://downloads.puppetlabs.com/windows/puppet5/puppet-agent-${version}-${arch}.msi"
+}
+else {
+    $msi_source = "http://downloads.puppetlabs.com/windows/puppet5/puppet-agent-${arch}-latest.msi"
+}
+
+$date_time_stamp = (Get-Date -format s) -replace ':', '-'
+$msi_dest = Join-Path ([System.IO.Path]::GetTempPath()) "puppet-agent-$arch.msi"
+$install_log = Join-Path ([System.IO.Path]::GetTempPath()) "$date_time_stamp-puppet-install.log"
+
+function DownloadPuppet {
+  Write-Verbose "Downloading the Puppet Agent for Puppet Enterprise on $env:COMPUTERNAME..."
+
+  $webclient = New-Object system.net.webclient
+
+  try {
+    $webclient.DownloadFile($msi_source,$msi_dest)
+  }
+  catch [System.Net.WebException] {
+    # If we can't find the msi, then we may not be configured correctly
+    if($_.Exception.Response.StatusCode -eq [system.net.httpstatuscode]::NotFound) {
+        Throw "Failed to download the Puppet Agent installer: $msi_source"
+    }
+    # Throw all other WebExceptions
+    Throw $_
+  }
+}
+
+function InstallPuppet {
+  $msiexec_args = "/qn /log $install_log /i $msi_dest /norestart"
+  Write-Output "Installing the Puppet Agent on $env:COMPUTERNAME..."
+  $msiexec_proc = [System.Diagnostics.Process]::Start('msiexec', $msiexec_args)
+  $msiexec_proc.WaitForExit()
+  if (@(0, 1641, 3010) -NotContains $msiexec_proc.ExitCode) {
+    Throw "Installation Failed on: $env:COMPUTERNAME. Exit code: " + $msiexec_proc.ExitCode + " Install Log: $install_log"
+  }
+}
+
+function Cleanup {
+    Write-Output "Deleting $msi_dest and $install_log"
+    Remove-Item -Force $msi_dest
+    Remove-Item -Force $install_log
+}
+
+DownloadPuppet
+InstallPuppet
+Cleanup
+
+Write-Output "Puppet Agent installed on $env:COMPUTERNAME"


### PR DESCRIPTION
Add powershell task implementation to install puppet agent on windows platforms. Logic based on https://github.com/puppetlabs/puppetlabs-pe_repo/blob/hoyt/templates/install.ps1.erb