### PR TITLE
(BOLT-742) Add support for collections to install task

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -185,19 +185,55 @@ describe 'install task' do
     end
   end
 
-  it 'runs and installs the agent' do
+  it 'runs and installs a specific agent version from puppet 5' do
+    # Note 5.5.3 is the first version that supports Ubuntu 18.04
+    results = run_task_on('target', "puppet_agent::install", params: { collection: 'puppet5', version: '5.5.3' })
+    results.each do |res|
+      expect(res["status"]).to eq("success")
+    end
+  end
+
+  it 'version returns the version with agent present' do
+    results = run_task_on('target', 'puppet_agent::version')
+    results.each do |res|
+      expect(res['status']).to eq('success')
+      expect(res['result']['version']).to eq('5.5.3')
+      expect(res['result']['source']).to be
+    end
+  end
+
+  it 'runs and upgrades the agent to latest puppet5' do
+    results = run_task_on('target', "puppet_agent::install", params: { collection: 'puppet5' })
+    results.each do |res|
+      expect(res["status"]).to eq("success")
+    end
+  end
+
+  it 'version returns a puppet5 version with agent present' do
+    results = run_task_on('target', 'puppet_agent::version')
+    results.each do |res|
+      expect(res['status']).to eq('success')
+      expect(res['result']['version']).not_to eq('5.5.3')
+      expect(res['result']['version']).to match(/^5\.\d+\.\d+/)
+      expect(res['result']['source']).to be
+    end
+  end
+
+  it 'runs and upgrades the agent to puppet by default' do
     results = run_task_on('target', "puppet_agent::install")
     results.each do |res|
       expect(res["status"]).to eq("success")
     end
   end
 
-  it 'vesion returns the version with agent present' do
+  it 'version returns a version with agent present' do
     results = run_task_on('target', 'puppet_agent::version')
     results.each do |res|
       expect(res['status']).to eq('success')
-      expect(res['result']['version']).to match(/^\d\.\d\.\d/)
+      expect(res['result']['version']).not_to eq('5.5.3')
+      expect(res['result']['version']).to match(/^[5-6]\.\d+\.\d+/)
       expect(res['result']['source']).to be
     end
   end
+
 end

--- a/tasks/install.json
+++ b/tasks/install.json
@@ -1,9 +1,13 @@
 {
-  "description": "Install the Puppet 5 agent package",
+  "description": "Install the Puppet agent package",
   "parameters": {
     "version": {
       "description": "The version of puppet-agent to install",
       "type": "Optional[String]"
+    },
+    "collection": {
+      "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
+      "type": "Optional[Enum[puppet5, puppet6, puppet]]"
     }
   },
   "implementations": [

--- a/tasks/install_powershell.ps1
+++ b/tasks/install_powershell.ps1
@@ -1,6 +1,7 @@
 [CmdletBinding()]
 Param(
-	[String]$version
+	[String]$version,
+    [String]$collection = 'puppet'
 )
 # If an error is encountered, the script will stop instead of the default of "Continue"
 $ErrorActionPreference = "Stop"
@@ -12,11 +13,13 @@ if ((Get-WmiObject Win32_OperatingSystem).OSArchitecture -match '^32') {
 }
 
 if ($version) {
-    $msi_source = "http://downloads.puppetlabs.com/windows/puppet5/puppet-agent-${version}-${arch}.msi"
+    $msi_name = "puppet-agent-${version}-${arch}.msi"
 }
 else {
-    $msi_source = "http://downloads.puppetlabs.com/windows/puppet5/puppet-agent-${arch}-latest.msi"
+    $msi_name = "puppet-agent-${arch}-latest.msi"
 }
+
+$msi_source = "http://downloads.puppetlabs.com/windows/${collection}/${msi_name}"
 
 $date_time_stamp = (Get-Date -format s) -replace ':', '-'
 $msi_dest = Join-Path ([System.IO.Path]::GetTempPath()) "puppet-agent-$arch.msi"

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -60,6 +60,12 @@ if [ -n "$PT_version" ]; then
   version=$PT_version
 fi
 
+if [ -n "$PT_collection" ]; then
+  collection=$PT_collection
+else
+  collection='puppet'
+fi
+
 #if [ -n "$PT_filename" ]; then
 #   cmdline_filename=$PT_filename
 #fi
@@ -373,14 +379,6 @@ do_download() {
   unable_to_retrieve_package
 }
 
-latest_macos_version() {
-  local mount="$1"
-  dmg_path=$(find "${mount}" -name '*.pkg' -mindepth 1 -maxdepth 1)
-  if [[ "${dmg_path}" =~ [0-9+].[0-9+].[0-9+]-[0-9+] ]]; then
-    dmg_version="${BASH_REMATCH[0]}"
-  fi
-}
-
 # install_file TYPE FILENAME
 # TYPE is "rpm", "deb", "solaris" or "dmg"
 install_file() {
@@ -419,8 +417,7 @@ install_file() {
       info "installing puppetlabs dmg with hdiutil and installer"
       mountpoint="$(mktemp -d -t $(random_hexdump))"
       /usr/bin/hdiutil attach "${download_filename?}" -nobrowse -readonly -mountpoint "${mountpoint?}"
-      latest_macos_version $mountpoint
-      /usr/sbin/installer -pkg "${mountpoint?}/puppet-agent-${dmg_version?}-installer.pkg" -target /
+      /usr/sbin/installer -pkg ${mountpoint?}/puppet-agent-*-installer.pkg -target /
       /usr/bin/hdiutil detach "${mountpoint?}"
       rm -f $download_filename
       ;;
@@ -451,14 +448,14 @@ case $platform in
       "el")
         info "Red hat like platform! Lets get you an RPM..."
         filetype="rpm"
-        filename="puppet5-release-el-${platform_version}.noarch.rpm"
-        download_url="http://yum.puppetlabs.com/puppet5/${filename}"
+        filename="${collection}-release-el-${platform_version}.noarch.rpm"
+        download_url="http://yum.puppetlabs.com/${collection}/${filename}"
         ;;
       "fedora")
         info "Fedora platform! Lets get the RPM..."
         filetype="rpm"
-        filename="puppet5-release-fedora-${platform_version}.noarch.rpm"
-        download_url="http://yum.puppetlabs.com/puppet5/${filename}"
+        filename="${collection}-release-fedora-${platform_version}.noarch.rpm"
+        download_url="http://yum.puppetlabs.com/${collection}/${filename}"
         ;;
       "debian")
         info "Debian platform! Lets get you a DEB..."
@@ -470,7 +467,7 @@ case $platform in
           "9") deb_codename="stretch";;
         esac
         filetype="deb"
-        filename="puppet5-release-${deb_codename}.deb"
+        filename="${collection}-release-${deb_codename}.deb"
         download_url="http://apt.puppetlabs.com/${filename}"
         ;;
       "ubuntu")
@@ -490,7 +487,7 @@ case $platform in
           "14.10") utopic;;
         esac
         filetype="deb"
-        filename="puppet5-release-${deb_codename}.deb"
+        filename="${collection}-release-${deb_codename}.deb"
         download_url="http://apt.puppetlabs.com/${filename}"
         ;;
       "mac_os_x")
@@ -501,7 +498,7 @@ case $platform in
         else
           filename="puppet-agent-${version}-1.osx${platform_version}.dmg"
         fi
-        download_url="http://downloads.puppetlabs.com/mac/puppet5/${platform_version}/x86_64/${filename}"
+        download_url="http://downloads.puppetlabs.com/mac/${collection}/${platform_version}/x86_64/${filename}"
         ;;
       *)
         critical "Sorry $platform is not supported yet!"


### PR DESCRIPTION
Adds a collections parameter that defaults to 'puppet'. Available values
- 'puppet5'
- 'puppet6', for future support when it's released
- 'puppet', aliases to the latest available collection

Install will select either the latest version from that collection, or
only work if you provide a valid version within that collection. To
install versions outside the default collection you'll need to
explicitly specify the collection and version.