### PR TITLE
(maint) Require beaker-puppet for beaker 4.0 update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}",                            :require => false, :platforms => "ruby"
   gem "puppet-module-win-system-r#{minor_version}",                              :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
   gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')
+  gem 'beaker-puppet', '~> 1.0'
   gem "beaker-docker", '~> 0.3'
   gem "beaker-vagrant", '~> 0.5'
   gem "beaker-vmpooler", '~> 1.3'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,3 +1,4 @@
+require 'beaker-puppet'
 require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
 require 'beaker/ca_cert_helper'


### PR DESCRIPTION
As of beaker 4.0 beaker no longer requires beaker-puppet. This commit adds beaker-puppet required for acceptance tests.