### PR TITLE
(maint) Revert to beaker 3.x.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,8 +54,7 @@ end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}",                            :require => false, :platforms => "ruby"
   gem "puppet-module-win-system-r#{minor_version}",                              :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')
-  gem 'beaker-puppet', '~> 1.0'
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.37')
   gem "beaker-docker", '~> 0.3'
   gem "beaker-vagrant", '~> 0.5'
   gem "beaker-vmpooler", '~> 1.3'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,4 +1,3 @@
-require 'beaker-puppet'
 require 'beaker-rspec/spec_helper'
 require 'beaker-rspec/helpers/serverspec'
 require 'beaker/ca_cert_helper'


### PR DESCRIPTION
This commit pins beaker-rspec at 6.2.3. This forces beaker to be pre 4.0.0. The combination of beaker 4.0.0 and beaker-puppet causes failures in acceptance tests tracked with https://tickets.puppetlabs.com/browse/BKR-1516.