### PR TITLE
(maint) Disable ssh host-key-check in config

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ group :system_tests do
   gem "puppet-blacksmith", '~> 3.4',                                             :require => false
   # Bundler fails on 2.1.9 even though this group is excluded
   if ENV['GEM_BOLT']
-    gem 'bolt', '~> 0.21.6', require: false
+    gem 'bolt', :git => 'https://github.com/puppetlabs/bolt.git', :branch => 'master', :submodules => true
     gem 'beaker-task_helper', '~> 1.5.2', require: false
   end
 end


### PR DESCRIPTION
This commit disables host-key-check for ssh in the config hash provided to `run_task`. Task acceptance tests in CI are sporadically failing due to host-key-check. The `host_to_inventory` method defined in beaker-task_helper library should set `host-key-check: false` for each target, addition of the setting in config should enforce this consistently.