### PR TITLE
(MOD-7655) SLES support for install_agent tasks

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -22,7 +22,7 @@ describe 'install task' do
 
   it 'works with version and install tasks' do
     # test the agent isn't already installed and that the version task works
-    results = run_task('puppet_agent::version', 'default', config: config, inventory: inventory)
+    results = run_task('puppet_agent::version', 'target', config: config, inventory: inventory)
     results.each do |res|
       expect(res).to include('status' => 'success')
       expect(res['result']['version']).to eq(nil)
@@ -35,7 +35,7 @@ describe 'install task' do
     end
 
     # It installed a version older than latest
-    results = run_task('puppet_agent::version', 'default', config: config, inventory: inventory)
+    results = run_task('puppet_agent::version', 'target', config: config, inventory: inventory)
     results.each do |res|
       expect(res).to include('status' => 'success')
       expect(res['result']['version']).to eq('5.5.3')

--- a/task_spec/spec/acceptance/nodesets/sles11-64.yml
+++ b/task_spec/spec/acceptance/nodesets/sles11-64.yml
@@ -1,0 +1,13 @@
+---
+HOSTS:
+  sles11-64-1:
+    hypervisor: vmpooler
+    platform: sles-11-x86_64
+    packaging_platform: sles-11-x86_64
+    template: sles-11-x86_64
+    roles:
+    - target
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/task_spec/spec/acceptance/nodesets/sles12-64.yml
+++ b/task_spec/spec/acceptance/nodesets/sles12-64.yml
@@ -1,0 +1,13 @@
+---
+HOSTS:
+  sles12-64-1:
+    hypervisor: vmpooler
+    platform: sles-12-x86_64
+    packaging_platform: sles-12-x86_64
+    template: sles-12-x86_64
+    roles:
+    - target
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -396,6 +396,15 @@ install_file() {
         yum install -y "puppet-agent-${puppet_agent_version}"
       fi
       ;;
+    "noarch.rpm")
+      info "installing puppetlabs yum repo with zypper..."
+      zypper install --no-confirm "$2"
+      if test "$version" = "latest"; then
+        zypper install --no-confirm "puppet-agent"
+      else
+        zypper install --no-confirm --oldpackage --no-recommends --no-confirm "puppet-agent-${puppet_agent_version}"
+      fi
+      ;;
     "deb")
       info "installing puppetlabs apt repo with dpkg..."
       dpkg -i "$2"
@@ -445,6 +454,16 @@ case $platform in
   *)
     info "Downloading Puppet $version for ${platform}..."
     case $platform in
+      "sles")
+        info "SLES platform! Lets get you an RPM..."
+        gpg_key="${tmp_dir}/RPM-GPG-KEY-puppet"
+        do_download "http://yum.puppetlabs.com/RPM-GPG-KEY-puppet" "$gpg_key"
+        rpm --import "$gpg_key"
+        rm -f "$gpg_key"
+        filetype="noarch.rpm"
+        filename="${collection}-release-sles-${platform_version}.noarch.rpm"
+        download_url="http://yum.puppetlabs.com/${collection}/${filename}"
+        ;;
       "el")
         info "Red hat like platform! Lets get you an RPM..."
         filetype="rpm"


### PR DESCRIPTION
This commit adds logic to the install_shell.sh install task implementation to support installing puppet-agent on SLES platforms. Currently the supported platform versions are 11 and 12. Nodeset templates have been added for manual testing.