### PR TITLE
(maint) Update to Bolt 0.21.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ group :system_tests do
   gem "puppet-blacksmith", '~> 3.4',                                             :require => false
   # Bundler fails on 2.1.9 even though this group is excluded
   if ENV['GEM_BOLT']
-    gem 'bolt', '~> 0.21.6', require: false
+    gem 'bolt', '~> 0.21.8', require: false
     gem 'beaker-task_helper', '~> 1.5.2', require: false
   end
 end


### PR DESCRIPTION
Bolt 0.21.8 includes update to host-key-check that is required by task acceptance tests. This commit updates the bolt dependency accordingly.