### PR TITLE
(MODULES-7758) Properly handle distro tag for Fedora platforms

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -165,7 +165,26 @@ class puppet_agent::install(
     # Workaround PUP-5802/PUP-5025
     if ($::operatingsystem == 'Fedora') {
       if $pa_collection == 'PC1' or $pa_collection == 'puppet5' {
-        $dist_tag = "fedoraf${::operatingsystemmajrelease}"
+        # There's three cases here due to some mistakes with how we
+        # set-up our distro tags for Fedora platforms:
+        #   * For newer Fedora platforms (e.g. Fedora 28), we want
+        #     to use the fc<major> tag
+        #
+        #   * For older Fedora platforms (e.g. Fedora 26 and 27), we
+        #     have two separate cases:
+        #       * If the package version's > 5.5.3, then we use the fedora<major>
+        #         tag, b/c in those versions we removed the 'f' prefix.
+        #
+        #       * If the package version's <= 5.5.3, then we use the fedoraf<major>
+        #         tag b/c the 'f' prefix is still there.
+        #     
+        if (versioncmp("${::operatingsystemmajrelease}", '27') > 0) {
+          $dist_tag = "fc${::operatingsystemmajrelease}"
+        } elsif (versioncmp("${package_version}", '5.5.3') > 0) {
+          $dist_tag = "fedora${::operatingsystemmajrelease}"
+        } else {
+          $dist_tag = "fedoraf${::operatingsystemmajrelease}"
+        }
       } else {
         $dist_tag = "fc${::operatingsystemmajrelease}"
       }


### PR DESCRIPTION
There were some recent changes made to remove the 'f' prefix for our
older Fedora platforms, specifically Fedora 26 and 27. However, this
inadvertently changed our distro tag for these platforms to also remove
the 'f' prefix so that e.g. fedoraf26 became fedora26. This change was not
carried over to the puppet_agent module. Furthermore, newer Fedora
platforms like Fedora 28 use the newer fc<major_version> distro tag
for the puppet5 collection. The puppet_agent module was also not
updated with this change. Thus, some agent upgrades were failing on our
Fedora platforms.

This commit updates the puppet_agent module to handle all possible cases
of the distro tag for our Fedora platforms.