### PR TITLE
(BOLT-834) Allow upgrade from puppet5 to puppet6 for install task

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -56,5 +56,20 @@ describe 'install task' do
       expect(res['result']['version']).to match(/^5\.\d+\.\d+/)
       expect(res['result']['source']).to be
     end
+
+    # Upgrade from puppet5 to puppet6
+    results = run_task( "puppet_agent::install", 'target', { 'collection' => 'puppet6' }, config: config, inventory: inventory)
+    results.each do |res|
+      expect(res).to include('status' => 'success')
+    end
+
+    # Verify that it upgraded
+    results = run_task('puppet_agent::version', 'target', config: config, inventory: inventory)
+    results.each do |res|
+      expect(res).to include('status' => 'success')
+      expect(res['result']['version']).not_to match(/^5\.\d+\.\d+/)
+      expect(res['result']['version']).to match(/^6\.\d+\.\d+/)
+      expect(res['result']['source']).to be
+    end
   end
 end

--- a/task_spec/spec/acceptance/nodesets/docker/ubuntu-18.04.yml
+++ b/task_spec/spec/acceptance/nodesets/docker/ubuntu-18.04.yml
@@ -1,5 +1,5 @@
 HOSTS:
-  ubuntu-1404-x64:
+  ubuntu-1804-x64:
     roles:
       - target
     platform: ubuntu-18.04-amd64

--- a/tasks/install_powershell.ps1
+++ b/tasks/install_powershell.ps1
@@ -6,10 +6,19 @@ Param(
 # If an error is encountered, the script will stop instead of the default of "Continue"
 $ErrorActionPreference = "Stop"
 
-if ((Get-WmiObject Win32_OperatingSystem).OSArchitecture -match '^32') {
-    $arch = "x86"
-} else {
+try {
+  if ((Get-WmiObject Win32_OperatingSystem).OSArchitecture -match '^32') {
+      $arch = "x86"
+  } else {
+      $arch = "x64"
+  }
+}
+catch [System.Management.Automation.CommandNotFoundException] {
+  if (((Get-CimInstance -ClassName win32_OperatingSystem).OSArchitecture) -eq '64-bit') {
     $arch = "x64"
+  } else {
+    $arch = "x86"
+  }
 }
 
 if ($version) {


### PR DESCRIPTION
When the install_shell.sh implementation is used to install an agent from the puppet5 collection package managment for debian based systems (notibly ubuntu) fail to install puppet-agent from puppet6 collection. This commit allows upgrade from puppet5 to puppet6.