### PR TITLE
(maint) Explicitly upgrade when version is not specified for yum

### DIFF
--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -404,7 +404,7 @@ install_file() {
 
       rpm -Uvh --oldpackage --replacepkgs "$2"
       if test "$version" = 'latest'; then
-        yum install -y puppet-agent
+        yum install -y puppet-agent && yum upgrade -y puppet-agent
       else
         yum install -y "puppet-agent-${puppet_agent_version}"
       fi


### PR DESCRIPTION
The tasks acceptance tests will install puppet-agent 5.5.3 from the `puppet5` collection by setting both the `collection` and `version` task parameters. Then the task is run again with only the `collection` parameter set to `puppet5` with the expectation that the latest version from the collection will be installed. For fedora 26 when `yum install puppet-agent` was run the upgrade happened as expected. For fedora 27 yum must explicitly upgrade puppet agent in order to have the desired result.