### PR TITLE
 (BOLT-878) Fail fast when run as non-root

### DIFF
--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -41,19 +41,6 @@ exists() {
   fi
 }
 
-# Helper bug-reporting text
-report_bug() {
-  critical "Please file a bug report at https://github.com/puppetlabs/puppetlabs-puppet_agent"
-  critical ""
-  critical "Version: $version"
-  critical "Platform: $platform"
-  critical "Platform Version: $platform_version"
-  critical "Machine: $machine"
-  critical "OS: $os"
-  critical ""
-  critical "Please detail your operating system type, version and any other relevant details"
-}
-
 # Get command line arguments
 
 if [ -n "$PT_version" ]; then
@@ -119,7 +106,6 @@ elif test -f "/usr/bin/sw_vers"; then
     "10.12") platform_version="10.12";;
     "10.13") platform_version="10.13";;
     *) echo "No builds for platform: $major_version"
-       report_bug
        exit 1
        ;;
   esac
@@ -156,7 +142,6 @@ fi
 
 if test "x$platform" = "x"; then
   critical "Unable to determine platform version!"
-  report_bug
   exit 1
 fi
 
@@ -203,7 +188,6 @@ esac
 
 if test "x$platform_version" = "x"; then
   critical "Unable to determine platform version!"
-  report_bug
   exit 1
 fi
 
@@ -215,7 +199,6 @@ fi
 
 unable_to_retrieve_package() {
   critical "Unable to retrieve a valid package!"
-  report_bug
   exit 1
 }
 
@@ -371,7 +354,7 @@ install_file() {
         info "Version ${installed_version} detected..."
         major=$(echo $installed_version | cut -d. -f1)
         pkg="puppet${major}-release"
-        
+
         if echo $2 | grep $pkg; then
           info "No collection upgrade detected"
         else
@@ -425,7 +408,7 @@ install_file() {
           dpkg --purge "puppet${major}-release"
         fi
       fi
-      
+
       dpkg -i "$2"
       apt-get update -y
 
@@ -452,13 +435,11 @@ install_file() {
       ;;
     *)
       critical "Unknown filetype: $1"
-      report_bug
       exit 1
       ;;
   esac
   if test $? -ne 0; then
     critical "Installation failed"
-    report_bug
     exit 1
   fi
 }
@@ -541,7 +522,6 @@ case $platform in
         ;;
       *)
         critical "Sorry $platform is not supported yet!"
-        report_bug
         exit 1
         ;;
     esac

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -66,37 +66,15 @@ else
   collection='puppet'
 fi
 
-#if [ -n "$PT_filename" ]; then
-#   cmdline_filename=$PT_filename
-#fi
-#
-#if [ -n "$PT_download_dir" ]; then
-#  cmdline_dl_dir==$PT_download_dir
-#fi
-#while getopts v:f:d:h opt
-#do
-#  case "$opt" in
-#    v)  version="$OPTARG";;
-#    f)  cmdline_filename="$OPTARG";;
-#    d)  cmdline_dl_dir="$OPTARG";;
-#    h) echo >&2 \
-#      "install_puppet_agent.sh - A shell script to install Puppet Agent > 5.0.0, assuming no dependencies
-#      usage:
-#      -v   version         version to install, defaults to \$latest_version
-#      -f   filename        filename for downloaded file, defaults to original name
-#      -d   download_dir    filename for downloaded file, defaults to /tmp/(random-number)"
-#      exit 0;;
-#    \?)   # unknown flag
-#      echo >&2 \
-#      "unknown option
-#      usage: $0 [-v version] [-f filename | -d download_dir]"
-#      exit 1;;
-#  esac
-#done
 shift `expr $OPTIND - 1`
 
 machine=`uname -m`
 os=`uname -s`
+
+if [ `id -u` -ne 0 ]; then
+  echo "puppet_agent::install task must be run as root"
+  exit 1
+fi
 
 if [ -f /opt/puppetlabs/puppet/VERSION ]; then
   installed_version=`cat /opt/puppetlabs/puppet/VERSION`


### PR DESCRIPTION
There is not a good way to make sure a non-root user is installed on test images which makes this hard to test. I've manually tested on:

centos7
fedora 28
debian8
ubuntu-1804
sles 12
osx 10.13