### PR TITLE
(BOLT-915) Use facts module to query for target platform

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ group :system_tests do
   gem "puppet-blacksmith", '~> 3.4',                                             :require => false
   # Bundler fails on 2.1.9 even though this group is excluded
   if ENV['GEM_BOLT']
-    gem 'bolt', '~> 0.21.8', require: false
+    gem 'bolt', '~> 1.1.0', require: false
     gem 'beaker-task_helper', '~> 1.5.2', require: false
   end
 end

--- a/README.markdown
+++ b/README.markdown
@@ -210,6 +210,8 @@ detected>"}`. If a version cannot be found, returns `{"version": null}`.
 Installs the puppet-agent package. Currently only supports Linux variants: Debian, Ubuntu, SLES, RHEL/CentOS/Fedora. A specific
 package `version` can be specified; if not, will install or upgrade to the latest Puppet 5 version available.
 
+**Note**: The `puppet_agent::install_shell` task requires the `facts::bash` implementation from the [facts](https://forge.puppet.com/puppetlabs/facts) module. Both the `puppet_agent` and `facts` modules are packaged with Bolt. For use outside of Bolt make sure the `facts` module is installed to the same `modules` directory as `puppet_agent`.
+
 ## Limitations
 
 Mac OS X Open Source packages are currently not supported.

--- a/task_spec/.fixtures.yml
+++ b/task_spec/.fixtures.yml
@@ -1,3 +1,7 @@
 fixtures:
+  forge_modules:
+    facts:
+      repo: "puppetlabs/facts"
+      ref: "0.4.1"
   symlinks:
     puppet_agent: "#{File.absolute_path(File.join(source_dir, '..'))}"

--- a/task_spec/spec/spec_helper_acceptance.rb
+++ b/task_spec/spec/spec_helper_acceptance.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-
 # Make sure bolt's puppet is loaded
 require 'bolt/pal'
 Bolt::PAL.load_puppet
@@ -21,8 +20,4 @@ RSpec.configure do |c|
   c.add_setting :module_path
   c.module_path  = File.join(base_dir, 'fixtures', 'modules')
 
-  # Configure all nodes in nodeset
-  c.before :suite do
-    #run_puppet_access_login(user: 'admin') if pe_install?
-  end
 end

--- a/tasks/install.json
+++ b/tasks/install.json
@@ -11,7 +11,7 @@
     }
   },
   "implementations": [
-    {"name": "install_shell.sh", "requirements": ["shell"]},
+    {"name": "install_shell.sh", "requirements": ["shell"], "files": ["facts/tasks/bash.sh"]},
     {"name": "install_powershell.ps1", "requirements": ["powershell"]}
   ]
 }

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -55,7 +55,6 @@ fi
 
 shift `expr $OPTIND - 1`
 
-machine=`uname -m`
 os=`uname -s`
 
 if [ `id -u` -ne 0 ]; then
@@ -110,14 +109,8 @@ elif test -f "/usr/bin/sw_vers"; then
        ;;
   esac
 
-  # x86_64 Apple hardware often runs 32-bit kernels (see OHAI-63)
-  x86_64=`sysctl -n hw.optional.x86_64`
-  if test $x86_64 -eq 1; then
-    machine="x86_64"
-  fi
 elif test -f "/etc/release"; then
   platform="solaris2"
-  machine=`/usr/bin/uname -p`
   platform_version=`/usr/bin/uname -r`
 elif test -f "/etc/SuSE-release"; then
   if grep -q 'Enterprise' /etc/SuSE-release;
@@ -137,7 +130,6 @@ elif test "x$os" = "xFreeBSD"; then
 elif test "x$os" = "xAIX"; then
   platform="aix"
   platform_version=`uname -v`
-  machine="ppc"
 fi
 
 if test "x$platform" = "x"; then


### PR DESCRIPTION
Much of the puppet_agent task is logic to determine the operating systems and version of the target. This is duplicated by the shell implementation of the facts task. The addition of multi-file task support allows using the facts module bash.sh implementation code. The bash.sh implementation has been modified to return platform and version when environment variables PLATFORM=TRUE or RELEASE=TRUE are set. This commit utilizes the code in the facts module to determine platform and version.