### PR TITLE
Allow "present" or "latest" as a package version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,7 +79,7 @@ class puppet_agent (
   } elsif $package_version == undef and $is_pe {
     info("puppet_agent performs no actions if the master's agent version cannot be determed on PE 3.x")
   } else {
-    if $package_version != undef and $package_version !~ /^\d+\.\d+\.\d+([.-]?\d*|\.\d+\.g[0-9a-f]+)$/ {
+    if $package_version != undef and $package_version !~ /^\d+\.\d+\.\d+([.-]?\d*|\.\d+\.g[0-9a-f]+)$|^present$|^latest$/ {
       fail("invalid version ${package_version} requested")
     }
 
@@ -101,7 +101,7 @@ class puppet_agent (
     # Allow for normalizing package_version for the package provider via _package_version.
     # This only needs to be passed through to install, as elsewhere we want to
     # use the full version string for comparisons.
-    if $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '11' {
+    if $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '11' and $package_version !~ /^present$|^latest$/ {
       # Strip letters from development builds. Unique to Solaris 11 packaging.
       # Need to pass the regex as strings for Puppet 3 compatibility.
       $_version_without_letters = regsubst($package_version, '[a-zA-Z]', '', 'G')

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -154,7 +154,7 @@ class puppet_agent::install(
         }
       }
     }
-  } elsif ($::osfamily == 'RedHat') and ($package_version != 'present') {
+  } elsif ($::osfamily == 'RedHat') and ($package_version !~ /^present$|^latest$/) {
     # Workaround PUP-5802/PUP-5025
     if ($::operatingsystem == 'Fedora') {
       $dist_tag = "fedoraf${::operatingsystemmajrelease}"
@@ -167,7 +167,7 @@ class puppet_agent::install(
       ensure          => "${package_version}-1.${dist_tag}",
       install_options => $install_options,
     }
-  } elsif ($::osfamily == 'Debian') and ($package_version != 'present') {
+  } elsif ($::osfamily == 'Debian') and ($package_version !~ /^present$|^latest$/) {
     # Workaround PUP-5802/PUP-5025
     package { $::puppet_agent::package_name:
       ensure          => "${package_version}-1${::lsbdistcodename}",


### PR DESCRIPTION
It appears that the module supported setting the package version to `present` or `latest` prior to c2206a7e9b882041ccb569332fc872f9524a34cd. This commit restores that functionality.