### PR TITLE
(MODULES-8086) Puppet 5 and 6: wrong urls for windows msi

### DIFF
--- a/manifests/windows/install.pp
+++ b/manifests/windows/install.pp
@@ -19,7 +19,12 @@ class puppet_agent::windows::install(
     $_https_source = "https://pm.puppetlabs.com/puppet-agent/${_pe_server_version}/${_agent_version}/repos/windows/${package_file_name}"
   }
   else {
-    $_https_source = "https://downloads.puppetlabs.com/windows/${package_file_name}"
+    $dir = $package_file_name ? {
+      /.*-5\..*/ => 'puppet5/',
+      /.*-6\..*/ => 'puppet6/',
+      default => ''
+    }
+    $_https_source = "https://downloads.puppetlabs.com/windows/${dir}${package_file_name}"
   }
 
   $_install_options = $install_options ? {

--- a/manifests/windows/install.pp
+++ b/manifests/windows/install.pp
@@ -20,8 +20,8 @@ class puppet_agent::windows::install(
   }
   else {
     $dir = $package_file_name ? {
-      /.*-5\..*/ => 'puppet5/',
-      /.*-6\..*/ => 'puppet6/',
+      /puppet-agent-5\..*/ => 'puppet5/',
+      /puppet-agent-6\..*/ => 'puppet6/',
       default => ''
     }
     $_https_source = "https://downloads.puppetlabs.com/windows/${dir}${package_file_name}"


### PR DESCRIPTION
Correct URLs for windows msis (Puppet 5 and 6)