### PR TITLE
 (MODULES-7760) Remove dist_tag in install.pp for RHEL platforms

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -201,7 +201,6 @@ class puppet_agent::install(
       install_options => $install_options,
     }
   } elsif ($::osfamily == 'Debian') and ($package_version != 'present') {
-    # Workaround PUP-5802/PUP-5025
     package { $::puppet_agent::package_name:
       ensure          => "${package_version}-1${::lsbdistcodename}",
       install_options => $install_options,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -161,45 +161,6 @@ class puppet_agent::install(
         }
       }
     }
-  } elsif ($::osfamily == 'RedHat') and ($package_version != 'present') {
-    # Workaround PUP-5802/PUP-5025
-    if ($::operatingsystem == 'Fedora') {
-      if $pa_collection == 'PC1' or $pa_collection == 'puppet5' {
-        # There's three cases here due to some mistakes with how we
-        # set-up our distro tags for Fedora platforms:
-        #   * For newer Fedora platforms (e.g. Fedora 28), we want
-        #     to use the fc<major> tag
-        #
-        #   * For older Fedora platforms (e.g. Fedora 26 and 27), we
-        #     have two separate cases:
-        #       * If the package version's > 5.5.3, then we use the fedora<major>
-        #         tag, b/c in those versions we removed the 'f' prefix.
-        #
-        #       * If the package version's <= 5.5.3, then we use the fedoraf<major>
-        #         tag b/c the 'f' prefix is still there.
-        #     
-        if (versioncmp("${::operatingsystemmajrelease}", '27') > 0) {
-          $dist_tag = "fc${::operatingsystemmajrelease}"
-        } elsif (versioncmp("${package_version}", '5.5.3') > 0) {
-          $dist_tag = "fedora${::operatingsystemmajrelease}"
-        } else {
-          $dist_tag = "fedoraf${::operatingsystemmajrelease}"
-        }
-      } else {
-        $dist_tag = "fc${::operatingsystemmajrelease}"
-      }
-    } elsif ($::platform_tag != undef and $::platform_tag =~ /redhatfips.*/) {
-      # The undef check here is for unit tests that don't supply this fact.
-      $dist_tag = 'redhatfips7'
-    } elsif $::operatingsystem == 'Amazon' {
-      $dist_tag = 'el6'
-    } else {
-      $dist_tag = "el${::operatingsystemmajrelease}"
-    }
-    package { $::puppet_agent::package_name:
-      ensure          => "${package_version}-1.${dist_tag}",
-      install_options => $install_options,
-    }
   } elsif ($::osfamily == 'Debian') and ($package_version != 'present') {
     package { $::puppet_agent::package_name:
       ensure          => "${package_version}-1${::lsbdistcodename}",

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -120,87 +120,6 @@ describe 'puppet_agent' do
     end
   end
 
-  # There are a lot of special cases here, so it is best to have a separate
-  # unit test context for them.
-  context 'distro tag on Fedora platforms' do
-    def sets_distro_tag_to(expected_distro_tag)
-      is_expected.to contain_package('puppet-agent').with_ensure(
-        "#{params[:package_version]}-1.#{expected_distro_tag}"
-      )
-    end
-
-    let(:facts) do
-      super().merge(:operatingsystem => 'Fedora')
-    end
-
-    context 'when the collection is PC1' do
-      let(:params) do
-        # Older agents use the PC1 collection, so set the package_version
-        # to 1.10.9 to simulate this.
-        super().merge(:collection => 'PC1', :package_version => '1.10.9')
-      end
-
-      let(:facts) do
-        # Older agents do not support anything past Fedora 27
-        super().merge(:operatingsystemmajrelease => 27)
-      end
-
-      it { sets_distro_tag_to('fedoraf27') }
-    end
-
-    context 'when the collection is puppet5' do
-      let(:params) do
-        super().merge(:collection => 'puppet5')
-      end
-
-      context 'on newer Fedora versions' do
-        let(:facts) do
-          super().merge(:operatingsystemmajrelease => 28)
-        end
-
-        it { sets_distro_tag_to('fc28') }
-      end
-
-      context 'on older Fedora versions' do
-        let(:facts) do
-          super().merge(:operatingsystemmajrelease => 27)
-        end
-
-        shared_examples 'a package version' do |package_version, distro_tag|
-          let(:params) do
-            super().merge(:package_version => package_version)
-          end
-
-          it { sets_distro_tag_to(distro_tag) }
-        end
-
-        context 'when package_version > 5.5.3' do
-          include_examples 'a package version', '5.5.4', 'fedora27'
-        end
-
-        context 'when package_version == 5.5.3' do
-          include_examples 'a package version', '5.5.3', 'fedoraf27'
-        end
-
-        context 'when package_version < 5.5.3' do
-          include_examples 'a package version', '5.5.1', 'fedoraf27'
-        end
-      end
-    end
-
-    context 'when the collection is newer than PC1 and puppet5' do
-      let(:params) do
-        super().merge(:collection => 'puppet6', :package_version => '6.0.0')
-      end
-
-      let(:facts) do
-        super().merge(:operatingsystemmajrelease => 27)
-      end
-
-      it { sets_distro_tag_to('fc27') }
-    end
-  end
-
   [['RedHat', 'el-7-x86_64', 'el-7-x86_64', 7], ['Amazon', '', 'el-6-x64', 6]].each do |os, tag, repodir, osmajor|
     context "when PE on #{os}" do
       before(:each) do
@@ -290,7 +209,7 @@ describe 'puppet_agent' do
             :package_version => package_version
           }
         }
-        it { is_expected.to contain_package('puppet-agent').with_ensure("#{params[:package_version]}-1.el#{osmajor}") }
+        it { is_expected.to contain_package('puppet-agent').with_ensure("#{params[:package_version]}") }
 
       end
 

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -160,16 +160,7 @@ describe 'puppet_agent' do
             it { is_expected.to contain_class('puppet_agent::prepare') }
             it { is_expected.to contain_class('puppet_agent::install').that_requires('Class[puppet_agent::prepare]') }
 
-            if facts[:osfamily] == 'RedHat'
-              if facts[:operatingsystem] == 'Fedora'
-                # Workaround PUP-5802/PUP-5025
-                yum_package_version = package_version + '-1.fedoraf' + facts[:operatingsystemmajrelease]
-                it { is_expected.to contain_package('puppet-agent').with_ensure(yum_package_version) }
-              else
-                yum_package_version = package_version + '-1.el' + facts[:operatingsystemmajrelease]
-                it { is_expected.to contain_package('puppet-agent').with_ensure(yum_package_version) }
-              end
-            elsif facts[:osfamily] == 'Debian'
+            if facts[:osfamily] == 'Debian'
               deb_package_version = package_version + '-1' + facts[:lsbdistcodename]
               it { is_expected.to contain_package('puppet-agent').with_ensure(deb_package_version) }
             elsif facts[:osfamily] == 'Solaris' && (facts[:operatingsystemmajrelease] == '10' || Puppet.version < '4.0.0')

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -170,7 +170,6 @@ describe 'puppet_agent' do
                 it { is_expected.to contain_package('puppet-agent').with_ensure(yum_package_version) }
               end
             elsif facts[:osfamily] == 'Debian'
-              # Workaround PUP-5802/PUP-5025
               deb_package_version = package_version + '-1' + facts[:lsbdistcodename]
               it { is_expected.to contain_package('puppet-agent').with_ensure(deb_package_version) }
             elsif facts[:osfamily] == 'Solaris' && (facts[:operatingsystemmajrelease] == '10' || Puppet.version < '4.0.0')


### PR DESCRIPTION
The dist_tag variable was introduced as a workaround for
PUP-5802/PUP-5025. These tickets were resolved two years
ago, so the workaround is no longer necessary.