### PR TITLE
remove deprecated file source_permissions

### DIFF
--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -17,17 +17,6 @@ class puppet_agent::prepare(
 ){
   include puppet_agent::params
   $_windows_client = downcase($::osfamily) == 'windows'
-  if $_windows_client {
-
-    File{
-      source_permissions => ignore,
-    }
-  }
-  else  {
-    File {
-      source_permissions => use,
-    }
-  }
 
   # Manage /opt/puppetlabs for platforms. This is done before both config and prepare because,
   # on Windows, both can be in C:/ProgramData/Puppet Labs; doing it later creates a dependency
@@ -53,6 +42,8 @@ class puppet_agent::prepare(
     # in the destination but not the source, it'll be overwritten.
     file { $::puppet_agent::params::puppetdirs:
       ensure => directory,
+      owner  => $::puppet_agent::params::user,
+      group  => $::puppet_agent::params::group,
     }
 
     if !$_windows_client { #Windows didn't change only nix systems
@@ -64,6 +55,8 @@ class puppet_agent::prepare(
       # manage client.cfg and server.cfg contents
       file { $::puppet_agent::params::mcodirs:
         ensure => directory,
+        owner  => $::puppet_agent::params::user,
+        group  => $::puppet_agent::params::group,
       }
 
       # The mco_*_config facts will return the location of mcollective config (or nil), prefering PE over FOSS.

--- a/manifests/prepare/mco_client_config.pp
+++ b/manifests/prepare/mco_client_config.pp
@@ -10,6 +10,8 @@ class puppet_agent::prepare::mco_client_config {
   $mco_client = $::puppet_agent::params::mco_client
   file { $mco_client:
     ensure => file,
+    owner  => $::puppet_agent::params::user,
+    group  => $::puppet_agent::params::group,
     source => $::mco_client_config,
   }
 

--- a/manifests/prepare/mco_server_config.pp
+++ b/manifests/prepare/mco_server_config.pp
@@ -11,6 +11,8 @@ class puppet_agent::prepare::mco_server_config {
   if !defined(File[$mco_server]) {
     file { $mco_server:
       ensure => file,
+      owner  => $::puppet_agent::params::user,
+      group  => $::puppet_agent::params::group,
       source => $::mco_server_config,
     }
 

--- a/manifests/prepare/puppet_config.pp
+++ b/manifests/prepare/puppet_config.pp
@@ -12,11 +12,15 @@ class puppet_agent::prepare::puppet_config (
   if $old_packages {
     file { $puppetconf:
       ensure => file,
+      owner  => $::puppet_agent::params::user,
+      group  => $::puppet_agent::params::group,
       source => $::puppet_config,
     }
   } elsif !defined(File[$puppetconf]) {
     file { $puppetconf:
       ensure => file,
+      owner  => $::puppet_agent::params::user,
+      group  => $::puppet_agent::params::group,
     }
   }
 

--- a/manifests/prepare/ssl.pp
+++ b/manifests/prepare/ssl.pp
@@ -10,6 +10,8 @@ class puppet_agent::prepare::ssl {
   $ssl_dir = $::puppet_agent::params::ssldir
   file { $ssl_dir:
     ensure  => directory,
+    owner   => $::puppet_agent::params::user,
+    group   => $::puppet_agent::params::group,
     source  => $::puppet_ssldir,
     backup  => false,
     recurse => false,
@@ -27,6 +29,8 @@ class puppet_agent::prepare::ssl {
     if $::puppet_sslpaths[$setting]['path_exists'] {
       file { "${ssl_dir}/${subdir}":
         ensure  => directory,
+        owner   => $::puppet_agent::params::user,
+        group   => $::puppet_agent::params::group,
         source  => $::puppet_sslpaths[$setting]['path'],
         backup  => false,
         recurse => true,
@@ -38,6 +42,8 @@ class puppet_agent::prepare::ssl {
   if $::puppet_sslpaths['hostcrl']['path_exists'] {
     file { "${ssl_dir}/crl.pem":
       ensure => file,
+      owner  => $::puppet_agent::params::user,
+      group  => $::puppet_agent::params::group,
       source => $::puppet_sslpaths['hostcrl']['path'],
       backup => false
     }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -15,6 +15,8 @@ class puppet_agent::service {
     notice ("Puppet service start log file at ${_logfile}")
     file { "${::env_temp_variable}/solaris_start_puppet.sh":
       ensure => file,
+      owner  => 0,
+      group  => 0,
       source => 'puppet:///modules/puppet_agent/solaris_start_puppet.sh',
       mode   => '0755',
     }


### PR DESCRIPTION
... to remove deprecation warnings with puppet 5.5.6+
```
puppet-agent[98883]: The `source_permissions` parameter is deprecated. Explicitly set `owner`, `group`, and `mode`.
puppet-agent[98883]:    (file: /etc/puppetlabs/code/environments/development/modules/puppet_agent/manifests/prepare.pp, line: 36)
puppet-agent[98883]: The `source_permissions` parameter is deprecated. Explicitly set `owner`, `group`, and `mode`.
puppet-agent[98883]:    (file: /etc/puppetlabs/code/environments/development/modules/puppet_agent/manifests/osfamily/redhat.pp, line: 75)
puppet-agent[98883]: The `source_permissions` parameter is deprecated. Explicitly set `owner`, `group`, and `mode`.
puppet-agent[98883]:    (file: /etc/puppetlabs/code/environments/development/modules/puppet_agent/manifests/osfamily/redhat.pp, line: 92)
```