### PR TITLE
Remove source permissions

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -188,9 +188,11 @@ class puppet_agent::install(
       } else {
         $dist_tag = "fc${::operatingsystemmajrelease}"
       }
-    } elsif ($::platform_tag != undef and $::platform_tag =~ /redhatfips.*/) {
+    } elsif (defined('$::platform_tag')) {
+      if ($::platform_tag =~ /redhatfips.*/) {
       # The undef check here is for unit tests that don't supply this fact.
-      $dist_tag = 'redhatfips7'
+        $dist_tag = 'redhatfips7'
+      }
     } elsif $::operatingsystem == 'Amazon' {
       $dist_tag = 'el6'
     } else {

--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -17,17 +17,6 @@ class puppet_agent::prepare(
 ){
   include puppet_agent::params
   $_windows_client = downcase($::osfamily) == 'windows'
-  if $_windows_client {
-
-    File{
-      source_permissions => ignore,
-    }
-  }
-  else  {
-    File {
-      source_permissions => use,
-    }
-  }
 
   # Manage /opt/puppetlabs for platforms. This is done before both config and prepare because,
   # on Windows, both can be in C:/ProgramData/Puppet Labs; doing it later creates a dependency


### PR DESCRIPTION
as they are deprecated. They were only used on windows_clients.. I assume when copying files from old puppet installation.. (so source was local windows filesystem). AFAIK it should still work without this though. 