### PR TITLE
(maint) Bump the puppetlabs-apt version

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -10,6 +10,6 @@ fixtures:
       ref: "2.1.0"
     apt:
       repo: "puppetlabs/apt"
-      ref: "2.3.0"
+      ref: "4.4.0"
   symlinks:
     puppet_agent: "#{source_dir}"


### PR DESCRIPTION
We're seeing failures in CI that require the puppetlabs-apt to be bumped.
This is done on the Master branch, but looks to not have been done on 1.x yet.