### PR TITLE
(maint) Use legacy dependencies repo for activemq

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -49,7 +49,7 @@ unless ENV['BEAKER_provision'] == 'no'
   install_modules_on master
 
   # Install activemq on master
-  install_puppetlabs_release_repo master
+  install_puppetlabs_release_repo(master, '')
   install_package master, 'activemq'
 
   ['truststore', 'keystore'].each do |ext|


### PR DESCRIPTION
Since activemq packages are currently only available in our legacy
dependencies repo, install the legacy puppetlabs-release package.