### PR TITLE
(MODULES-8198) Use beaker ~> 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,7 @@ end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}",                            :require => false, :platforms => "ruby"
   gem "puppet-module-win-system-r#{minor_version}",                              :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '>= 3')
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3')
   gem "beaker-pe",                                                               :require => false
   gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])


### PR DESCRIPTION
Acceptance tests in 1.x are not yet compatible with beaker 4; specify beaker ~> 3 in the Gemfile instead of >= 3.