### PR TITLE
(MODULES-8318) Update rspec-puppet, add yumrepo_core fixtures for puppet 6

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -11,5 +11,7 @@ fixtures:
     apt:
       repo: "puppetlabs/apt"
       ref: "2.3.0"
+    yumrepo_core:
+      repo: "puppetlabs/yumrepo_core"
   symlinks:
     puppet_agent: "#{source_dir}"

--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ group :development do
   gem "json_pure", '<= 2.0.1',                              :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
   gem "fast_gettext", '1.1.0',                              :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
   gem "fast_gettext",                                       :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
-  gem "rspec-puppet", "2.6.9",                              :require => false
+  gem "rspec-puppet", "2.7.2",                              :require => false
 end
 
 group :system_tests do


### PR DESCRIPTION
There are two commits here, both of which are updates to dependencies:

- Update rspec-puppet (2.6.9 to 2.7.2)
- Add yumrepo_core as a fixture to support running spec tests with puppet 6 gems (which can't manage yumrepo resources without the module)