### PR TITLE
(PA-2282) Add Docker workflow for iterative development

### DIFF
--- a/docker/bin/helpers/run-upgrade.sh
+++ b/docker/bin/helpers/run-upgrade.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Run upgrades on a container. The default upgrade TO argument will be 6.2.0 if
+# no arguments are passed to this script.
+set -e
+
+to_version=${1:-6.2.0}
+# Calculate which collection should be used. This is derived from the puppet
+# version.
+puppet_version=( ${to_version//./ } )
+puppet_major=${puppet_version[0]}
+case $puppet_major in
+4)
+    to_collection=PC1
+    ;;
+5)
+    to_collection=puppet5
+    ;;
+6)
+    to_collection=puppet6
+    ;;
+*)
+    echo "Invalid version supplied" 1>&2
+    exit 1
+esac
+FACTER_to_version=${1:-6.2.0} FACTER_to_collection=${to_collection} /opt/puppetlabs/puppet/bin/puppet apply --debug --modulepath /tmp/modules /tmp/upgrade.pp
+# Make e.g. `puppet --version` work out of the box.
+PATH=/opt/puppetlabs/bin:$PATH \
+    read -p "Explore the upgraded container? [y/N]: " choice && \
+    choice=${choice:-N} && \
+    if [ "${choice}" = "y" ]; then \
+        bash; \
+    else \
+        echo "Moving on..."; \
+    fi

--- a/docker/bin/upgrade.sh
+++ b/docker/bin/upgrade.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Usage: `./upgrade.sh [<PLATFORM>] [<BEFORE>] [<AFTER>]`
+#
+# Builds an upgrade process for the puppet-agent module and tags as
+# "pa-dev:<PLATFORM>".
+#
+# Parameters:
+# - PLATFORM: The platform on which the upgrade should occur. This also
+#             supports comma-separated lists. Available:
+#             - `ubuntu`
+#             - `centos`
+#             Default: `ubuntu`
+# - BEFORE: The puppet-agent package version that is installed prior to upgrade.
+#           Default: 1.10.14
+# - AFTER: The puppet-agent package version that should exist after upgrade.
+#          Default: 6.2.0
+set -e
+
+cd "$(dirname "$0")/../.."
+platforms=${1:-ubuntu}
+before=${2:-1.10.14}
+after=${3:-6.2.0}
+for platform in ${platforms//,/ }
+do
+    docker build --rm -f docker/$platform/Dockerfile . -t pa-dev:$platform \
+        --build-arg before=${before}
+    docker run --rm -ti pa-dev:$platform ${after}
+done
+echo Complete

--- a/docker/bin/versions.sh
+++ b/docker/bin/versions.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Usage: `./upgrade.sh [<PLATFORM>] [<BEFORE>] [<AFTER>]`
+#
+# Outputs the package versions of puppet-agent that are available on a given
+# platform.
+#
+# Parameters:
+# - PLATFORM: The platform on which the upgrade should occur. Available:
+#             - `ubuntu`
+#             - `centos`
+#             Default: `ubuntu`
+set -e
+
+platform=${1:-ubuntu}
+
+case "${platform}" in
+    ubuntu|centos)
+        ;;
+    *) echo "Invalid platform: '${platform}'. Must be 'ubuntu' or 'centos'"
+        exit 1
+        ;;
+esac
+cd "$(dirname "$0")/../.."
+docker build -f docker/${platform}/Dockerfile.versions . -t pa-dev:${platform}-versions
+docker run -it --rm pa-dev:${platform}-versions

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -1,0 +1,107 @@
+# This Dockerfile enables an iterative development workflow where you can make
+# a change and test it out quickly. The majority of commands in this file will
+# be cached, making the feedback loop typically quite short. The workflow is
+# as follows:
+#   1. Set up pre-conditions for the system in puppet code using `deploy.pp`.
+#   2. Make a change to the module.
+#   3. Run `docker build -f docker/Dockerfile .` or
+#      `./docker/bin/upgrade.sh centos` from the project directory. If you would
+#      like to test specific version upgrades, you can add run this like so:
+#        `docker build -f docker/centos/Dockerfile . \
+#           -t pa-dev:centos --build-arg before=1.10.14`
+#   4. Upgrade the container by running the image:
+#        `docker run -it pa-dev:centos`
+#      Specify your upgrade TO version as an argument to the `docker run`
+#      command.
+#   5. Review the output. Repeat steps 2-5 as needed.
+#
+# At the end of execution, you will see a line like:
+#
+# Notice: /Stage[main]/Puppet_agent::Install/Package[puppet-agent]/ensure: ensure changed '1.10.14-1.el7' to '6.2.0'
+#
+# This specifies the versions that were used for upgrade.
+#
+# Arguments:
+# - before: The version to do upgrade FROM. Default: "1.10.14"
+
+FROM centos:7
+
+# Use this to force a cache reset (e.g. for output purposes)
+#COPY $0 /tmp/Dockerfile
+
+# Install some other dependencies for ease of life.
+RUN  yum update -y \
+  && yum install -y wget git \
+  && yum clean all
+
+ARG before=1.10.14
+LABEL before=${before}
+
+# Install proper FROM repo: PC1 (puppet 4), puppet 5, or puppet 6.
+RUN if [[ ${before} == 1.* ]]; then \
+        echo Installing PC1 repo; \
+        wget -O puppet-pc1.rpm http://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm && \
+        rpm -i puppet-pc1.rpm; \
+    elif [[ ${before} == 5.* ]]; then \
+        echo Installing PC1 repo; \
+        wget -O puppet5.rpm http://yum.puppetlabs.com/puppet5/puppet5-release-el-7.noarch.rpm && \
+        rpm -i puppet5.rpm; \
+    elif [[ ${before} == 6.* ]]; then \
+        echo Installing PC1 repo; \
+        wget -O puppet6.rpm http://yum.puppetlabs.com/puppet6/puppet6-release-el-7.noarch.rpm && \
+        rpm -i puppet6.rpm; \
+    else echo no; \
+    fi
+
+# Print out which versions of the puppet-agent package are available (for reference).
+#RUN yum list puppet-agent --showduplicates
+
+# Install FROM version of puppet-agent.
+RUN yum -y update && \
+    yum install -y puppet-agent-${before}-1.el7
+
+# This is also duplicated in the docker/bin/helpers/run-upgrade.sh.
+ENV module_path=/tmp/modules
+WORKDIR "${module_path}/puppet_agent"
+COPY metadata.json ./
+
+# Dependency installation: Forge or source? The former is what the user will
+# have downloaded, but the latter allows testing of version bumps.
+# Install module dependencies from the Forge using Puppet Module Tool (PMT).
+RUN /opt/puppetlabs/puppet/bin/puppet module install --modulepath $module_path --target-dir .. puppetlabs-stdlib
+RUN /opt/puppetlabs/puppet/bin/puppet module install --modulepath $module_path --target-dir .. puppetlabs-inifile
+RUN /opt/puppetlabs/puppet/bin/puppet module install --modulepath $module_path --target-dir .. puppetlabs-apt
+
+# Installing dependencies from source. These versions should be within the range
+# of `dependencies` in metadata.json. `translate` is a dependency for inifile.
+#RUN git clone https://github.com/puppetlabs/puppetlabs-stdlib ../stdlib --branch 5.2.0
+#RUN git clone https://github.com/puppetlabs/puppetlabs-inifile ../inifile --branch 2.5.0
+#RUN git clone https://github.com/puppetlabs/puppetlabs-translate ../translate --branch 1.2.0
+#RUN git clone https://github.com/puppetlabs/puppetlabs-apt ../apt --branch 6.3.0
+
+# Check that all dependencies are installed.
+RUN /opt/puppetlabs/puppet/bin/puppet module --modulepath $module_path list --tree
+COPY docker/deploy.pp /tmp/deploy.pp
+RUN ["sh", "-c", "/opt/puppetlabs/puppet/bin/puppet apply --modulepath $module_path /tmp/deploy.pp"]
+
+# Now move the project directory's files into the image. That way, if these
+# files change, caching will skip everything before this.
+COPY docker/bin/helpers/run-upgrade.sh /tmp/bin/run-upgrade.sh
+COPY files/ ./files/
+COPY locales/ ./locales/
+COPY spec/ ./spec/
+COPY task_spec/  ./task_spec/
+COPY tasks/ ./tasks/
+COPY templates/ ./templates
+COPY types/ ./types/
+COPY Gemfile Gemfile.lock Rakefile ./
+COPY lib/ ./lib/
+COPY manifests/ ./manifests/
+
+COPY docker/upgrade.pp /tmp/upgrade.pp
+
+# Print out which versions of the puppet-agent package are available (for reference).
+#RUN yum list puppet-agent --showduplicates
+
+# Perform the upgrade.
+ENTRYPOINT ["/tmp/bin/run-upgrade.sh"]

--- a/docker/centos/Dockerfile.versions
+++ b/docker/centos/Dockerfile.versions
@@ -1,0 +1,18 @@
+FROM centos:7
+
+# Install some other dependencies for ease of life.
+RUN  yum update -y \
+  && yum install -y wget git \
+  && yum clean all
+
+# Install several repos: PC1 (puppet 4), puppet 5, and puppet 6.
+RUN wget -O puppet-pc1.rpm http://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm && \
+    rpm -i puppet-pc1.rpm --force --replacefiles && \
+    wget -O puppet5.rpm http://yum.puppetlabs.com/puppet5/puppet5-release-el-7.noarch.rpm && \
+    rpm -i puppet5.rpm --force --replacefiles && \
+    wget -O puppet6.rpm http://yum.puppetlabs.com/puppet6/puppet6-release-el-7.noarch.rpm && \
+    rpm -i puppet6.rpm --force --replacefiles --nodeps
+
+# Print out available package versions for puppet-agent. If a specific version
+# is desired, pass that in with e.g. `--build-arg before=1.1.1`
+ENTRYPOINT ["yum", "list", "puppet-agent", "--showduplicates"]

--- a/docker/deploy.pp
+++ b/docker/deploy.pp
@@ -1,0 +1,3 @@
+file {'/tmp/test-start-file':
+  ensure => file,
+}

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,0 +1,111 @@
+# This Dockerfile enables an iterative development workflow where you can make
+# a change and test it out quickly. The majority of commands in this file will
+# be cached, making the feedback loop typically quite short. The workflow is
+# as follows:
+#   1. Set up pre-conditions for the system in puppet code using `deploy.pp`.
+#   2. Make a change to the module.
+#   3. Run `docker build -f docker/Dockerfile .` or
+#      `./docker/bin/upgrade.sh ubuntu` from the project directory. If you would
+#      like to test specific version upgrades, you can add run this like so:
+#        `docker build -f docker/ubuntu/Dockerfile . \
+#           -t pa-dev:ubuntu --build-arg before=1.10.14`
+#   4. Upgrade the container by running the image:
+#        `docker run -it pa-dev:ubuntu`
+#      Specify your upgrade TO version as an argument to the `docker run`
+#      command.
+#   5. Review the output. Repeat steps 2-5 as needed.
+#
+# At the end of execution, you will see a line like:
+#
+# Notice: /Stage[main]/Puppet_agent::Install/Package[puppet-agent]/ensure: ensure changed '1.10.14-1xenial' to '6.2.0-1xenial'
+#
+# This specifies the versions that were used for upgrade.
+#
+# Arguments:
+# - before: The version to do upgrade FROM. Default: "1.10.14"
+
+FROM ubuntu:xenial
+
+# Install some other dependencies for ease of life.
+RUN  apt-get update \
+  && apt-get install -y wget git lsb-release apt-utils systemd \
+  && rm -rf /var/lib/apt/lists/*
+
+# Use this to force a cache reset (e.g. for output purposes)
+COPY $0 /tmp/Dockerfile
+
+# Print out which versions of the puppet-agent package are available (for reference).
+#RUN apt-cache madison puppet-agent
+
+ARG before=1.10.14
+LABEL before=${before}
+
+# Install proper FROM repo: PC1 (puppet 4), puppet 5, or puppet 6.
+RUN if (echo "$before" | grep -Eq  ^1\..*$) ; then \
+        echo Installing PC1 repo; \
+        wget -O puppet-pc1.deb http://apt.puppetlabs.com/puppetlabs-release-pc1-xenial.deb && \
+        dpkg -i puppet-pc1.deb; \
+    elif (echo "$before" | grep -Eq  ^5\..*$) ; then \
+        echo Installing puppet5 repo; \
+        wget -O puppet5.deb http://apt.puppetlabs.com/puppet5-release-xenial.deb && \
+        dpkg -i puppet5.deb; \
+    elif (echo "$before" | grep -Eq  ^6\..*$) ; then \
+        echo Installing puppet6 repo; \
+        wget -O puppet6.deb http://apt.puppetlabs.com/puppet6-release-xenial.deb && \
+        dpkg -i puppet6.deb; \
+    else echo no; \
+    fi
+
+# Install FROM version of puppet-agent.
+RUN apt-get update && \
+    apt-get -f -y install && \
+    apt-get install puppet-agent=${before}-1xenial
+
+# This is also duplicated in docker/bin/helpers/run-upgrade.sh.
+ENV module_path=/tmp/modules
+WORKDIR "${module_path}/puppet_agent"
+COPY metadata.json ./
+
+# Dependency installation: Forge or source? The former is what the user will
+# have downloaded, but the latter allows testing of version bumps.
+# Install module dependencies from the Forge using Puppet Module Tool (PMT).
+RUN /opt/puppetlabs/puppet/bin/puppet module install --modulepath $module_path --target-dir .. puppetlabs-stdlib
+RUN /opt/puppetlabs/puppet/bin/puppet module install --modulepath $module_path --target-dir .. puppetlabs-inifile
+RUN /opt/puppetlabs/puppet/bin/puppet module install --modulepath $module_path --target-dir .. puppetlabs-apt
+
+# Installing dependencies from source. These versions should be within the range
+# of `dependencies` in metadata.json. `translate` is a dependency for inifile.
+#RUN git clone https://github.com/puppetlabs/puppetlabs-stdlib ../stdlib --branch 5.2.0
+#RUN git clone https://github.com/puppetlabs/puppetlabs-inifile ../inifile --branch 2.5.0
+#RUN git clone https://github.com/puppetlabs/puppetlabs-translate ../translate --branch 1.2.0
+#RUN git clone https://github.com/puppetlabs/puppetlabs-apt ../apt --branch 6.3.0
+
+# Check that all dependencies are installed.
+RUN /opt/puppetlabs/puppet/bin/puppet module --modulepath $module_path list --tree
+COPY docker/deploy.pp /tmp/deploy.pp
+RUN ["sh", "-c", "/opt/puppetlabs/puppet/bin/puppet apply --modulepath $module_path /tmp/deploy.pp"]
+
+# Now move the project directory's files into the image. That way, if these
+# files change, caching will skip everything before this.
+COPY docker/bin/helpers/run-upgrade.sh /tmp/bin/run-upgrade.sh
+COPY files/ ./files/
+COPY locales/ ./locales/
+COPY spec/ ./spec/
+COPY task_spec/  ./task_spec/
+COPY tasks/ ./tasks/
+COPY templates/ ./templates
+COPY types/ ./types/
+COPY Gemfile Gemfile.lock Rakefile ./
+COPY lib/ ./lib/
+COPY manifests/ ./manifests/
+
+COPY docker/upgrade.pp /tmp/upgrade.pp
+
+# Print out which versions of the puppet-agent package are available in this
+# repo (for reference).
+#RUN apt-cache madison puppet-agent
+
+# Perform the upgrade. Arguments will be appended in `docker run` or use
+# defaults in the script.
+ENTRYPOINT ["/tmp/bin/run-upgrade.sh"]
+

--- a/docker/ubuntu/Dockerfile.versions
+++ b/docker/ubuntu/Dockerfile.versions
@@ -1,0 +1,22 @@
+FROM ubuntu:xenial
+
+# Use this to force a cache reset (e.g. for output purposes)
+#COPY docker/Dockerfile /tmp/Dockerfile
+
+# Install some other dependencies for ease of life.
+RUN  apt-get update \
+  && apt-get install -y wget git lsb-release apt-utils systemd \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install several repos: PC1 (puppet 4), puppet 5, and puppet 6.
+RUN wget -O puppet-pc1.deb http://apt.puppetlabs.com/puppetlabs-release-pc1-xenial.deb && \
+    dpkg -i --force-conflicts puppet-pc1.deb && \
+    wget -O puppet5.deb http://apt.puppetlabs.com/puppet5-release-xenial.deb && \
+    dpkg -i --force-conflicts puppet5.deb && \
+    wget -O puppet6.deb http://apt.puppetlabs.com/puppet6-release-xenial.deb && \
+    dpkg -i --force-conflicts puppet6.deb && \
+    apt-get update
+
+# Print out available package versions for puppet-agent. If a specific version
+# is desired, pass that in with e.g. `--build-arg before=1.1.1`
+ENTRYPOINT ["apt-cache", "madison", "puppet-agent"]

--- a/docker/upgrade.pp
+++ b/docker/upgrade.pp
@@ -1,0 +1,12 @@
+node default {
+  class { '::puppet_agent':
+    package_version => $facts['to_version'],
+    # Upgrades in Docker cannot start the puppet service due to systemd
+    # incompatibilities. Essentially, Docker expects an init system for
+    # services, but puppet installs services as systemd services. The line below
+    # ensures that no services are started, resulting in a proper upgrade
+    # process.
+    service_names   => [],
+    collection      => $facts['to_collection'],
+  }
+}


### PR DESCRIPTION
This commit decreases the feedback cycle time to enable iterative
development. The gist is that a developer can use Docker to test out
upgrades on a machine.

The `docker/bin/upgrade.sh [<PLATFORM>] [<BEFORE>] [<AFTER>]`
command builds a container on the `<PLATFORM>` platform that has the
`<BEFORE>` version of puppet on it and adds the `puppet_agent`
module. It then runs `puppet apply` in the container such that the
`<AFTER>` version of puppet exists afterward. This script ends with
a shell inside the container.

Available platforms are Ubuntu Xenial (`ubuntu`) and CentOS 7
(`centos`).

Also available is `docker/bin/versions.sh [<PLATFORM>]`, which will
output which versions of puppet are available on a given
`<PLATFORM>`.

For full details, see docker/ubuntu/Dockerfile or
docker/centos/Dockerfile.