### PR TITLE
(MODULES-8393) Add task required metadata, hide extra implementations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,23 +16,21 @@ before_install:
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.4.1
-    env: CHECK="validate lint"
-  - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="4.7.1" HIERA_GEM_VERSION="3.2.2" CHECK=spec
-  - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 4.10" CHECK=spec
-  - rvm: 2.4.1
+  - rvm: 2.5.3
+    env: CHECK="validate lint spec"
+  - rvm: 2.5.3
     env: PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
+  - rvm: 2.3.8
+    env: PUPPET_GEM_VERSION="~> 4.10" CHECK=spec
   # These cells test the task on different platforms
-  - rvm: 2.3.1
+  - rvm: 2.3.8
     dist: trusty
     env: GEM_BOLT=true BEAKER_debug=true BEAKER_set=docker/ubuntu-18.04
     install: bundle install
     script: cd task_spec && bundle exec rake task_acceptance
     services: docker
     sudo: required
-  - rvm: 2.3.1
+  - rvm: 2.3.8
     dist: trusty
     env: GEM_BOLT=true BEAKER_debug=true BEAKER_set=docker/centos-7
     install: bundle install

--- a/tasks/install_powershell.json
+++ b/tasks/install_powershell.json
@@ -1,5 +1,6 @@
 {
   "description": "Install the Puppet agent package",
+  "private": true,
   "parameters": {
     "version": {
       "description": "The version of puppet-agent to install",
@@ -9,9 +10,5 @@
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
       "type": "Optional[Enum[puppet5, puppet6, puppet]]"
     }
-  },
-  "implementations": [
-    {"name": "install_shell.sh", "requirements": ["shell"], "files": ["facts/tasks/bash.sh"], "input_method": "environment"},
-    {"name": "install_powershell.ps1", "requirements": ["powershell"]}
-  ]
+  }
 }

--- a/tasks/install_shell.json
+++ b/tasks/install_shell.json
@@ -1,5 +1,7 @@
 {
   "description": "Install the Puppet agent package",
+  "private": true,
+  "input_method": "environment",
   "parameters": {
     "version": {
       "description": "The version of puppet-agent to install",
@@ -9,9 +11,5 @@
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
       "type": "Optional[Enum[puppet5, puppet6, puppet]]"
     }
-  },
-  "implementations": [
-    {"name": "install_shell.sh", "requirements": ["shell"], "files": ["facts/tasks/bash.sh"], "input_method": "environment"},
-    {"name": "install_powershell.ps1", "requirements": ["powershell"]}
-  ]
+  }
 }

--- a/tasks/version.json
+++ b/tasks/version.json
@@ -2,7 +2,7 @@
   "description": "Get the version of the Puppet agent package installed. Returns nothing if none present.",
   "parameters": {},
   "implementations": [
-    {"name": "version_shell.sh", "requirements": ["shell"]},
+    {"name": "version_shell.sh", "requirements": ["shell"], "input_method": "environment"},
     {"name": "version_powershell.ps1", "requirements": ["powershell"]}
   ]
 }

--- a/tasks/version_powershell.json
+++ b/tasks/version_powershell.json
@@ -1,0 +1,5 @@
+{
+  "description": "Get the version of the Puppet agent package installed. Returns nothing if none present.",
+  "private": true,
+  "parameters": {}
+}

--- a/tasks/version_shell.json
+++ b/tasks/version_shell.json
@@ -1,0 +1,6 @@
+{
+  "description": "Get the version of the Puppet agent package installed. Returns nothing if none present.",
+  "private": true,
+  "input_method": "environment",
+  "parameters": {}
+}


### PR DESCRIPTION
Adds task metadata required to publish to the Forge. Also declare
input_method where it would use the default `both` and hide extra
implementations for task runners that implement private tasks and task
implementations.