### PR TITLE
(MODULES-8348) Acceptance scaffold with beaker-puppet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.iml
 .*.sw[op]
 .DS_Store
+.beaker/
 .bundle/
 .idea/
 .metadata
@@ -13,6 +14,8 @@ Gemfile.lock
 bin/
 coverage/
 doc/
+hosts.yaml
+hosts.yml
 junit/
 log/
 pkg/

--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -1,0 +1,26 @@
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
+
+# Find a location or specific version before installing a gem
+#
+# @param place_or_version can be one of:
+#   - A specific version,
+#   - A git branch, as `git://<your-repo>.git#<branch-name>`
+#   - A file URI, as `file:///absolute/file/path`
+def location_for(place, fake_version = nil)
+  if place =~ /^(git[:@][^#]*)#(.*)/
+    [fake_version, { git: $1, branch: $2, require: false }].compact
+  elsif place =~ /^file:\/\/(.*)/
+    ['>= 0', { path: File.expand_path($1), require: false }]
+  else
+    [place, { require: false }]
+  end
+end
+
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4')
+gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1')
+
+gem "beaker-docker", *location_for(ENV['BEAKER_DOCKER_VERSION'] || '~> 0')
+gem "beaker-vagrant", *location_for(ENV['BEAKER_VAGRANT_VERSION'] || '~> 0')
+gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || '~> 1')
+gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '~> 1')
+gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0')

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -1,0 +1,114 @@
+# Acceptance tests for puppetlabs-puppet_agent
+
+## Background
+
+### About Beaker
+
+Beaker is a host provisioning and an acceptance testing framework. If you are
+unfamiliar with beaker, you can start with these documents:
+
+- [The Beaker DSL document](https://github.com/puppetlabs/beaker/blob/master/docs/how_to/the_beaker_dsl.md) will help you understand the test code in the `tests/` and `pre_suite/` subdirectories.
+- [The Beaker Style Guide](https://github.com/puppetlabs/beaker/blob/master/docs/concepts/style_guide.md) will help you write new test code.
+- [Argument Processing](https://github.com/puppetlabs/beaker/blob/master/docs/concepts/argument_processing_and_precedence.md) and [Using Subcommands](https://github.com/puppetlabs/beaker/blob/master/docs/tutorials/subcommands.md) have more information on beaker's command line and environmental options.
+
+### About these tests
+
+This module is responsible for upgrading and downgrading puppet-agent.  Testing
+this behavior necessarily involves repeatedly installing and uninstalling
+puppet-agent. Ideally, the test hosts would be totally destroyed and
+reprovisioned before each fresh install of puppet-agent, but beaker does not
+support workflows like this. Instead:
+
+- Use the `run_setup` helper method to install puppet-agent, plus this module
+  and its dependencies, before the main content of each of your tests.
+- Use the `run_teardown` helper method to uninstall puppet-agent and remove
+  modules in your tests' teardown steps.
+
+See [helpers.rb](./helpers.rb) for the impelementations of these methods.
+
+#### Environment variables affecting test behavior
+
+When the `run_setup` helper installs puppet-agent, it determines the version to
+install as follows:
+
+1. If the `FROM_AGENT_VERSION` environment variable is set, install that version.
+2. Otherwise, install the latest agent from the `FROM_PUPPET_COLLECTION`
+    environment variable (set this to `pc1`, `puppet5`, or `puppet6` for puppet
+    versions 4.x, 5.x, or 6.x respectively).
+3. Otherwise, and by default, install the latest agent from the `pc1`
+    collection (this would be puppet-agent 1.x with puppet 4.x).
+
+During your tests, you may upgrade or downgrade puppet-agent to different
+versions. Unless you're testing a version-specific behavior, any tests that
+upgrade or downgrade the version of puppet-agent should use the
+`TO_AGENT_VERSION` environment variable as the target version by default.
+Similarly, use `TO_PUPPET_COLLECTION` in similar cases where behavior is based
+on the collection instead of the agent version.
+
+## How to run the tests
+
+### Install the dependencies
+
+This directory has its own Gemfile, containing gems required only for these
+acceptance tests. Ensure that you have [bundler](https://bundler.io/) installed,
+and then use it to install the dependencies:
+
+```sh
+bundle install --path .bundle
+```
+
+This will install [`beaker`](https://github.com/puppetlabs/beaker) and
+[`beaker-puppet`](https://github.com/puppetlabs/beaker-puppet) (a beaker
+library for working with puppet specifically), plus several hypervisor gems
+for working with beaker and vagrant, docker, or vsphere.
+
+### Set up the test hosts
+
+Before running any of the acceptance tests in the `tests/` directory, you must
+do the following once:
+
+- configure beaker,
+- provision VMs or containers as test hosts, and
+- run the setup tasks in the `pre_suite/` directory.
+
+Here's how:
+
+```sh
+# Use `beaker-hostgenerator` generate a hosts file that describes the
+# types of hosts you want to test. See beaker-hostgenerator's help for more
+# information on available host types and roles.
+# This example creates a Centos 7 master and a single Debian 9 agent, which will be provisioned with Docker.
+bundle exec beaker-hostgenerator -t docker centos7-64mcda-debian9-64a > ./hosts.yaml
+
+# Now run `beaker init` to generate configuration for this beaker run in
+# `.beaker/`. Pass it the location of your hosts file and the options file:
+bundle exec beaker init -h ./hosts.yaml -o options.rb
+
+# Create the VMs or containers that will act as the test hosts:
+bundle exec beaker provision
+
+# Now run the pre-suite setup tasks. This will install puppetserver and the
+# puppet_agent module on your master host in preparation for running the tests:
+bundle exec beaker exec pre-suite
+```
+
+### Run and re-run the tests
+
+Once you've set up beaker, you can run any number of tests any number of times:
+
+```sh
+# Run all the tests
+bundle exec beaker exec
+# Run all the tests in a specific directory
+bundle exec beaker exec ./tests/subdir
+# Run a commma-separated list of specific tests:
+bundle exec beaker exec ./path/to/test.rb,./another/test.rb
+```
+
+### Clean up
+
+You can destroy existing test hosts like this:
+
+```sh
+bundle exec beaker destroy
+```

--- a/acceptance/files/uninstall.ps1
+++ b/acceptance/files/uninstall.ps1
@@ -1,0 +1,13 @@
+$agentVer = Get-ChildItem -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall, HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall |
+    Get-ItemProperty |
+        Where-Object {$_.DisplayName -like "Puppet Agent*" } |
+            Select-Object -Property DisplayName, UninstallString
+
+ForEach ($ver in $agentVer) {
+    If ($ver.UninstallString) {
+        $uninst = "start /wait "+$ver.UninstallString+" /quiet /norestart /l*vx uninstall_puppet.log"
+        Write-Host "Uninstalling: $uninst"
+        & cmd.exe /c $uninst
+    }
+
+}

--- a/acceptance/helpers.rb
+++ b/acceptance/helpers.rb
@@ -1,0 +1,227 @@
+require 'beaker-puppet'
+
+module Beaker
+  module DSL
+    # Host selectors by role
+    module Roles
+      # Select any hosts which have the agent role and are not the master.
+      # Beaker's `agents` selector selects all of the hosts that have the
+      # `agent` role, but some masters may have _both_ the agent and master
+      # roles. This `agents_only` selector will not include any agent hosts that
+      # have the `master` role.
+      # @return [Array<Beaker::Host>] A set of beaker hosts which have the `agent` role but not the `master` role
+      def agents_only
+        hosts_as(:agent).reject { |host| host['roles'].include?('master') }.to_a
+      end
+    end
+
+    # Helpers for testing the puppetlabs-puppet_agent module with Beaker
+    module Helpers
+      # Purging puppet-agent between the tests requires a helper script for some
+      # platforms (for example, on Windows). This directory holds those scripts.
+      SUPPORTING_FILES = File.expand_path('./files').freeze
+
+      PE_ONLY_PLATFORMS = ['aix', 'amazon', 'sles', 'solaris', 'osx']
+
+      # Check for one or more environment variables and fail the test if they are not present
+      # @param [Array<String>] *names Any number of required environment variables
+      def expect_environment_variables(*names)
+        names.each do |name|
+          fail_test("Please set the $#{name} environment variable") unless ENV[name]
+        end
+      end
+
+      # Gather arguments for {Beaker::DSL::Helpers.install_puppet_agent_on}
+      # based on the environment, sanity check them, and format them for use in
+      # this module's tests. **This helper should be used this whenever
+      # {Beaker::DSL::Helpers.install_puppet_agent_on} is called.** The agent
+      # version is selected as follows:
+      #
+      #   - First, it attempts to determine an exact version of the agent to install, based on:
+      #     - `ENV['FROM_AGENT_VERSION']`, or, failing that,
+      #     - `ENV['PUPPET_CLIENT_VERSION']` (this was the name of the
+      #       equivalent environment variable in version 1.x of this module).
+      #   - If an exact version isn't available:
+      #     - `ENV['FROM_PUPPET_COLLECTION']` is checked to try to identify a
+      #       puppet collection to install from; Valid values here are `puppet5`
+      #       (latest release in the puppet 5 series), `puppet6` (latest release
+      #       in the puppet 6 series), and `pc1` (legacy, refers to the latest
+      #       release in the puppet 4 series.
+      #   - If none of the above is available, the `pc1` collection is used:
+      #     this selects the latest release of puppet-agent that uses Puppet 4.
+      #
+      # @see BeakerPuppet::Helpers::install_puppet_agent_on
+      # @raise [Beaker::DSL::Outcomes::FailTest] Raises when a specific version
+      #   of puppet-agent has been selected to install, but the SUT does not have
+      #   access to the internal Puppet build servers where these are hosted.
+      # @return [Hash] An options hash to pass to BeakerPuppet's `install_puppet_agent_on` method
+      def agent_install_options
+        agent_version = ENV['FROM_AGENT_VERSION'] || ENV['PUPPET_CLIENT_VERSION'] # This is the legacy name from puppet 3 / module 1.x
+
+        if agent_version
+          unless dev_builds_accessible?
+            # The user requested a specific build, but they can't download from internal sources
+            env_var_name = ENV['FROM_AGENT_VERSION'] ? 'FROM_AGENT_VERSION' : 'PUPPET_CLIENT_VERSION'
+            fail_test(<<-WHY
+  You requested a specific build of puppet-agent, but you don't have access to
+  Puppet's internal build servers. You can either:
+
+  - Unset the #{env_var_name} environment variable to accept the latest Puppet 4
+    agent release (this is the default), or
+  - Set the $FROM_PUPPET_COLLECTION environment variable to 'puppet5' or 'puppet6' to
+    use the latest releases from the 5 or 6 series.
+
+            WHY
+            )
+          end
+
+          return { puppet_agent_version: agent_version }
+        end
+
+        { puppet_collection: (ENV['FROM_PUPPET_COLLECTION'] || 'pc1').downcase }
+      end
+
+      # Use `puppet module install` to install the puppet_agent module's
+      # dependencies on the target host, and then install the puppet_agent
+      # module itself. Requires that puppet is installed in advance.
+      # @param [Beaker::Host] host The target host
+      def install_modules_on(host)
+        on(host, puppet('module', 'install', 'puppetlabs-stdlib',     '--version', '5.1.0'), { acceptable_exit_codes: [0] })
+        on(host, puppet('module', 'install', 'puppetlabs-inifile',    '--version', '2.4.0'), { acceptable_exit_codes: [0] })
+        on(host, puppet('module', 'install', 'puppetlabs-apt',        '--version', '6.0.0'), { acceptable_exit_codes: [0] })
+
+        install_dev_puppet_module_on(host,
+                                     source: File.join(File.dirname(__FILE__), '..', ),
+                                     module_name: 'puppet_agent')
+      end
+
+      # Install puppet-agent on all agent nodes at the version determined by
+      # {agent_install_options}, and connect them to the master. This is
+      # intended to prepare SUTs for tests that upgrade puppet-agent from some
+      # initial version.
+      def run_setup
+        logger.notify("Setup: Install puppet-agent on agents")
+
+        master_agent_version = puppet_agent_version_on(master)
+        fail_test("Expected puppet-agent to already be installed on the master, but it was not; make sure you have run the pre-suite tests") unless master_agent_version
+
+        master_fqdn = on(master, 'facter fqdn').stdout.strip
+
+        # Install the puppet-agent package and stop the firewalls
+        install_options = agent_install_options
+        agents_only.each do |agent|
+          if install_options[:puppet_agent_version] && dev_builds_accessible_on?(agent)
+            # Install from internal sources
+            install_puppet_agent_from_dev_builds_on(agent, install_options[:puppet_agent_version])
+          else
+            # Attempt to install from public sources; Won't work for PE platforms
+            install_puppet_agent_on(agent, agent_install_options)
+          end
+
+          stop_firewall_with_puppet_on(agent)
+
+          configure_puppet_on(agent, {
+              'main' => { 'server' => master_fqdn },
+          })
+        end
+
+        logger.notify("Setup: connect agents to master")
+
+        generate_and_sign_certificates
+
+        agents_only.each do |agent|
+          fail_test("Failed to install puppet-agent on #{agent} during setup") unless puppet_agent_version_on(agent)
+        end
+      end
+
+      # Purge puppet-agent and this module's `pc_repo` repository (if present)
+      # from all agents (but _not_ from the master).
+      def run_teardown
+        logger.notify("Teardown: Purge puppet from agents")
+
+        agents_only.each do |host|
+          next unless puppet_agent_version_on(host)
+
+          if host['platform'] =~ /windows/
+            scp_to(host, "#{SUPPORTING_FILES}/uninstall.ps1", "uninstall.ps1")
+            on(host, 'rm -rf C:/ProgramData/PuppetLabs')
+            on(host, 'powershell.exe -File uninstall.ps1 < /dev/null')
+          else
+            manifest_lines = []
+            # Remove pc_repo:
+            # Note pc_repo is specific to this module's manifests. This is knowledge we need to clean from the machine after each run.
+            if host['platform'] =~ /debian|ubuntu/
+              on(host, puppet('module', 'install', 'puppetlabs-apt'), { acceptable_exit_codes: [0] })
+              manifest_lines << "include apt"
+              manifest_lines << "apt::source { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"
+            elsif host['platform'] =~ /fedora|el|centos/
+              manifest_lines << "yumrepo { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"
+            end
+
+            manifest_lines << "file { ['/etc/puppet', '/etc/puppetlabs', '/etc/mcollective']: ensure => absent, force => true, backup => false }"
+
+            if host['platform'] =~ /^(osx|solaris)/
+              # The macOS pkgdmg and Solaris sun providers don't support 'purged':
+              manifest_lines << "package { ['puppet-agent']: ensure => absent }"
+            else
+              manifest_lines << "package { ['puppet-agent']: ensure => purged }"
+            end
+
+            on(host, puppet('apply', '-e', %("#{manifest_lines.join("\n")}"), '--no-report'), acceptable_exit_codes: [0, 2])
+          end
+        end
+      end
+
+      # Wraps {Beaker::DSL::PuppetHelpers.with_puppet_running_on} to apply a default
+      # manifest to all nodes and execute a block. Behaves as follows:
+      #
+      # 1. Set up a `site.pp` file in the production environment on the master
+      #    such that the puppet code in `site_pp_contents` is applied to all nodes.
+      #    - If a `site.pp` already exists there, record its contents and
+      #      permissions and create a teardown task to restore them after the test
+      #      finishes.
+      # 2. Using {Beaker::DSL::PuppetHelpers.with_puppet_running_on}:
+      #    - Perform a puppet run on the agents, and
+      #    - execute the block, if any.
+      #
+      # @see Beaker::DSL::PuppetHelpers.with_puppet_running_on
+      # @param [String] site_pp_contents The contents of the default site.pp file. This
+      #   content will be wrapped as follows, so that it applies to all nodes:
+      #     ```
+      #     node default {
+      #       #{site_pp_contents}
+      #     }
+      #     ```
+      # @param [Hash] master_opts Options to pass to {Beaker::DSL::PuppetHelpers.with_puppet_running_on}.
+      # @yield [self] Invokes {Beaker::DSL::PuppetHelpers.with_puppet_running_on}, passing along master_opts, if supplied.
+      def with_default_site_pp(site_pp_contents, master_opts = {})
+        manifest_contents = %(node default { #{site_pp_contents} })
+
+        # PMT will have installed dependencies in the production environment; Put our manifest there, too:
+        site_pp_path = File.join(master.puppet['environmentpath'], 'production', 'manifests', 'site.pp')
+
+        if file_exists_on(master, site_pp_path)
+          original_contents = file_contents_on(master, site_pp_path)
+          original_perms = on(master, %(stat -c "%a" #{site_pp_path})).stdout.strip
+
+          teardown do
+            on(master, %(echo "#{original_contents}" > #{site_pp_path}))
+            on(master, %(chmod #{original_perms} #{site_pp_path}))
+          end
+        else
+          teardown do
+            on(master, "rm -f #{site_pp_path}")
+          end
+        end
+
+        create_remote_file(master, site_pp_path, manifest_contents)
+        on(master, "chmod 755 #{site_pp_path}")
+
+        with_puppet_running_on(master, master_opts) do
+          on(agents_only, puppet("agent --test --server #{master.hostname}"), acceptable_exit_codes: [0, 2])
+          yield if block_given?
+        end
+      end
+    end
+  end
+end

--- a/acceptance/options.rb
+++ b/acceptance/options.rb
@@ -1,0 +1,14 @@
+{
+  pre_suite: 'pre_suite',
+  tests: 'tests',
+
+  # Ensure the defaults are correct; we can't trust beaker to get this right.
+  # Most of these are defaults that stop beaker from expecting/trying to use puppet 3:
+
+  type: 'aio', # this is a FOSS install; Note that beaker considers the 'foss' type to be FOSS puppet 3. AIO is FOSS puppet 4+.
+  'is_puppetserver': true,
+  'use-service': true,
+  'puppetservice': 'puppetserver',
+  'puppetserver-confdir': '/etc/puppetlabs/puppetserver/conf.d',
+  'puppetserver-config':'/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf'
+}

--- a/acceptance/pre_suite/00_master_setup.rb
+++ b/acceptance/pre_suite/00_master_setup.rb
@@ -1,0 +1,49 @@
+require 'beaker-puppet'
+require_relative '../helpers'
+
+opts = agent_install_options
+
+if opts[:puppet_agent_version]
+  description = "at version #{opts[:puppet_agent_version]}"
+elsif opts[:puppet_collection]
+  description = "from collection '#{opts[:puppet_collection]}'"
+else
+  description = 'at default version'
+end
+
+# Install an agent package on the master:
+test_name "Pre-Suite: Install puppet-agent #{description} on the master" do
+  install_puppet_agent_on(master, opts)
+
+  agent_version = puppet_agent_version_on(master)
+  fail_test('Failed to install puppet-agent') unless agent_version
+
+  logger.notify("Installed puppet-agent #{agent_version}")
+end
+
+# We'll assume here that the agent package has been installed from a repo
+# (since master platforms all use repos) and that we can grab whatever
+# puppetserver comes with that repo:
+test_name 'Pre-Suite: Install and start a compatible puppetserver on the master' do
+  install_package(master, 'puppetserver')
+  master_fqdn = on(master, 'facter fqdn').stdout.strip
+  master_hostname = on(master, 'hostname').stdout.strip
+
+  configure_puppet_on(master, {
+    'main' => { 'server' => master_fqdn },
+    'master' => { 'dns_alt_names' => "puppet,#{master_hostname},#{master_fqdn}"}
+  })
+
+  server_version = puppetserver_version_on(master)
+  fail_test('Failed to install puppetserver') unless server_version
+
+  logger.notify("Installed puppetserver #{server_version}")
+
+  stop_firewall_with_puppet_on(master)
+  on(master, puppet('resource', 'service', master['puppetservice'], 'ensure=running', 'enable=true'))
+end
+
+# Now install the puppet_agent module itself, and its dependencies
+test_name 'Pre-Suite: Install puppet_agent module and dependencies on the master' do
+  install_modules_on(master)
+end

--- a/acceptance/tests/test_package_version_parameter.rb
+++ b/acceptance/tests/test_package_version_parameter.rb
@@ -1,0 +1,27 @@
+require 'beaker-puppet'
+require_relative '../helpers'
+
+# Tests an upgrade from one specific agent version to another.
+# @example
+#   FROM_AGENT_VERSION=6.0.1 TO_AGENT_VERSION=6.0.2 beaker exec ./tests/test_package_version_parameter.rb
+test_name 'puppet_agent class: package_version parameter for FOSS upgrades' do
+  confine :except, platform: PE_ONLY_PLATFORMS
+
+  expect_environment_variables('FROM_AGENT_VERSION', 'TO_AGENT_VERSION')
+  teardown { run_teardown }
+  run_setup
+
+  target_version = ENV['TO_AGENT_VERSION']
+
+  manifest_content = <<-PP
+  class { 'puppet_agent': package_version => '#{target_version}' }
+PP
+
+  agents_only.each do |agent|
+    with_default_site_pp(manifest_content) do
+      installed_version = puppet_agent_version_on(agent)
+      assert_equal(target_version, installed_version,
+                   "Expected puppet-agent version '#{target_version}' to be installed on #{agent} (#{agent['platform']}), but found '#{installed_version}'")
+    end
+  end
+end


### PR DESCRIPTION
This commit is a starting point for future work:

It adds an acceptance directory containing a set of scaffold test files and helpers to allow for testing this module with beaker-puppet instead of beaker-puppet_install_helper (which is no longer supported). The README in the acceptance directory describes how to run the new tests. Our plan is to test only FOSS functionality (not PE) in the updated acceptance tests

This leaves the existing tests in spec/acceptance intact for now; in the future these old tests will either be migrated to the acceptance directory, or (if they test puppet 3 functionality) removed.

Take note that this process will also eventually remove beaker-rspec, since it is incompatible with the use of subcommands in beaker 4.

This commit depends on the merge and release of https://github.com/puppetlabs/beaker/pull/1563 and https://github.com/puppetlabs/beaker-puppet/pull/89 -- I will update the Gemfile here to require the new tags once they are made. I'll block this PR until then.