### PR TITLE
(MODULES-8446) Improve error messages for PE-only platforms

### DIFF
--- a/manifests/osfamily/aix.pp
+++ b/manifests/osfamily/aix.pp
@@ -3,6 +3,14 @@ class puppet_agent::osfamily::aix(
 ) {
   assert_private()
 
+  if $::operatingsystem != 'AIX' {
+    fail("${::operatingsystem} not supported")
+  }
+
+  if $::puppet_agent::is_pe != true {
+    fail('AIX upgrades are only supported on Puppet Enterprise')
+  }
+
   class { 'puppet_agent::prepare::package':
     package_file_name => $package_file_name,
   }

--- a/manifests/osfamily/darwin.pp
+++ b/manifests/osfamily/darwin.pp
@@ -7,6 +7,10 @@ class puppet_agent::osfamily::darwin(
     fail("${::macosx_productname} ${::maxosx_productversion_major} not supported")
   }
 
+  if $::puppet_agent::is_pe != true {
+    fail("${::macosx_productname} upgrades are only supported on Puppet Enterprise")
+  }
+
   class { 'puppet_agent::prepare::package':
     package_file_name => $package_file_name,
   }

--- a/manifests/osfamily/solaris.pp
+++ b/manifests/osfamily/solaris.pp
@@ -7,7 +7,7 @@ class puppet_agent::osfamily::solaris(
     fail("${::operatingsystem} not supported")
   }
 
-  if $::puppet_agent::is_pe == false {
+  if $::puppet_agent::is_pe != true {
     fail('Solaris upgrades are only supported on Puppet Enterprise')
   }
 

--- a/manifests/osfamily/suse.pp
+++ b/manifests/osfamily/suse.pp
@@ -3,8 +3,12 @@ class puppet_agent::osfamily::suse(
 ) {
   assert_private()
 
-  if $::operatingsystem != 'SLES' or getvar('::puppet_agent::is_pe') == false {
+  if $::operatingsystem != 'SLES' {
     fail("${::operatingsystem} not supported")
+  }
+
+  if $::puppet_agent::is_pe != true {
+    fail('SLES upgrades are only supported on Puppet Enterprise')
   }
 
   case $::operatingsystemmajrelease {

--- a/spec/classes/puppet_agent_osfamily_aix_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_aix_spec.rb
@@ -3,11 +3,13 @@ require 'spec_helper'
 describe 'puppet_agent' do
   let(:common_facts) {
     {
-      is_pe:           true,
-      osfamily:        'AIX',
-      operatingsystem: 'AIX',
-      servername:      'master.example.vm',
-      clientcert:      'foo.example.vm',
+      architecture:               'PowerPC_POWER7',
+      clientcert:                 'foo.example.vm',
+      is_pe:                      true,
+      operatingsystem:            'AIX',
+      osfamily:                   'AIX',
+      platform_tag:               'aix-7.2-power',
+      servername:                 'master.example.vm',
     }
   }
 
@@ -87,6 +89,25 @@ describe 'puppet_agent' do
       context "aix #{aixver}" do
         include_examples 'aix', aixver, pkg_aixver, powerver
       end
+    end
+  end
+
+  context 'unsupported environments' do
+    let(:params) {
+      {
+          package_version: '6.0.0',
+          collection: 'puppet6'
+      }
+    }
+
+    context 'outside PE' do
+      let(:facts) { common_facts.merge({ is_pe: false }) }
+      it { expect { catalogue }.to raise_error(/Puppet Enterprise/) }
+    end
+
+    context 'not AIX' do
+      let(:facts) { common_facts.merge({ operatingsystem: 'not-AIX' })}
+      it { expect { catalogue }.to raise_error(/not supported/)}
     end
   end
 end

--- a/spec/classes/puppet_agent_osfamily_darwin_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_darwin_spec.rb
@@ -29,6 +29,14 @@ describe 'puppet_agent' do
   }
 
   describe 'unsupported environment' do
+    context 'when not PE' do
+      let(:facts) do
+        facts.merge(is_pe: false)
+      end
+
+      it { expect { catalogue }.to raise_error(/Puppet Enterprise/) }
+    end
+
     context "when OSX 10.8" do
       let(:facts) do
         facts.merge({

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -32,18 +32,15 @@ describe 'puppet_agent' do
   describe 'unsupported environment' do
     context 'when not PE' do
       let(:facts) do
-        facts.merge({
-          :is_pe => false,
-        })
+        facts.merge(is_pe: false)
       end
 
-      it { expect { catalogue }.to raise_error(/SLES not supported/) }
+      it { expect { catalogue }.to raise_error(/Puppet Enterprise/) }
     end
 
     context 'when not SLES' do
       let(:facts) do
         facts.merge({
-          :is_pe           => false,
           :operatingsystem => 'OpenSuse',
         })
       end

--- a/spec/classes/puppet_agent_prepare_spec.rb
+++ b/spec/classes/puppet_agent_prepare_spec.rb
@@ -7,20 +7,10 @@ MCO_LOGFILE = '/var/log/puppetlabs/mcollective.log'
 
 describe 'puppet_agent::prepare' do
   context 'supported operating system families' do
-    ['Debian', 'RedHat', 'SuSE'].each do |osfamily|
-      case osfamily
-      when 'SuSE'
-        os = 'SLES'
-        osmajor = '10'
-      else
-        os = 'foo'
-        osmajor = '42'
-      end
-
-
+    ['Debian', 'RedHat'].each do |osfamily|
       facts = {
-        :operatingsystem => os,
-        :operatingsystemmajrelease => osmajor,
+        :operatingsystem => 'foo',
+        :operatingsystemmajrelease => '42',
         :architecture => 'bar',
         :osfamily => osfamily,
         :lsbdistid => osfamily,


### PR DESCRIPTION
Previously, macOS upgrades (which are supported only under PE) would
fail silently outside of PE. This adds an error message for that case
and updates other PE-only platforms so that they have consistent error
messages for FOSS installations.