### PR TITLE
(MODULES-8445) Fix collection determination outside PE

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -112,17 +112,26 @@ class puppet_agent::params {
     true    => pe_build_version(),
     default => undef
   }
-  # Not PE or pe_version < 2018.1.3, use PC1
-  if ($_pe_version == undef or versioncmp("${_pe_version}", '2018.1.3') < 0) {
+
+  # The default behavior is to install the most recent version of the package
+  # that's compatible with the agent on the master. Find the puppet collection
+  # that matches it:
+  if versioncmp("${::aio_agent_version}", '5.0.0') < 0 {
+    # PE versions before 2018.1.3 use the Puppet 4 series of puppet agent
+    # releases. Outside of PE, we refer to this series of releases as 'PC1'. Note
+    # that although they include Puppet 4, the puppet-agent packages in this
+    # series are numbered '1.y.z' (later series _do_ match the version of puppet
+    # to that of the puppet-agent package, though).
     $collection = 'PC1'
-  }
-  # 2018.1.3 <= pe_version < 2018.2, use puppet5
-  elsif versioncmp("${_pe_version}", '2018.2') < 0 {
+  } elsif versioncmp("${::aio_agent_version}", '5.99.0') < 0 { # (5.99.z indicates pre-release puppet6)
+    # PE versions between 2018.1.3 and 2018.2 contain Puppet 5:
     $collection = 'puppet5'
-  }
-  # pe_version >= 2018.2, use puppet6
-  else {
+  } elsif versioncmp("${::aio_agent_version}", '6.99.0') < 0 {
+    # PE versions 2018.2 and later contain Puppet 6:
     $collection = 'puppet6'
+  } else {
+    # The 'puppet' collection always installs the latest release:
+    $collection = 'puppet'
   }
 
   $ssldir = "${confdir}/ssl"

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -1,30 +1,31 @@
 require 'spec_helper'
 
 describe 'puppet_agent' do
+  # All FOSS and all Puppet 4+ upgrades require the package_version
+  package_version = '1.10.14'
+
   facts = {
+    :aio_agent_verison => '1.10.13',
     :lsbdistid => 'Debian',
     :osfamily => 'Debian',
     :lsbdistcodename => 'wheezy',
     :os => {
-      'name' => 'Debian',
-      'release' => {
-        'full' => '6.0',
-        'major' => '6',
-      },
+        'name' => 'Debian',
+        'release' => {
+            'full' => '8.0',
+            'major' => '8',
+        },
     },
     :operatingsystem => 'Debian',
     :architecture => 'x64',
-      :servername   => 'master.example.vm',
-      :clientcert   => 'foo.example.vm',
+    :servername   => 'master.example.vm',
+    :clientcert   => 'foo.example.vm',
   }
 
-  # All FOSS and all Puppet 4+ upgrades require the package_version
-  package_version = '1.10.100'
   let(:params) {
-    {
-      :package_version => package_version
-    }
+    { :package_version => package_version }
   }
+
   let(:facts) { facts }
 
   it { is_expected.to contain_class('apt') }

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -15,10 +15,11 @@ describe 'puppet_agent' do
       :architecture              => 'x64',
       :servername                => 'master.example.vm',
       :clientcert                => 'foo.example.vm',
+      :aio_agent_version         => '5.5.3'
     }
   end
 
-  [['Fedora', 'fedora/f$releasever', 27], ['Fedora', 'fedora/f$releasever', 29], ['CentOS', 'el/$releasever', 7], ['Amazon', 'el/6', 6]].each do |os, urlbit, osmajor|
+  [['Fedora', 'fedora/$releasever', 27], ['Fedora', 'fedora/$releasever', 29], ['CentOS', 'el/$releasever', 7], ['Amazon', 'el/6', 6]].each do |os, urlbit, osmajor|
     context "with #{os} and #{urlbit}" do
       let(:facts) do
         super().merge(:operatingsystem  => os, :operatingsystemmajrelease => osmajor)
@@ -80,7 +81,7 @@ describe 'puppet_agent' do
         }
         it { is_expected.not_to contain_yumrepo('puppetlabs-pepackages').with_ensure('absent') }
         it { is_expected.to contain_yumrepo('pc_repo').with({
-          'baseurl' => "http://yum.puppetlabs.com/#{urlbit}/PC1/x64",
+          'baseurl' => "http://yum.puppetlabs.com/puppet5/#{urlbit}/x64",
           'enabled' => 'true',
             'gpgcheck' => '1',
             'gpgkey' => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs\n  file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet",

--- a/spec/classes/puppet_agent_params_spec.rb
+++ b/spec/classes/puppet_agent_params_spec.rb
@@ -1,77 +1,47 @@
 require 'spec_helper'
 
 describe 'puppet_agent::params' do
-  let(:facts) do
-    {
-      is_pe:           true,
-      clientversion:   '5.5.3',
-      osfamily:        'Debian',
-      operatingsystem: 'Debian',
-      servername:      'server',
-      # custom fact meant to be used only for tests in this file
-      custom_fact__pe_version: '2018.1.3'
-    }
-  end
+  facts = {
+    osfamily: 'Debian'
+  }
 
-  before(:each) do
-    Puppet::Parser::Functions.newfunction(:pe_build_version, type: :rvalue, doc: '') do |args|
-      lookupvar('::custom_fact__pe_version')
-    end
-  end
-
-  context 'collection' do
-    # rspec-puppet lets us query the compiled catalog only, so we can only check if any specific resources
-    # have been declared. We cannot query for a class' variables, so we cannot query for the collection
-    # variable's value. But we can use a workaround by creating a notify resource whose message contains
-    # the value and query that instead since it will be added as part of the catalog. post_condition tells
-    # rspec-puppet to include this resource only after our class has been compiled, which is what we want.
-    let(:notify_title) { "check puppet_agent::params::collection's value" }
-    let(:post_condition) do
-      <<-NOTIFY_RESOURCE
+  # rspec-puppet lets us query the compiled catalog only, so we can only check
+  # if any specific resources have been declared. We cannot query for class
+  # variables, so we cannot query for the collection variable's value. But we
+  # can use a workaround by creating a notify resource whose message contains
+  # the value and query that instead since it will be added as part of the
+  # catalog. notify_resource tells rspec-puppet to include this resource only
+  # after our class has been compiled, which is what we want.
+  let(:notify_title) { "check puppet_agent::params::collection's value" }
+  let(:post_condition) do
+    <<-NOTIFY_RESOURCE
 notify { "#{notify_title}":
   message => "${::puppet_agent::params::collection}"
 }
-      NOTIFY_RESOURCE
-    end
+    NOTIFY_RESOURCE
+  end
 
-    def sets_collection_to(collection)
-      is_expected.to contain_notify(notify_title).with_message(collection)
-    end
+  def sets_collection_to(collection)
+    is_expected.to contain_notify(notify_title).with_message(collection)
+  end
 
-    context 'not in PE' do
-      let(:facts) { super().merge(is_pe: false, custom_fact__pe_version: '') }
-
-      it { sets_collection_to('PC1') }
-    end
-
-    context 'pe_version < 2018.1.3' do
-      let(:facts) { super().merge(custom_fact__pe_version: '2018.1.2') }
-
-      it { sets_collection_to('PC1') }
-    end
-
-    context 'pe_version == 2018.1.3' do
-      let(:facts) { super().merge(custom_fact__pe_version: '2018.1.3') }
-
-      it { sets_collection_to('puppet5') }
-    end
-
-    context '2018.1.3 < pe_version < 2018.2' do
-      let(:facts) { super().merge(custom_fact__pe_version: '2018.1.5') }
-
-      it { sets_collection_to('puppet5') }
-    end
-
-    context 'pe_version == 2018.2' do
-      let(:facts) { super().merge(custom_fact__pe_version: '2018.2') }
-
-      it { sets_collection_to('puppet6') }
-    end
-
-    context 'pe_version > 2018.2' do
-      let(:facts) { super().merge(custom_fact__pe_version: '2018.3') }
-
-      it { sets_collection_to('puppet6') }
+  context 'default puppet_collection value' do
+    {
+      '0.0.0'   => 'PC1',
+      '1.10.14' => 'PC1',
+      '3.2.1'   => 'PC1',
+      '5.5.4'   => 'puppet5',
+      '6.0.2'   => 'puppet6',
+      '5.99.0'  => 'puppet6',
+      '100.0.0' => 'puppet',
+      ''        => 'PC1',
+    }.each do |agent_version, default_collection|
+      context "when puppet-agent version is '#{agent_version}'" do
+        let(:facts) { facts.merge(aio_agent_version: agent_version) }
+        it "the default collection is '#{default_collection}'" do
+          sets_collection_to(default_collection)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
By default, this module installs the most recent version of puppet-agent
that's compatible with the master's version, using puppet collections to
do so.

Previously, the name of the default puppet collection was determined
based on the installed version of PE, which was technically correct for
PE installations, but did not help outside of PE. For open source users,
it incorrectly selected 'PC1' as the collection name regardless of which
version of the agent was installed on the master.

This derives the collection name from the aio_agent_version fact on the
master instead, as follows:

- Agents in the 1.y.z series (containing puppet 4) still get `PC1`
- Agents in the 5.y.z series (containing puppet 5) now get `puppet5`
- Agents in the 6.y.z series (containing puppet 6) now get `puppet6`
- Later agents will get 'puppet', which always defaults to the latest release (this would be puppet6 right now)
- The default, absent any aio_agent_version information, is still to install from `PC1`