### PR TITLE
(MODULES-8443) Don't restart mco for FOSS puppet6 upgrades

### DIFF
--- a/files/solaris_start_puppet.sh
+++ b/files/solaris_start_puppet.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 
 puppet_pid=$1
+shift
+service_names=$*
+
 while $(kill -0 ${puppet_pid:?}); do
   sleep 5
 done
 
-function start_service() {
-  service="${1:?}"
-  /opt/puppetlabs/bin/puppet resource service "${service:?}" ensure=running enable=true
-}
-
-start_service puppet
-start_service mcollective
+for service_name in $service_names; do
+  /opt/puppetlabs/bin/puppet resource service "${service_name:?}" ensure=running enable=true
+done

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -172,14 +172,16 @@ class puppet_agent (
     contain '::puppet_agent::prepare'
     contain '::puppet_agent::install'
 
-    # On windows, our MSI handles the services
-    # On PE AIO nodes, PE Agent nodegroup is managing the services
+    # Service management:
+    # - Under Puppet Enterprise, the agent nodegroup is managed by PE, and we don't need to manage services here.
+    # - On Windows, services are handled by the puppet-agent MSI packages themselves.
+    # ...but outside of PE, on other platforms, we must make sure the services are restarted. We do that with the
+    # ::puppet_agent::service class. Make sure it's applied after the install process finishes if needed:
     if $::osfamily != 'windows' and (!$is_pe or versioncmp($::clientversion, '4.0.0') < 0) {
       class { '::puppet_agent::service':
         require => Class['::puppet_agent::install'],
       }
       contain '::puppet_agent::service'
     }
-
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -40,6 +40,7 @@ class puppet_agent::install(
     # The following are expected to be available in the solaris_install.sh.erb template:
     $adminfile = '/opt/puppetlabs/packages/solaris-noask'
     $sourcefile = "/opt/puppetlabs/packages/${_unzipped_package_name}"
+    $service_names = $puppet_agent::service_names
 
     # Puppet prior to 5.0 would not use a separate process contract when forking from the Puppet
     # service. That resulted in service-initiated upgrades failing because trying to remove or

--- a/manifests/windows/install.pp
+++ b/manifests/windows/install.pp
@@ -13,6 +13,8 @@ class puppet_agent::windows::install(
   ) {
   assert_private()
 
+  $service_names         = $::puppet_agent::service_names
+
   if $::puppet_agent::is_pe {
     $_agent_version = $puppet_agent::params::master_agent_version
     $_pe_server_version = pe_build_version()

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -173,13 +173,16 @@ describe 'puppet_agent' do
               end
             end
 
-            # Windows platform does not use Service resources
+            # Windows platform does not use Service resources; their services
+            # are managed by the MSI installer.
             unless facts[:osfamily] == 'windows'
               if params[:service_names].nil? &&
                   !(facts[:osfamily] == 'Solaris' && facts[:operatingsystemmajrelease] == '11') &&
                   os !~ /sles/
                 it { is_expected.to contain_service('puppet') }
-                it { is_expected.to contain_service('mcollective') }
+                if Puppet.version < "5.99.0" # mcollective was removed in puppet 6 (5.99 indicates a pre-release version)
+                  it { is_expected.to contain_service('mcollective') }
+                end
               else
                 it { is_expected.to_not contain_service('puppet') }
                 it { is_expected.to_not contain_service('mcollective') }

--- a/templates/install_puppet.bat.erb
+++ b/templates/install_puppet.bat.erb
@@ -39,9 +39,10 @@ REM sets its startup type, which prevents installs from proceeding.
 REM This may fail on agents without pxp-agent, but since this is not
 REM run interactively and the next command sets ERRORLEVEL, it's OK.
 net stop pxp-agent
-REM Same for the Marionette Collective Service and Puppet Agent service
-net stop mcollective
-net stop puppet
+REM Same for the <% @service_names.join(', ') %> services
+<% @service_names.each do |service_name| %>
+net stop <%= service_name %>
+<% end %>
 
 REM Log the current user token privileges for debugging
 whoami /all

--- a/templates/solaris_install.sh.erb
+++ b/templates/solaris_install.sh.erb
@@ -12,5 +12,7 @@ pkgadd -a <%= @adminfile %> -d <%= @sourcefile %> -G <%= @install_options.join('
 # Ensure services are running. We do this on Solaris 10 b/c the installer cannot restart
 # services on its own since that only happens when the service manifests change, which is
 # highly unlikely in most agent upgrade scenarios.
-start_service puppet
-start_service mcollective
+
+<% @service_names.each do |service_name| %>
+start_service <%= service_name %>
+<% end %>


### PR DESCRIPTION
When attempting to upgrade to or within the puppet 6 series in an open
source context (that is, only outside of PE), the module was still
attempting to restart the mcollective servicte after the upgrade -- but
mcollective was removed in puppet 6.

This updates the agent class params so that they find an accurate list
of the services to restart under FOSS.