### PR TITLE
(maint) Update task_acceptance tests to use updated dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ group :system_tests do
   gem "puppet-blacksmith", '~> 3.4',                                             :require => false
   # Bundler fails on 2.1.9 even though this group is excluded
   if ENV['GEM_BOLT']
-    gem 'bolt', '~> 1.1.0', require: false
+    gem 'bolt', '~> 1.9', require: false
     gem 'beaker-task_helper', '~> 1.5.2', require: false
   end
 end

--- a/task_spec/.fixtures.yml
+++ b/task_spec/.fixtures.yml
@@ -2,6 +2,6 @@ fixtures:
   forge_modules:
     facts:
       repo: "puppetlabs/facts"
-      ref: "0.4.1"
+      ref: "0.5.0"
   symlinks:
     puppet_agent: "#{File.absolute_path(File.join(source_dir, '..'))}"

--- a/task_spec/Rakefile
+++ b/task_spec/Rakefile
@@ -10,6 +10,4 @@ PuppetLint.configuration.send('disable_single_quote_string_with_variables')
 PuppetLint.configuration.send('disable_only_variable_string')
 PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
-task :task_acceptance => [:spec_prep, :beaker] do
-  # nothing to do
-end
+task :task_acceptance => [:spec_prep, :beaker]


### PR DESCRIPTION
Previously bolt was pinned back to 1.1.x due to an issue in https://github.com/puppetlabs/bolt/pull/824 which was fixed in 1.9.0. There has also been a new release in the facts module we would like to be testing with. Finally the task acceptance test invocation has been modified to be more succinct and to match other modules that use conditionally require bolt to test module content.