### PR TITLE
(FM-7656) Use the HTTPS endpoint to fetch puppet-agent MSI files.

### DIFF
--- a/tasks/install_powershell.ps1
+++ b/tasks/install_powershell.ps1
@@ -28,7 +28,7 @@ else {
     $msi_name = "puppet-agent-${arch}-latest.msi"
 }
 
-$msi_source = "http://downloads.puppetlabs.com/windows/${collection}/${msi_name}"
+$msi_source = "https://downloads.puppetlabs.com/windows/${collection}/${msi_name}"
 
 $date_time_stamp = (Get-Date -format s) -replace ':', '-'
 $msi_dest = Join-Path ([System.IO.Path]::GetTempPath()) "puppet-agent-$arch.msi"


### PR DESCRIPTION
Prior to this fix, we were getting things from the HTTP endpoint, which
had the possibility of a man-in-the-middle attack. This closes that.