### PR TITLE
(MODULES-8348) Acceptance scaffold with beaker-puppet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.iml
 .*.sw[op]
 .DS_Store
+.beaker/
 .bundle/
 .idea/
 .metadata
@@ -13,6 +14,8 @@ Gemfile.lock
 bin/
 coverage/
 doc/
+hosts.yaml
+hosts.yml
 junit/
 log/
 pkg/

--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -1,0 +1,28 @@
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
+
+# Find a location or specific version before installing a gem
+#
+# @param place_or_version can be one of:
+#   - A specific version,
+#   - A git branch, as `git://<your-repo>.git#<branch-name>`
+#   - A file URI, as `file:///absolute/file/path`
+def location_for(place, fake_version = nil)
+  if place =~ /^(git[:@][^#]*)#(.*)/
+    [fake_version, { git: $1, branch: $2, require: false }].compact
+  elsif place =~ /^file:\/\/(.*)/
+    ['>= 0', { path: File.expand_path($1), require: false }]
+  else
+    [place, { require: false }]
+  end
+end
+
+gem "rake", "~> 12.3"
+
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4')
+gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 1.15')
+
+gem "beaker-docker", *location_for(ENV['BEAKER_DOCKER_VERSION'] || '~> 0')
+gem "beaker-vagrant", *location_for(ENV['BEAKER_VAGRANT_VERSION'] || '~> 0')
+gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || '~> 1')
+gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '~> 1')
+gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0')

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -1,0 +1,125 @@
+# Acceptance tests for puppetlabs-puppet_agent
+
+These integration tests use the [beaker](https://github.com/puppetlabs/beaker)
+acceptance test framework to test puppet-agent installation and upgrades with
+the puppetlabs-puppet_agent module.
+
+## Quick start
+
+If you are already familiar with beaker, you can get started like this:
+
+```sh
+# Install the dependencies
+bundle install
+# Create a hosts.yml file in this directory with at least one master and one agent
+bundle exec beaker-hostgenerator -t docker centos7-64mcda-debian8-64a > hosts.yml
+# Use the `prepare` rake task to provision your hosts and set up the master with the latest puppet 5 agent and server:
+MASTER_COLLECTION=puppet5 bundle exec rake prepare
+# Run the tests
+bundle exec beaker exec ./tests/
+# Destroy your test hosts
+bundle exec beaker destroy
+```
+
+See "How to run the tests", below, for more detail.
+
+## Background
+
+### About Beaker
+
+Beaker is a host provisioning and an acceptance testing framework. If you are
+unfamiliar with beaker, you can start with these documents:
+
+- [The Beaker DSL document](https://github.com/puppetlabs/beaker/blob/master/docs/how_to/the_beaker_dsl.md) will help you understand the test code in the `tests/` and `pre_suite/` subdirectories.
+- [The Beaker Style Guide](https://github.com/puppetlabs/beaker/blob/master/docs/concepts/style_guide.md) will help you write new test code.
+- [Argument Processing](https://github.com/puppetlabs/beaker/blob/master/docs/concepts/argument_processing_and_precedence.md) and [Using Subcommands](https://github.com/puppetlabs/beaker/blob/master/docs/tutorials/subcommands.md) have more information on beaker's command line and environmental options.
+
+### About these tests
+
+This module is responsible for upgrading and downgrading puppet-agent. Testing
+this behavior necessarily involves repeatedly installing and uninstalling
+puppet-agent. Ideally, the test hosts would be totally destroyed and
+reprovisioned before each fresh install of puppet-agent, but beaker does not
+support workflows like this. Instead, helper methods are used to install
+puppet-agent on agent hosts at the beginning of each test and to uninstall it
+during teardown. See [helpers.rb](./helpers.rb) for more.
+
+#### Environment variables and the `prepare` rake task
+
+The `prepare` rake task runs `beaker init`, `beaker provision`, and `beaker
+pre-suite` all at once to provision your test hosts and prepare you to run
+`beaker exec` on the tests you care about.
+
+The pre-suite installs a puppet-agent package and a compatible puppetserver
+package on the master host in preparation for running tests on the agent hosts.
+It also installs this module (from your local checkout) and its dependencies.
+
+The versions of puppet-agent and puppetserver installed on the master during
+the pre-suite can be controlled in two ways:
+
+- set `MASTER_COLLECTION` to 'pc1' (for puppet 4), 'puppet5', or 'puppet6' to
+  install the latest releases from those streams, or
+- set `MASTER_PACKAGE_VERSION` to a specific version of puppet-agent (like
+  '5.5.10') to install that agent package and a compatible puppetserver
+
+You may also set `DEBUG` to run beaker in debug mode.
+
+## How to run the tests
+
+### Install the dependencies
+
+This directory has its own Gemfile, containing gems required only for these
+acceptance tests. Ensure that you have [bundler](https://bundler.io/) installed,
+and then use it to install the dependencies:
+
+```sh
+bundle install --path .bundle
+```
+
+This will install [`beaker`](https://github.com/puppetlabs/beaker) and
+[`beaker-puppet`](https://github.com/puppetlabs/beaker-puppet) (a beaker
+library for working with puppet specifically), plus several hypervisor gems for
+working with beaker and vagrant, docker, or vsphere.
+
+### Set up the test hosts
+
+Use `beaker-hostgenerator` generate a hosts file that describes the types of
+hosts you want to test. See beaker-hostgenerator's help for more information on
+available host OSes, types and roles.
+
+Make sure your set of test hosts has at least one host with the master role and
+one host with the agent role. This example creates a Centos 7 master and a
+single Debian 9 agent, which will be provisioned with Docker:
+
+```sh
+bundle exec beaker-hostgenerator -t docker centos7-64mcda-debian9-64a > ./hosts.yaml
+```
+
+Decide on a collection or version of puppet-agent to use on your master, and
+run the `prepare` rake task to set it up. This example installs the latest
+puppet-agent and puppetserver in the puppet 5 series on the master:
+
+```sh
+MASTER_COLLECTION=puppet5 bundle exec rake prepare
+````
+
+### Run and re-run the tests
+
+Once you've set up beaker, you can run any number of tests any number of times:
+
+```sh
+# Run all the tests
+bundle exec beaker exec ./tests/
+# Run all the tests in a specific directory
+bundle exec beaker exec ./tests/subdir
+# Run a commma-separated list of specific tests:
+bundle exec beaker exec ./path/to/test.rb,./another/test.rb
+```
+
+### Clean up
+
+To destroy the provisioned test hosts:
+
+```sh
+bundle exec beaker destroy
+```

--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -1,0 +1,60 @@
+def beaker(command)
+  debug_flag = ''
+  if ENV['BEAKER_debug'] || ENV['DEBUG']
+    debug_flag = '--debug'
+  end
+
+  sh(%(beaker #{command} #{debug_flag}))
+end
+
+desc 'Prepare for running tests: Run beaker init, provision, and pre-suite all at once.'
+task :prepare do
+  errors = []
+
+  if !ENV['MASTER_PACKAGE_VERSION'] && !ENV['MASTER_COLLECTION']
+    errors << 'You must set a starting version of puppet-agent using ' +
+              '$MASTER_PACKAGE_VERSION or $MASTER_COLLECTION'
+  end
+
+  if ENV['HOSTS']
+    hosts_file = File.expand_path(ENV['HOSTS'])
+    errors << "Couldn't find $HOSTS file at #{hosts_file}" unless File.exist?(hosts_file)
+  elsif File.exist?('hosts.yml')
+    hosts_file = './hosts.yml'
+  elsif File.exist?('hosts.yaml')
+    hosts_file = './hosts.yaml'
+  else
+    errors << 'Unable to find a hosts file in $HOSTS or at ./hosts.yml or at ./hosts.yaml'
+  end
+
+  unless errors.empty?
+    raise errors.join("\n")
+  end
+
+  puts "Using beaker hosts file #{hosts_file}"
+
+  # Log the contents of the host file if running in Jenkins
+  if ENV['JENKINS_HOME']
+    pp File.read(hosts_file)
+  end
+
+  beaker("init -h #{hosts_file} -o options.rb")
+  beaker("provision")
+  beaker("exec ./pre_suite")
+
+  # Don't print these human instructions if running in Jenkins
+  unless ENV['JENKINS_HOME']
+    puts 'You can run individual test(s) with `bundle exec beaker exec <path-to-test(s)>`'
+    puts "You can destroy your provisioned hosts with `bundle exec beaker destroy` when you're ready"
+  end
+end
+
+desc 'Run all the tests and destroy the hosts afterward'
+task :ci do
+  begin
+    Rake.application['prepare'].invoke
+    beaker('exec ./tests')
+  ensure
+    beaker('destroy')
+  end
+end

--- a/acceptance/files/uninstall.ps1
+++ b/acceptance/files/uninstall.ps1
@@ -1,0 +1,13 @@
+$agentVer = Get-ChildItem -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall, HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall |
+    Get-ItemProperty |
+        Where-Object {$_.DisplayName -like "Puppet Agent*" } |
+            Select-Object -Property DisplayName, UninstallString
+
+ForEach ($ver in $agentVer) {
+    If ($ver.UninstallString) {
+        $uninst = "start /wait "+$ver.UninstallString+" /quiet /norestart /l*vx uninstall_puppet.log"
+        Write-Host "Uninstalling: $uninst"
+        & cmd.exe /c $uninst
+    }
+
+}

--- a/acceptance/helpers.rb
+++ b/acceptance/helpers.rb
@@ -1,0 +1,231 @@
+require 'beaker-puppet'
+
+module Beaker
+  module DSL
+    # Host selectors by role
+    module Roles
+      # Select any hosts which have the agent role and are not the master.
+      # Beaker's `agents` selector selects all of the hosts that have the
+      # `agent` role, but some masters may have _both_ the agent and master
+      # roles. This `agents_only` selector will not include any agent hosts that
+      # have the `master` role.
+      #
+      # @return [Array<Beaker::Host>] A set of beaker hosts which have the `agent` role but not the `master` role
+      def agents_only
+        hosts_as(:agent).reject { |host| host['roles'].include?('master') }.to_a
+      end
+    end
+
+    # Helpers for testing the puppetlabs-puppet_agent module with Beaker
+    module Helpers
+      # Purging puppet-agent between the tests requires a helper script for some
+      # platforms (for example, on Windows). This directory holds those scripts.
+      SUPPORTING_FILES = File.expand_path('./files').freeze
+
+      # These platforms are only supported under Puppet Enterprise, and FOSS
+      # tests should be skipped on them.
+      PE_ONLY_UPGRADES = %w[aix amazon sles solaris osx]
+
+      # Use `puppet module install` to install the puppet_agent module's
+      # dependencies on the target host, and then install the puppet_agent
+      # module itself. Requires that puppet is installed in advance.
+      #
+      # @param [Beaker::Host] host The target host
+      def install_puppet_agent_module_on(host)
+        on(host, puppet('module', 'install', 'puppetlabs-stdlib',     '--version', '5.1.0'), { acceptable_exit_codes: [0] })
+        on(host, puppet('module', 'install', 'puppetlabs-inifile',    '--version', '2.4.0'), { acceptable_exit_codes: [0] })
+        on(host, puppet('module', 'install', 'puppetlabs-apt',        '--version', '6.0.0'), { acceptable_exit_codes: [0] })
+
+        install_dev_puppet_module_on(host,
+                                     source: File.join(File.dirname(__FILE__), '..', ),
+                                     module_name: 'puppet_agent')
+      end
+
+      # Install puppet-agent on all agent nodes and connect them to the master.
+      # This is intended to prepare SUTs for tests that upgrade puppet-agent
+      # from some initial version.
+      #
+      # @param [String] initial_package_version_or_collection Either a version
+      #   of puppet-agent or the name of a puppet collection to install the agent from.
+      def prepare_upgrade_with(initial_package_version_or_collection)
+        master_agent_version = fact_on(master, 'aio_agent_version')
+        unless master_agent_version
+          fail_test('Expected puppet-agent to already be installed on the master, but it was not. ' \
+                    'Try running the `prepare` rake task.')
+        end
+
+        step 'Setup: Prepare agents for upgrade' do
+          step 'Install puppet-agent on agent hosts' do
+            initial_package_version_or_collection ||= master_agent_version
+            if initial_package_version_or_collection =~ /(^pc1$|^puppet\d+)/i
+              agent_install_options = { puppet_collection: initial_package_version_or_collection }
+            else
+              agent_install_options = {
+                puppet_agent_version: initial_package_version_or_collection,
+                puppet_collection: puppet_collection_for(:puppet_agent, initial_package_version_or_collection)
+              }
+            end
+
+            block_on(agents_only) do |agent|
+              install_puppet_agent_on(agent, agent_install_options)
+            end
+          end
+
+          step 'Clear SSL and stop firewalls' do
+            block_on(agents_only) do |agent|
+              ssldir = puppet_config(agent, 'ssldir').strip
+              on(agent, "rm -rf '#{ssldir}'/*") # Preserve the directory itself, to keep permissions
+
+              stop_firewall_with_puppet_on(agent)
+            end
+          end
+
+          step 'Sign certs' do
+            master_fqdn = on(master, facter('fqdn')).stdout.strip
+            master_hostname = on(master, facter('hostname')).stdout.strip
+            master_conf = { 'main' => {
+                'autosign'      => true,
+                'dns_alt_names' => "puppet,#{master_hostname},#{master_fqdn}",
+                'verbose'       => true,
+                'daemonize'     => true,
+            }}
+
+            with_puppet_running_on(master, master_conf) do
+              block_on(agents_only) do |agent|
+                on(agent, puppet("agent --test --server #{master}"), acceptable_exit_codes: [0])
+              end
+            end
+          end
+        end
+      end
+
+      # Purge puppet-agent and this module's `pc_repo` repository (if present)
+      # from all agents (but _not_ from the master).
+      def purge_agents
+        step 'Teardown: purge puppet from agents' do
+          step 'Clear agent certs from master' do
+            server_version = puppetserver_version_on(master)
+            agent_certnames = agents_only.map(&:to_s)
+            if version_is_less('5.99.99', server_version)
+              on(master, "puppetserver ca clean --certname #{agent_certnames.join(',')}")
+            else
+              on(master, puppet("cert clean #{agent_certnames.join(' ')}"))
+            end
+          end
+
+          step 'Uninstall puppet-agent on agents'
+          agents_only.each do |agent|
+            next unless fact_on(agent, 'aio_agent_version')
+
+            if agent['platform'] =~ /windows/
+              scp_to(agent, "#{SUPPORTING_FILES}/uninstall.ps1", "uninstall.ps1")
+              on(agent, 'rm -rf C:/ProgramData/PuppetLabs')
+              on(agent, 'powershell.exe -File uninstall.ps1 < /dev/null')
+            else
+              manifest_lines = []
+              # Remove pc_repo:
+              # Note pc_repo is specific to this module's manifests. This is
+              # knowledge we need to clean from the machine after each run.
+              if agent['platform'] =~ /debian|ubuntu/
+                on(agent, puppet('module', 'install', 'puppetlabs-apt'), acceptable_exit_codes: [0])
+                manifest_lines << 'include apt'
+                manifest_lines << "apt::source { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"
+              elsif agent['platform'] =~ /fedora|el|centos/
+                manifest_lines << "yumrepo { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"
+              end
+
+              manifest_lines << "file { ['/etc/puppet', '/etc/puppetlabs', '/etc/mcollective']: ensure => absent, force => true, backup => false }"
+
+              if agent['platform'] =~ /^(osx|solaris)/
+                # The macOS pkgdmg and Solaris sun providers don't support 'purged':
+                manifest_lines << "package { ['puppet-agent']: ensure => absent }"
+              else
+                manifest_lines << "package { ['puppet-agent']: ensure => purged }"
+              end
+
+              on(agent, puppet('apply', '-e', %("#{manifest_lines.join("\n")}"), '--no-report'), acceptable_exit_codes: [0, 2])
+            end
+          end
+        end
+      end
+
+      # Wraps {Beaker::DSL::PuppetHelpers.with_puppet_running_on} to apply a default
+      # manifest to all nodes and execute a block. Behaves as follows:
+      #
+      # 1. Set up a `site.pp` file in the production environment on the master
+      #    such that the puppet code in `site_pp_contents` is applied to all nodes.
+      #    - If a `site.pp` already exists there, record its contents and
+      #      permissions and create a teardown task to restore them after the test
+      #      finishes.
+      # 2. Using {Beaker::DSL::PuppetHelpers.with_puppet_running_on}:
+      #    - Perform a puppet run on the agents, and
+      #    - execute the block, if any.
+      #
+      # @see Beaker::DSL::PuppetHelpers.with_puppet_running_on
+      # @param [String] site_pp_contents The contents of the default site.pp file. This
+      #   content will be wrapped as follows, so that it applies to all nodes:
+      #     ```
+      #     node default {
+      #       #{site_pp_contents}
+      #     }
+      #     ```
+      # @param [Hash] master_opts Options to pass to {Beaker::DSL::PuppetHelpers.with_puppet_running_on}.
+      # @yield Invokes {Beaker::DSL::PuppetHelpers.with_puppet_running_on},
+      # passing along master_opts, if supplied.
+      def with_default_site_pp(site_pp_contents, master_opts = {})
+        manifest_contents = %(node default { #{site_pp_contents} })
+
+        # PMT will have installed dependencies in the production environment; We will put our manifest there, too:
+        site_pp_path = File.join(puppet_config(master, 'codedir'), 'environments', 'production', 'manifests', 'site.pp')
+
+        if file_exists_on(master, site_pp_path)
+          original_contents = file_contents_on(master, site_pp_path)
+          original_perms = on(master, %(stat -c "%a" #{site_pp_path})).stdout.strip
+
+          teardown do
+            on(master, %(echo "#{original_contents}" > #{site_pp_path}))
+            on(master, %(chmod #{original_perms} #{site_pp_path}))
+          end
+        else
+          teardown do
+            on(master, "rm -f #{site_pp_path}")
+          end
+        end
+
+        create_remote_file(master, site_pp_path, manifest_contents)
+        on(master, %(chown #{puppet_user(master)} "#{site_pp_path}"))
+        on(master, %(chmod 755 "#{site_pp_path}"))
+
+        with_puppet_running_on(master, master_opts) do
+          on(agents_only, puppet(%(agent --test --server #{master.hostname})), acceptable_exit_codes: [0, 2])
+          yield if block_given?
+        end
+      end
+
+      # Wraps {with_default_site_pp} to:
+      #
+      # - Install the a puppet-agent package (`initial_package_version_or_collection`)
+      #   on all the agent hosts,
+      # - Put a teardown step in place so that this package is uninstalled after the test,
+      # - Run a default manifest on all the agent hosts, and
+      # - Allow for assertions inside in a block
+      #
+      # @param [String] initial_package_version_or_collection Either a version
+      #   of puppet-agent or the name of a puppet collection to install on agent hosts
+      # @param [String] upgrade_manifest A manifest to apply to all agent nodes
+      def run_foss_upgrade_with_manifest(initial_package_version_or_collection, upgrade_manifest)
+        confine :except, platform: PE_ONLY_UPGRADES
+
+        logger.notify("Performing FOSS upgrade with default manifest:\n#{upgrade_manifest}")
+
+        prepare_upgrade_with(initial_package_version_or_collection)
+        teardown { purge_agents }
+
+        with_default_site_pp(upgrade_manifest) do
+          # Put your assertions here
+          yield if block_given?
+        end
+      end
+    end
+  end
+end

--- a/acceptance/options.rb
+++ b/acceptance/options.rb
@@ -1,0 +1,14 @@
+{
+  pre_suite: 'pre_suite',
+  tests: 'tests',
+
+  # Ensure the defaults are correct; we can't trust beaker to get this right.
+  # Most of these are defaults that stop beaker from expecting/trying to use puppet 3:
+
+  type: 'aio', # this is a FOSS install; Note that beaker considers the 'foss' type to be FOSS puppet 3. AIO is FOSS puppet 4+.
+  'is_puppetserver': true,
+  'use-service': true,
+  'puppetservice': 'puppetserver',
+  'puppetserver-confdir': '/etc/puppetlabs/puppetserver/conf.d',
+  'puppetserver-config':'/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf'
+}

--- a/acceptance/pre_suite/00_master_setup.rb
+++ b/acceptance/pre_suite/00_master_setup.rb
@@ -1,0 +1,88 @@
+require 'beaker-puppet'
+require_relative '../helpers'
+
+install_options = {}
+
+if ENV['MASTER_PACKAGE_VERSION']
+  install_options[:puppet_agent_version] = ENV['MASTER_PACKAGE_VERSION'].strip
+  install_options[:puppet_collection] = puppet_collection_for(:puppet_agent, install_options[:puppet_agent_version])
+  description = "at version #{install_options[:puppet_agent_version]}"
+elsif ENV['MASTER_COLLECTION']
+  install_options[:puppet_collection] = ENV['MASTER_COLLECTION'].downcase.strip
+  description = "from collection '#{install_options[:puppet_collection]}'"
+else
+  description = 'at default version'
+end
+
+# Install a puppet-agent package on the master:
+test_name "Pre-Suite: Install puppet-agent #{description} on the master" do
+  install_puppet_agent_on(master, install_options)
+
+  agent_version = puppet_agent_version_on(master)
+  fail_test('Failed to install puppet-agent') unless agent_version
+
+  logger.notify("Installed puppet-agent #{agent_version} on master")
+end
+
+# Install a compatible puppetserver:
+test_name 'Pre-Suite: Install, configure, and start a compatible puppetserver on the master' do
+  server_version = nil
+
+  step 'Install puppetserver' do
+    # puppetserver is distributed in "release streams" instead of collections.
+    if install_options[:puppet_collection] =~ /^pc1$/i
+      # There is no release stream that's equivalent to the PC1 (puppet-agent
+      # 1.y.z/puppet 4) collection; This version is fine.
+      opts = { version: '2.8.1' }
+    else
+      # puppet collections _do_ match with server release streams from puppet 5 onward.
+      opts = { release_stream: install_options[:puppet_collection] }
+    end
+
+    install_puppetserver_on(master, opts)
+
+    server_version = puppetserver_version_on(master)
+    fail_test('Failed to install puppetserver') unless server_version
+
+    logger.notify("Installed puppetserver #{server_version} on master")
+  end
+
+  step 'Configure puppetserver' do
+    server_version = puppetserver_version_on(master)
+    master_fqdn = on(master, 'facter fqdn').stdout.strip
+    master_hostname = on(master, 'hostname').stdout.strip
+
+    puppet_conf = { 'main' => {
+      'dns_alt_names' => "puppet,#{master_hostname},#{master_fqdn}",
+      'server'        => master_fqdn,
+      'verbose'       => true,
+    }}
+
+    lay_down_new_puppet_conf(master, puppet_conf, create_tmpdir_on(master))
+
+    unless version_is_less(server_version, '6.0.0')
+      tk_config = { 'certificate-authority' => { 'allow-subject-alt-names' => true }}
+      path = '/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf'
+      modify_tk_config(master, path, tk_config)
+    end
+  end
+
+  step 'Stop the firewall, clear SSL, set up the CA, if needed' do
+    stop_firewall_with_puppet_on(master)
+    ssldir = puppet_config(master, 'ssldir').strip
+    on(master, "rm -rf '#{ssldir}'/*") # Preserve the directory itself, to keep permissions
+    unless version_is_less(server_version, '6.0.0')
+      on(master, 'puppetserver ca setup')
+    end
+  end
+
+
+  step 'Start puppetserver' do
+    on(master, puppet('resource', 'service', master['puppetservice'], 'ensure=running', 'enable=true'))
+  end
+end
+
+# Now install the puppet_agent module itself, and its dependencies
+test_name 'Pre-Suite: Install puppet_agent module and dependencies on the master' do
+  install_puppet_agent_module_on(master)
+end

--- a/acceptance/tests/test_upgrade_pc1_to_puppet5.rb
+++ b/acceptance/tests/test_upgrade_pc1_to_puppet5.rb
@@ -1,0 +1,30 @@
+require 'beaker-puppet'
+require_relative '../helpers'
+
+# Tests FOSS upgrades from the latest puppet 4 (the PC1 collection) to puppet 5.5.10.
+# This test will only run if the version of puppet on the master host is less than 5.
+test_name 'puppet_agent class: collection parameter for FOSS upgrades' do
+  master_agent_version = puppet_agent_version_on(master)
+
+  unless version_is_less(master_agent_version, '5.0.0')
+    skip_test("The puppet-agent package on the master is #{master_agent_version}; Skipping PC1 to puppet5 upgrade test")
+  end
+
+  upgrade_to = '5.5.10'
+
+  manifest = <<-PP
+  class { puppet_agent:
+    package_version => '#{upgrade_to}',
+    collection      => 'puppet5'
+  }
+  PP
+
+  run_foss_upgrade_with_manifest('PC1', manifest) do
+    agents_only.each do |agent|
+      installed_version = puppet_agent_version_on(agent)
+      assert_equal(upgrade_to, installed_version,
+                   "Expected puppet-agent #{upgrade_to} to be installed on #{agent} (#{agent['platform']}), but found '#{installed_version}'")
+    end
+  end
+end
+

--- a/acceptance/tests/test_upgrade_puppet5_to_puppet6.rb
+++ b/acceptance/tests/test_upgrade_puppet5_to_puppet6.rb
@@ -1,0 +1,29 @@
+require 'beaker-puppet'
+require_relative '../helpers'
+
+# Tests FOSS upgrades from the latest puppet 5 (the puppet5 collection) to puppet 6.0.0.
+# This test will only run if the version of puppet on the master host is less than 6.
+test_name 'puppet_agent class: collection parameter for FOSS upgrades' do
+  master_agent_version = puppet_agent_version_on(master)
+
+  unless version_is_less(master_agent_version, '6.0.0')
+    skip_test("The puppet-agent package on the master is #{master_agent_version}; Skipping puppet5 to puppet6 upgrade test")
+  end
+
+  upgrade_to = '6.0.0'
+
+  manifest = <<-PP
+  class { puppet_agent:
+    package_version => '#{upgrade_to}',
+    collection      => 'puppet6'
+  }
+  PP
+
+  run_foss_upgrade_with_manifest('puppet5', manifest) do
+    agents_only.each do |agent|
+      installed_version = puppet_agent_version_on(agent)
+      assert_equal(upgrade_to, installed_version,
+                   "Expected puppet-agent #{upgrade_to} to be installed on #{agent} (#{agent['platform']}), but found '#{installed_version}'")
+    end
+  end
+end


### PR DESCRIPTION
Adds an acceptance directory containing a set of scaffold test files
and helpers to allow for testing this module with beaker-puppet instead
of beaker-puppet_install_helper (which is no longer supported). The
README in the acceptance directory describes how to run the new tests.

This leaves the existing tests in spec/acceptance intact for now; in the
future these old tests will either be migrated to the acceptance
directory, or (if they test puppet 3 functionality) removed.

Take note that this process will also eventually remove beaker-rspec,
since it is incompatible with the use of subcommands in beaker 4.

Do not merge until https://github.com/puppetlabs/beaker-puppet/pull/97 has been merged and released. I will need to update the beaker version in the Gemfile once that happens to require a new enough beaker release.