### PR TITLE
(MODULES-8406) fix the broken unless check for inherited permissions

### DIFF
--- a/manifests/windows/install.pp
+++ b/manifests/windows/install.pp
@@ -84,7 +84,7 @@ class puppet_agent::windows::install(
   # PUP-5480/PE-15037 Cache dir loses inheritable SYSTEM perms
   exec { 'fix inheritable SYSTEM perms':
     command => "${::system32}\\icacls.exe \"${::puppet_client_datadir}\" /grant \"SYSTEM:(OI)(CI)(F)\"",
-    unless  => "${::system32}\\icacls.exe \"${::puppet_client_datadir}\" | findstr \"SYSTEM:(OI)(CI)(F)\"",
+    unless  => "${::system32}\\cmd.exe /c ${::system32}\\icacls.exe \"${::puppet_client_datadir}\" | findstr \"SYSTEM:(OI)(CI)(F)\"",
     require => Exec['install_puppet.ps1'],
   }
 }


### PR DESCRIPTION
The windows provider only runs bare commands, which means an embedded pipe
will be seen as a command parameter and not a pipe. This change adds a cmd
shell as the primary command such that piping, etc. will work as expected.