### PR TITLE
(MODULES-4730) Do not pass the agent environment during MSI installs

### DIFF
--- a/templates/install_puppet.ps1.erb
+++ b/templates/install_puppet.ps1.erb
@@ -288,7 +288,6 @@ try {
     $temp_puppetres = Move-PuppetresDLL
   }
   $msi_arguments = "/qn /norestart /i `"$Source`" /l*vx+ `"$Logfile`""
-  $msi_arguments += " PUPPET_AGENT_ENVIRONMENT=`"$((puppet.bat config print --section agent environment) -replace '\s','')`""
   if ($InstallDir) {
     $msi_arguments += " INSTALLDIR=`"$InstallDir`""
   }


### PR DESCRIPTION
Since the MSI installer already preserves the environment of an existing
agent install, there's no need to specify it. Additionally, when there is
no 'environment' key present in puppet.conf, this would set the environment
key to the default value 'production', which can cause nodes to be
incorrectly classified after upgrades.