### PR TITLE
(MODULES-5535) Update test matrix to work with MacOS/Solaris/Windows

### DIFF
--- a/acceptance/pre_suite/00_master_setup.rb
+++ b/acceptance/pre_suite/00_master_setup.rb
@@ -81,8 +81,3 @@ test_name 'Pre-Suite: Install, configure, and start a compatible puppetserver on
     on(master, puppet('resource', 'service', master['puppetservice'], 'ensure=running', 'enable=true'))
   end
 end
-
-# Now install the puppet_agent module itself, and its dependencies
-test_name 'Pre-Suite: Install puppet_agent module and dependencies on the master' do
-  install_puppet_agent_module_on(master)
-end

--- a/acceptance/tests/test_upgrade_pc1_to_puppet5.rb
+++ b/acceptance/tests/test_upgrade_pc1_to_puppet5.rb
@@ -6,17 +6,37 @@ test_name 'puppet_agent class: collection parameter for FOSS upgrades' do
   require_master_collection 'puppet5'
   exclude_pe_upgrade_platforms
 
-  set_up_agents_to_upgrade('pc1')
+  puppet_testing_environment = new_puppet_testing_environment
 
-  step "Upgrading the agents from PC1 to Puppet 5..." do
+  step "Create new site.pp with upgrade manifest" do
     manifest = <<-PP
+node default {
   class { puppet_agent:
     package_version => '5.5.10',
     collection      => 'puppet5'
   }
+}
     PP
-    apply_manifest_on_agents(manifest)
+    site_pp_path = File.join(environment_location(puppet_testing_environment), 'manifests', 'site.pp')
+    create_remote_file(master, site_pp_path, manifest)
+    on(master, %(chown #{puppet_user(master)} "#{site_pp_path}"))
+    on(master, %(chmod 755 "#{site_pp_path}"))
   end
 
-  assert_successful_upgrade('5.5.10')
+  agents_only.each do |agent|
+    set_up_initial_agent_on(agent, 'pc1') do
+      step '(Agent) Change agent environment to testing environment' do
+        on(agent, puppet("config --section agent set environment #{puppet_testing_environment}"))
+        on(agent, puppet("config --section user set environment production"))
+      end
+    end
+  end
+
+  step "Upgrade the agents from Puppet 4 to Puppet 5..." do
+    agents_only.each do |agent|
+      start_puppet_service_and_wait_for_puppet_run(agent)
+      wait_for_installation_pid(agent)
+      assert_agent_version_on(agent, '5.5.10')
+    end
+  end
 end

--- a/acceptance/tests/test_upgrade_puppet5_to_puppet6.rb
+++ b/acceptance/tests/test_upgrade_puppet5_to_puppet6.rb
@@ -6,17 +6,37 @@ test_name 'puppet_agent class: collection parameter for FOSS upgrades' do
   require_master_collection 'puppet5'
   exclude_pe_upgrade_platforms
 
-  set_up_agents_to_upgrade('puppet5')
+  puppet_testing_environment = new_puppet_testing_environment
 
-  step "Upgrading the agents from Puppet 5 to Puppet 6..." do
+  step "Create new site.pp with upgrade manifest" do
     manifest = <<-PP
+node default {
   class { puppet_agent:
     package_version => '6.0.0',
     collection      => 'puppet6'
   }
+}
     PP
-    apply_manifest_on_agents(manifest)
+    site_pp_path = File.join(environment_location(puppet_testing_environment), 'manifests', 'site.pp')
+    create_remote_file(master, site_pp_path, manifest)
+    on(master, %(chown #{puppet_user(master)} "#{site_pp_path}"))
+    on(master, %(chmod 755 "#{site_pp_path}"))
   end
 
-  assert_successful_upgrade('6.0.0')
+  agents_only.each do |agent|
+    set_up_initial_agent_on(agent, 'puppet5') do
+      step '(Agent) Change agent environment to testing environment' do
+        on(agent, puppet("config --section agent set environment #{puppet_testing_environment}"))
+        on(agent, puppet("config --section user set environment production"))
+      end
+    end
+  end
+
+  step "Upgrade the agents from Puppet 5 to Puppet 6..." do
+    agents_only.each do |agent|
+      start_puppet_service_and_wait_for_puppet_run(agent)
+      wait_for_installation_pid(agent)
+      assert_agent_version_on(agent, '6.0.0')
+    end
+  end
 end


### PR DESCRIPTION
Currently, the update testing in the acceptance directory does not
test by waiting for pidfiles during installations. For
MacOS/Solaris/Windows this means the acceptance tests will not work,
since those platforms will spawn scripts to perform installations
outside of an agent run

So this commit updates the acceptance testing to include waiting for
pidfiles after the puppet run completes so the testing will wait for
the full installation.

There were a few larger refactors done to help facilitate the changes:

1. new functions for waiting for puppet to finish and waiting on
installation PIDs

2. the actual execution of puppet to perform the upgrade now consists
of turning on the puppet service rather than executing 'puppet agent
-t'. This is the approach we use when testing upgrades in PE and
should be consistent

3. several functions were refactored to be smaller and more focused.