### PR TITLE
(FM-7732) Download puppet-agent packages over https

### DIFF
--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -416,24 +416,24 @@ case $platform in
   "SLES")
     info "SLES platform! Lets get you an RPM..."
     gpg_key="${tmp_dir}/RPM-GPG-KEY-puppet"
-    do_download "http://yum.puppetlabs.com/RPM-GPG-KEY-puppet" "$gpg_key"
+    do_download "https://yum.puppetlabs.com/RPM-GPG-KEY-puppet" "$gpg_key"
     rpm --import "$gpg_key"
     rm -f "$gpg_key"
     filetype="noarch.rpm"
     filename="${collection}-release-sles-${platform_version}.noarch.rpm"
-    download_url="http://yum.puppetlabs.com/${collection}/${filename}"
+    download_url="https://yum.puppetlabs.com/${collection}/${filename}"
     ;;
   "el")
     info "Red hat like platform! Lets get you an RPM..."
     filetype="rpm"
     filename="${collection}-release-el-${platform_version}.noarch.rpm"
-    download_url="http://yum.puppetlabs.com/${collection}/${filename}"
+    download_url="https://yum.puppetlabs.com/${collection}/${filename}"
     ;;
   "Fedora")
     info "Fedora platform! Lets get the RPM..."
     filetype="rpm"
     filename="${collection}-release-fedora-${platform_version}.noarch.rpm"
-    download_url="http://yum.puppetlabs.com/${collection}/${filename}"
+    download_url="https://yum.puppetlabs.com/${collection}/${filename}"
     ;;
   "Debian")
     info "Debian platform! Lets get you a DEB..."
@@ -446,7 +446,7 @@ case $platform in
     esac
     filetype="deb"
     filename="${collection}-release-${deb_codename}.deb"
-    download_url="http://apt.puppetlabs.com/${filename}"
+    download_url="https://apt.puppetlabs.com/${filename}"
     ;;
   "Ubuntu")
     info "Ubuntu platform! Lets get you a DEB..."
@@ -466,7 +466,7 @@ case $platform in
     esac
     filetype="deb"
     filename="${collection}-release-${deb_codename}.deb"
-    download_url="http://apt.puppetlabs.com/${filename}"
+    download_url="https://apt.puppetlabs.com/${filename}"
     ;;
   "mac_os_x")
     info "OSX platform! Lets get you a DMG..."
@@ -476,7 +476,7 @@ case $platform in
     else
       filename="puppet-agent-${version}-1.osx${platform_version}.dmg"
     fi
-    download_url="http://downloads.puppetlabs.com/mac/${collection}/${platform_version}/x86_64/${filename}"
+    download_url="https://downloads.puppetlabs.com/mac/${collection}/${platform_version}/x86_64/${filename}"
     ;;
   *)
     critical "Sorry $platform is not supported yet!"


### PR DESCRIPTION
This commit updates the install_shell task implementation to use https endpoints when downloading puppet-agent packages. Previously the http endpoints were used.