### PR TITLE
(MODULES-8583) Improve rpm importing of the puppet GPG key

### DIFF
--- a/manifests/osfamily/suse.pp
+++ b/manifests/osfamily/suse.pp
@@ -44,13 +44,13 @@ class puppet_agent::osfamily::suse{
       }
 
       # Given the path to a key, see if it is imported, if not, import it
-      $legacy_gpg_pubkey = "gpg-pubkey-$(echo $(gpg --homedir ${gpg_homedir} --throw-keyids < ${legacy_gpg_path})"
-      $gpg_pubkey = "gpg-pubkey-$(echo $(gpg --homedir ${gpg_homedir} --throw-keyids < ${gpg_path})"
+      $legacy_gpg_pubkey = "gpg-pubkey-$(echo $(gpg --homedir ${gpg_homedir} --with-colons ${legacy_gpg_path} 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))"
+      $gpg_pubkey        = "gpg-pubkey-$(echo $(gpg --homedir ${gpg_homedir} --with-colons ${gpg_path} 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))"
 
       exec { "import-${legacy_keyname}":
         path      => '/bin:/usr/bin:/sbin:/usr/sbin',
         command   => "rpm --import ${legacy_gpg_path}",
-        unless    => "rpm -q ${legacy_gpg_pubkey} | cut --characters=11-18 | tr [:upper:] [:lower:])",
+        unless    => "rpm -q ${legacy_gpg_pubkey}",
         require   => File[$legacy_gpg_path],
         logoutput => 'on_failure',
       }
@@ -58,7 +58,7 @@ class puppet_agent::osfamily::suse{
       exec { "import-${keyname}":
         path      => '/bin:/usr/bin:/sbin:/usr/sbin',
         command   => "rpm --import ${gpg_path}",
-        unless    => "rpm -q ${gpg_pubkey} | cut --characters=11-18 | tr [:upper:] [:lower:])",
+        unless    => "rpm -q ${gpg_pubkey}",
         require   => File[$gpg_path],
         logoutput => 'on_failure',
       }

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -24,21 +24,39 @@ describe 'puppet_agent' do
         super().merge(:operatingsystem  => os, :operatingsystemmajrelease => osmajor)
       end
 
-      it { is_expected.to contain_exec('import-GPG-KEY-puppetlabs').with({
-        'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
-        'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
-        'unless'    => "rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs) | cut --characters=11-18 | tr '[:upper:]' '[:lower:]'`",
-        'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs]',
-        'logoutput' => 'on_failure',
-      }) }
+      if os == 'Fedora' then
+        it { is_expected.to contain_exec('import-GPG-KEY-puppetlabs').with({
+          'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
+          'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
+          'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg2 --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
+          'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs]',
+          'logoutput' => 'on_failure',
+        }) }
 
-      it { is_expected.to contain_exec('import-GPG-KEY-puppet').with({
-        'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
-        'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet',
-        'unless'    => "rpm -q gpg-pubkey-`echo $(gpg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet) | cut --characters=11-18 | tr '[:upper:]' '[:lower:]'`",
-        'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet]',
-        'logoutput' => 'on_failure',
-      }) }
+        it { is_expected.to contain_exec('import-GPG-KEY-puppet').with({
+          'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
+          'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet',
+          'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg2 --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
+          'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet]',
+          'logoutput' => 'on_failure',
+        }) }
+      else
+        it { is_expected.to contain_exec('import-GPG-KEY-puppetlabs').with({
+          'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
+          'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
+          'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
+          'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs]',
+          'logoutput' => 'on_failure',
+        }) }
+
+        it { is_expected.to contain_exec('import-GPG-KEY-puppet').with({
+          'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
+          'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet',
+          'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
+          'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet]',
+          'logoutput' => 'on_failure',
+        }) }
+      end
 
       context 'with manage_pki_dir => true' do
         ['/etc/pki', '/etc/pki/rpm-gpg'].each do |path|

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -55,7 +55,7 @@ describe 'puppet_agent' do
           it { is_expected.to contain_exec('import-GPG-KEY-puppet').with({
             'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
             'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet',
-            'unless'    => 'rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet) | cut --characters=11-18 | tr [:upper:] [:lower:])',
+            'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
             'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet]',
             'logoutput' => 'on_failure',
           }) }
@@ -63,7 +63,7 @@ describe 'puppet_agent' do
           it { is_expected.to contain_exec('import-GPG-KEY-puppetlabs').with({
             'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
             'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs',
-            'unless'    => 'rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --throw-keyids < /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs) | cut --characters=11-18 | tr [:upper:] [:lower:])',
+            'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
             'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppetlabs]',
             'logoutput' => 'on_failure',
           }) }


### PR DESCRIPTION
SLES 15 uses gpg 2.2, which changed some of its key output formatting
and is noisier about missing commands. This change normalizes the text
parsing of gpg keys, using the --with-colons option, that is recommended
in the man page for use in scripts. The updated parsing pipelines work with
older and newer versions of gpg.