### PR TITLE
(MODULES-8665) Add missing puppetlabs-facts dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -11,5 +11,8 @@ fixtures:
       ref: "6.0.0"
     yumrepo_core:
       repo: "puppetlabs/yumrepo_core"
+    facts:
+      repo: "puppetlabs/facts"
+      ref: "0.5.1"
   symlinks:
     puppet_agent: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -117,6 +117,7 @@
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 5.1.0 < 6.0.0"},
     {"name":"puppetlabs-inifile","version_requirement":">= 2.4.0 <= 3.0.0"},
-    {"name":"puppetlabs-apt","version_requirement":">= 6.0.0 < 7.0.0"}
+    {"name":"puppetlabs-apt","version_requirement":">= 6.0.0 < 7.0.0"},
+    {"name":"puppetlabs-facts","version_requirement":">= 0.5.0 < 1.0.0"}
   ]
 }

--- a/task_spec/.fixtures.yml
+++ b/task_spec/.fixtures.yml
@@ -2,6 +2,6 @@ fixtures:
   forge_modules:
     facts:
       repo: "puppetlabs/facts"
-      ref: "0.5.0"
+      ref: "0.5.1"
   symlinks:
     puppet_agent: "#{File.absolute_path(File.join(source_dir, '..'))}"


### PR DESCRIPTION
This commit adds the puppetlabs-facts module to the dependency list of
puppetlabs-puppet_agent. Tasks from the facts module are required by
the puppet_agent::install task.