### PR TITLE
(BOLT-1057) Pass required args to run_task

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -22,7 +22,7 @@ describe 'install task' do
 
   it 'works with version and install tasks' do
     # test the agent isn't already installed and that the version task works
-    results = run_task('puppet_agent::version', 'target', config: config, inventory: inventory)
+    results = run_task('puppet_agent::version', 'target', {}, config: config, inventory: inventory)
     results.each do |res|
       expect(res).to include('status' => 'success')
       expect(res['result']['version']).to eq(nil)
@@ -35,7 +35,7 @@ describe 'install task' do
     end
 
     # It installed a version older than latest
-    results = run_task('puppet_agent::version', 'target', config: config, inventory: inventory)
+    results = run_task('puppet_agent::version', 'target', {}, config: config, inventory: inventory)
     results.each do |res|
       expect(res).to include('status' => 'success')
       expect(res['result']['version']).to eq('5.5.3')
@@ -49,7 +49,7 @@ describe 'install task' do
     end
 
     # Verify that it upgraded
-    results = run_task('puppet_agent::version', 'target', config: config, inventory: inventory)
+    results = run_task('puppet_agent::version', 'target', {}, config: config, inventory: inventory)
     results.each do |res|
       expect(res).to include('status' => 'success')
       expect(res['result']['version']).not_to eq('5.5.3')
@@ -64,7 +64,7 @@ describe 'install task' do
     end
 
     # Verify that it upgraded
-    results = run_task('puppet_agent::version', 'target', config: config, inventory: inventory)
+    results = run_task('puppet_agent::version', 'target', {}, config: config, inventory: inventory)
     results.each do |res|
       expect(res).to include('status' => 'success')
       expect(res['result']['version']).not_to match(/^5\.\d+\.\d+/)


### PR DESCRIPTION
Previously, the tests were omitting the `params` argument to `run_task`.
In newer versions of BoltSpec, that parameter is going to be required,
so now we always pass it.