### PR TITLE
Fix unnecessary changes in load balanced envs due to pkg source

### DIFF
--- a/lib/facter/settings.rb
+++ b/lib/facter/settings.rb
@@ -36,7 +36,17 @@ end
 
 Facter.add('puppet_master_server') do
   setcode do
-    Puppet.settings['server']
+    if Puppet.settings['server_list'].nil? || Puppet.settings['server_list'].empty?
+      Puppet.settings['server']
+    else
+      case (entry = Puppet.settings['server_list'].first)
+      when Array
+        # Tuple of hostname and port
+        entry.first
+      else
+        entry
+      end
+    end
   end
 end
 

--- a/manifests/osfamily/debian.pp
+++ b/manifests/osfamily/debian.pp
@@ -10,7 +10,7 @@ class puppet_agent::osfamily::debian{
       if $::puppet_agent::source {
         $source = $::puppet_agent::source
       } else {
-        $source = "https://${::servername}:8140/packages/${pe_server_version}/${::platform_tag}"
+        $source = "https://${::puppet_master_server}:8140/packages/${pe_server_version}/${::platform_tag}"
       }
       # In Puppet Enterprise, agent packages are served by the same server
       # as the master, which can be using either a self signed CA, or an external CA.

--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -11,7 +11,7 @@ class puppet_agent::osfamily::redhat{
     if $::puppet_agent::source {
       $source = $::puppet_agent::source
     } else {
-      $source = "https://${::servername}:8140/packages/${pe_server_version}/${pe_repo_dir}"
+      $source = "https://${::puppet_master_server}:8140/packages/${pe_server_version}/${pe_repo_dir}"
     }
     # In Puppet Enterprise, agent packages are served by the same server
     # as the master, which can be using either a self signed CA, or an external CA.

--- a/manifests/osfamily/suse.pp
+++ b/manifests/osfamily/suse.pp
@@ -9,7 +9,7 @@ class puppet_agent::osfamily::suse{
     $source = $::puppet_agent::source
   } elsif $::puppet_agent::is_pe {
     $pe_server_version = pe_build_version()
-    $source = "https://${::servername}:8140/packages/${pe_server_version}/${::platform_tag}"
+    $source = "https://${::puppet_master_server}:8140/packages/${pe_server_version}/${::platform_tag}"
   } else {
     $source = "https://yum.puppet.com/${::puppet_agent::collection}/sles/${::operatingsystemmajrelease}/${::puppet_agent::arch}"
   }

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -2,20 +2,20 @@ require 'spec_helper'
 
 describe 'puppet_agent' do
   facts = {
-    :lsbdistid => 'Debian',
-    :osfamily => 'Debian',
-    :lsbdistcodename => 'stretch',
-    :os => {
-      'name' => 'Debian',
-      'release' => {
-        'full' => '9.0',
-        'major' => '9',
-      },
-    },
-    :operatingsystem => 'Debian',
-    :architecture => 'x64',
-      :servername   => 'master.example.vm',
-      :clientcert   => 'foo.example.vm',
+    :lsbdistid            => 'Debian',
+    :osfamily             => 'Debian',
+    :lsbdistcodename      => 'stretch',
+    :os                   => {
+                               'name' => 'Debian',
+                               'release' => {
+                                 'full' => '9.0',
+                                 'major' => '9',
+                               },
+                             },
+    :operatingsystem      => 'Debian',
+    :architecture         => 'x64',
+    :puppet_master_server => 'master.example.vm',
+    :clientcert           => 'foo.example.vm',
   }
 
   # All FOSS and all Puppet 4+ upgrades require the package_version

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -13,7 +13,7 @@ describe 'puppet_agent' do
     {
       :osfamily                  => 'RedHat',
       :architecture              => 'x64',
-      :servername                => 'master.example.vm',
+      :puppet_master_server      => 'master.example.vm',
       :clientcert                => 'foo.example.vm',
     }
   end

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -19,7 +19,7 @@ describe 'puppet_agent' do
     :operatingsystem           => 'SLES',
     :operatingsystemmajrelease => '12',
     :architecture              => 'x64',
-    :servername                => 'master.example.vm',
+    :puppet_master_server      => 'master.example.vm',
     :clientcert                => 'foo.example.vm',
   }
 


### PR DESCRIPTION
In environments with multiple compile masters behind a load balancer,
using `$::servername` could cause Puppet to constantly update the repo
configuration based on the compile master that happens to be compiling
the catalog at that time.

Changing the value to `$::puppet_master_server` uses the server value in
puppet.conf, which in most (all?) cases should be the load balanced point.