### PR TITLE
(MODULES-6604) Add new source parameters

### DIFF
--- a/acceptance/pre_suite/00_master_setup.rb
+++ b/acceptance/pre_suite/00_master_setup.rb
@@ -69,9 +69,8 @@ test_name 'Pre-Suite: Install, configure, and start a compatible puppetserver on
     stop_firewall_with_puppet_on(master)
     ssldir = puppet_config(master, 'ssldir').strip
     on(master, "rm -rf '#{ssldir}'/*") # Preserve the directory itself, to keep permissions
-    unless version_is_less(server_version, '6.0.0')
-      on(master, 'puppetserver ca setup')
-    end
+    # DO NOT RUN 'puppetserver ca setup': this will create the new intermediate certs that
+    # will not work when installing the old version of agents.
   end
 
 

--- a/manifests/install/darwin.pp
+++ b/manifests/install/darwin.pp
@@ -1,8 +1,8 @@
-# == Class puppet_agent::windows::install
+# == Class puppet_agent::install::darwin
 #
 # Private class called from puppet_agent class
 #
-# Manage the install process for windows specifically
+# Manage the install process for Darwin OSes specifically
 #
 class puppet_agent::install::darwin(
   $package_version,

--- a/manifests/install/darwin.pp
+++ b/manifests/install/darwin.pp
@@ -1,0 +1,26 @@
+# == Class puppet_agent::windows::install
+#
+# Private class called from puppet_agent class
+#
+# Manage the install process for windows specifically
+#
+class puppet_agent::install::darwin(
+  $package_version,
+  $install_options = [],
+){
+  assert_private()
+  $install_script = 'osx_install.sh.erb'
+
+  $_logfile = "${::env_temp_variable}/osx_install.log"
+  notice("Puppet install log file at ${_logfile}")
+
+  $_installsh = "${::env_temp_variable}/osx_install.sh"
+  file { "${_installsh}":
+    ensure  => file,
+    mode    => '0755',
+    content => template('puppet_agent/do_install.sh.erb')
+  }
+  -> exec { 'osx_install script':
+    command => "${_installsh} ${::puppet_agent_pid} 2>&1 > ${_logfile} &",
+  }
+}

--- a/manifests/install/solaris.pp
+++ b/manifests/install/solaris.pp
@@ -1,8 +1,8 @@
-# == Class puppet_agent::windows::install
+# == Class puppet_agent::install::solaris
 #
 # Private class called from puppet_agent class
 #
-# Manage the install process for windows specifically
+# Manage the install process for solaris specifically
 #
 class puppet_agent::install::solaris(
   $package_version,
@@ -27,7 +27,7 @@ class puppet_agent::install::solaris(
     # service. That resulted in service-initiated upgrades failing because trying to remove or
     # upgrade the package would stop the service, thereby killing the Puppet run. Use a script
     # to perform the upgrade after Puppet is done running.
-    # Puppet 5.0 adds this, but some i18n implementation is loading code fairly late and appearsx
+    # Puppet 5.0 adds this, but some i18n implementation is loading code fairly late and appears
     # to be messing up the upgrade.
 
     if $::puppet_agent::aio_upgrade_required {

--- a/manifests/install/solaris.pp
+++ b/manifests/install/solaris.pp
@@ -1,0 +1,53 @@
+# == Class puppet_agent::windows::install
+#
+# Private class called from puppet_agent class
+#
+# Manage the install process for windows specifically
+#
+class puppet_agent::install::solaris(
+  $package_version,
+  $install_options = [],
+){
+  assert_private()
+  if $::operatingsystemmajrelease == '10' {
+    $_unzipped_package_name = regsubst($::puppet_agent::prepare::package::package_file_name, '\.gz$', '')
+    $install_script = 'solaris_install.sh.erb'
+
+    # The following are expected to be available in the solaris_install.sh.erb template:
+    $adminfile = '/opt/puppetlabs/packages/solaris-noask'
+    $sourcefile = "/opt/puppetlabs/packages/${_unzipped_package_name}"
+    # Starting with puppet6 collections we no longer carry the mcollective service
+    if $::puppet_agent::collection != 'PC1' and $::puppet_agent::collection != 'puppet5' {
+      $service_names = delete($::puppet_agent::service_names, 'mcollective')
+    } else {
+      $service_names = $::puppet_agent::service_names
+    }
+
+    # Puppet prior to 5.0 would not use a separate process contract when forking from the Puppet
+    # service. That resulted in service-initiated upgrades failing because trying to remove or
+    # upgrade the package would stop the service, thereby killing the Puppet run. Use a script
+    # to perform the upgrade after Puppet is done running.
+    # Puppet 5.0 adds this, but some i18n implementation is loading code fairly late and appearsx
+    # to be messing up the upgrade.
+
+    if $::puppet_agent::aio_upgrade_required {
+      $_logfile = "${::env_temp_variable}/solaris_install.log"
+      notice ("Puppet install log file at ${_logfile}")
+
+      $_installsh = "${::env_temp_variable}/solaris_install.sh"
+      file { "${_installsh}":
+        ensure  => file,
+        mode    => '0755',
+        content => template('puppet_agent/do_install.sh.erb')
+      }
+      -> exec { 'solaris_install script':
+        command => "/usr/bin/ctrun -l none ${_installsh} ${::puppet_agent_pid} 2>&1 > ${_logfile} &",
+      }
+    }
+  } else {
+    package { $::puppet_agent::package_name:
+      ensure          => $package_version,
+      install_options => $install_options,
+    }
+  }
+}

--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -4,10 +4,9 @@
 #
 # Manage the install process for windows specifically
 #
-class puppet_agent::windows::install(
+class puppet_agent::install::windows(
   $install_dir           = undef,
   $install_options       = [],
-  $msi_move_locked_files = $::puppet_agent::msi_move_locked_files,
   ) {
   assert_private()
 
@@ -26,7 +25,7 @@ class puppet_agent::windows::install(
     $_agent_startup_mode = undef
   }
 
-  if $msi_move_locked_files {
+  if $::puppet_agent::msi_move_locked_files {
     $_move_dll_workaround = '-UseLockedFilesWorkaround'
   } else {
     $_move_dll_workaround = undef

--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -1,4 +1,4 @@
-# == Class puppet_agent::windows::install
+# == Class puppet_agent::install::windows
 #
 # Private class called from puppet_agent class
 #

--- a/manifests/osfamily/aix.pp
+++ b/manifests/osfamily/aix.pp
@@ -44,10 +44,14 @@ class puppet_agent::osfamily::aix{
       $aix_ver_number = '6.1'
     }
   }
-  if $::puppet_agent::source {
-    $source = $::puppet_agent::source
+  if $::puppet_agent::absolute_source {
+    $source = $::puppet_agent::absolute_source
+  } elsif $::puppet_agent::alternate_pe_source {
+    $source = "${::puppet_agent::alternate_pe_source}/packages/${pe_server_version}/aix-${aix_ver_number}-power/${::puppet_agent::package_name}-${::puppet_agent::package_version}-1.aix${aix_ver_number}.ppc.rpm"
+  } elsif $::puppet_agent::source {
+    $source = "${::puppet_agent::source}/packages/${pe_server_version}/aix-${aix_ver_number}-power/${::puppet_agent::package_name}-${::puppet_agent::package_version}-1.aix${aix_ver_number}.ppc.rpm"
   } else {
-    $source = "puppet:///pe_packages/${pe_server_version}/aix-${aix_ver_number}-power/${::puppet_agent::package_name}-${::puppet_agent::package_version}-1.aix${aix_ver_number}.ppc.rpm"
+    $source = "${::puppet_agent::aix_source}/${pe_server_version}/aix-${aix_ver_number}-power/${::puppet_agent::package_name}-${::puppet_agent::package_version}-1.aix${aix_ver_number}.ppc.rpm"
   }
 
   class { '::puppet_agent::prepare::package':

--- a/manifests/osfamily/darwin.pp
+++ b/manifests/osfamily/darwin.pp
@@ -1,15 +1,20 @@
 class puppet_agent::osfamily::darwin{
   assert_private()
 
-  if $::puppet_agent::source {
-    $source = $::puppet_agent::source
-  } elsif $::puppet_agent::is_pe {
+  if $::puppet_agent::absolute_source {
+    $source = $::puppet_agent::absolute_source
+  } elsif ($::puppet_agent::is_pe and (!$::puppet_agent::use_alternate_sources)) {
     $pe_server_version = pe_build_version()
-    $source = "puppet:///pe_packages/${pe_server_version}/${::platform_tag}/${puppet_agent::package_name}-${puppet_agent::package_version}-1.osx${$::macosx_productversion_major}.dmg"
+    if $::puppet_agent::alternate_pe_source {
+      $source = "${::puppet_agent::alternate_pe_source}/packages/${pe_server_version}/${::platform_tag}/${puppet_agent::package_name}-${puppet_agent::package_version}-1.osx${$::macosx_productversion_major}.dmg"
+    } elsif $::puppet_agent::source {
+      $source = "${::puppet_agent::source}/packages/${pe_server_version}/${::platform_tag}/${puppet_agent::package_name}-${puppet_agent::package_version}-1.osx${$::macosx_productversion_major}.dmg"
+    } else {
+      $source = "puppet:///pe_packages/${pe_server_version}/${::platform_tag}/${puppet_agent::package_name}-${puppet_agent::package_version}-1.osx${$::macosx_productversion_major}.dmg"
+    }
   } else {
-    $source = "https://downloads.puppet.com/mac/${::puppet_agent::collection}/${::macosx_productversion_major}/${::puppet_agent::arch}/${puppet_agent::package_name}-${puppet_agent::package_version}-1.osx${$::macosx_productversion_major}.dmg"
+    $source = "${::puppet_agent::mac_source}/mac/${::puppet_agent::collection}/${::macosx_productversion_major}/${::puppet_agent::arch}/${puppet_agent::package_name}-${puppet_agent::package_version}-1.osx${$::macosx_productversion_major}.dmg"
   }
-
   class { '::puppet_agent::prepare::package':
     source => $source,
   }

--- a/manifests/osfamily/debian.pp
+++ b/manifests/osfamily/debian.pp
@@ -1,121 +1,127 @@
 class puppet_agent::osfamily::debian{
   assert_private()
 
-  if getvar('::puppet_agent::manage_repo') == true {
 
-    include ::apt
+  if $::puppet_agent::absolute_source {
+    # Absolute sources are expected to be actual packages (not repos)
+    # so when absolute_source is set just download the package to the
+    # system and finish with this class.
+    $source = $::puppet_agent::absolute_source
+    class { '::puppet_agent::prepare::package':
+      source => $source,
+    }
+    contain puppet_agent::prepare::package
+  } else {
+    if getvar('::puppet_agent::manage_repo') == true {
+      include ::apt
+      if ($::puppet_agent::is_pe and (!$::puppet_agent::use_alternate_sources)) {
+        $pe_server_version = pe_build_version()
+        if $::puppet_agent::source {
+          $source = "${::puppet_agent::source}/packages/${pe_server_version}/${::platform_tag}"
+        } elsif $::puppet_agent::alternate_pe_source {
+          $source = "${::puppet_agent::alternate_pe_source}/packages/${pe_server_version}/${::platform_tag}"
+        } else {
+          $source = "https://${::puppet_master_server}:8140/packages/${pe_server_version}/${::platform_tag}"
+        }
+        # In Puppet Enterprise, agent packages are served by the same server
+        # as the master, which can be using either a self signed CA, or an external CA.
+        # In order for apt to authenticate to the repo on the PE Master, it will need
+        # to be configured to pass in the agents certificates. By the time this code is called,
+        # the module has already moved the certs to $ssl_dir/{certs,private_keys}, which
+        # happen to be the default in PE already.
+        $_ssl_dir = $::puppet_agent::params::ssldir
+        $_sslcacert_path = "${_ssl_dir}/certs/ca.pem"
+        $_sslclientcert_path = "${_ssl_dir}/certs/${::clientcert}.pem"
+        $_sslclientkey_path = "${_ssl_dir}/private_keys/${::clientcert}.pem"
 
-    if getvar('::puppet_agent::is_pe') == true {
-      $pe_server_version = pe_build_version()
-      if $::puppet_agent::source {
-        $source = $::puppet_agent::source
+        # For debian based platforms, in order to add SSL verification, you need to add a
+        # configuration file specific to just the sources host
+        $source_host = uri_host_from_string($source)
+        $_ca_cert_verification = [
+          "Acquire::https::${source_host}::CaInfo \"${_sslcacert_path}\";",
+        ]
+        $_proxy_host = [
+          "Acquire::http::proxy::${source_host} DIRECT;",
+        ]
+
+        $_apt_settings = concat(
+          $_ca_cert_verification,
+          $_proxy_host)
+
+
+        apt::setting { 'conf-pc_repo':
+          content  => $_apt_settings.join(''),
+          priority => 90,
+        }
+
+        # Due to the file paths changing on the PE Master, the 3.8 repository is no longer valid.
+        # On upgrade, remove the repo file so that a dangling reference is not left behind returning
+        # a 404 on subsequent runs.
+
+        # Pass in an empty content string since apt requires it even though we are removing it
+        apt::setting {'list-puppet-enterprise-installer':
+          ensure  => absent,
+          content => '',
+        }
+
+        apt::setting { 'conf-pe-repo':
+          ensure   => absent,
+          priority => '90',
+          content  => '',
+        }
       } else {
-        $source = "https://${::puppet_master_server}:8140/packages/${pe_server_version}/${::platform_tag}"
+        $source = $::puppet_agent::apt_source
       }
-      # In Puppet Enterprise, agent packages are served by the same server
-      # as the master, which can be using either a self signed CA, or an external CA.
-      # In order for apt to authenticate to the repo on the PE Master, it will need
-      # to be configured to pass in the agents certificates. By the time this code is called,
-      # the module has already moved the certs to $ssl_dir/{certs,private_keys}, which
-      # happen to be the default in PE already.
-      $_ssl_dir = $::puppet_agent::params::ssldir
-      $_sslcacert_path = "${_ssl_dir}/certs/ca.pem"
-      $_sslclientcert_path = "${_ssl_dir}/certs/${::clientcert}.pem"
-      $_sslclientkey_path = "${_ssl_dir}/private_keys/${::clientcert}.pem"
+      $legacy_keyname = 'GPG-KEY-puppetlabs'
+      $legacy_gpg_path = "/etc/pki/deb-gpg/${legacy_keyname}"
+      $keyname = 'GPG-KEY-puppet'
+      $gpg_path = "/etc/pki/deb-gpg/${keyname}"
 
-      # For debian based platforms, in order to add SSL verification, you need to add a
-      # configuration file specific to just the sources host
-      $source_host = uri_host_from_string($source)
-      $_ca_cert_verification = [
-        "Acquire::https::${source_host}::CaInfo \"${_sslcacert_path}\";",
-      ]
-      $_proxy_host = [
-        "Acquire::http::proxy::${source_host} DIRECT;",
-      ]
-
-      $_apt_settings = concat(
-        $_ca_cert_verification,
-        $_proxy_host)
-
-
-      apt::setting { 'conf-pc_repo':
-        content  => $_apt_settings.join(''),
-        priority => 90,
+      if getvar('::puppet_agent::manage_pki_dir') == true {
+        file { ['/etc/pki', '/etc/pki/deb-gpg']:
+          ensure => directory,
+        }
       }
 
-      # Due to the file paths changing on the PE Master, the 3.8 repository is no longer valid.
-      # On upgrade, remove the repo file so that a dangling reference is not left behind returning
-      # a 404 on subsequent runs.
-
-      # Pass in an empty content string since apt requires it even though we are removing it
-      apt::setting {'list-puppet-enterprise-installer':
-        ensure  => absent,
-        content => '',
+      file { $legacy_gpg_path:
+        ensure => present,
+        owner  => 0,
+        group  => 0,
+        mode   => '0644',
+        source => "puppet:///modules/puppet_agent/${legacy_keyname}",
       }
 
-      apt::setting { 'conf-pe-repo':
-        ensure   => absent,
-        priority => '90',
-        content  => '',
+      apt::key { 'legacy key':
+        id     => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
+        source => $legacy_gpg_path,
       }
-    } else {
-      if $::puppet_agent::source {
-        $source = $::puppet_agent::source
-      } else {
-        $source = 'https://apt.puppet.com'
+
+      file { $gpg_path:
+        ensure => present,
+        owner  => 0,
+        group  => 0,
+        mode   => '0644',
+        source => "puppet:///modules/puppet_agent/${keyname}",
+      }
+
+      apt::source { 'pc_repo':
+        location => $source,
+        repos    => $::puppet_agent::collection,
+        key      => {
+          'id'     => '6F6B15509CF8E59E6E469F327F438280EF8D349F',
+          'source' => $gpg_path,
+        },
+        notify   => Exec['pc_repo_force'],
+      }
+
+      # apt_update doesn't inherit the future class dependency, so it
+      # can wait until the end of the run to exec. Force it to happen now.
+      exec { 'pc_repo_force':
+        command     => "/bin/echo 'forcing apt update for pc_repo ${::puppet_agent::collection}'",
+        refreshonly => true,
+        logoutput   => true,
+        subscribe   => Exec['apt_update'],
       }
     }
-
-    $legacy_keyname = 'GPG-KEY-puppetlabs'
-    $legacy_gpg_path = "/etc/pki/deb-gpg/${legacy_keyname}"
-    $keyname = 'GPG-KEY-puppet'
-    $gpg_path = "/etc/pki/deb-gpg/${keyname}"
-
-    if getvar('::puppet_agent::manage_pki_dir') == true {
-      file { ['/etc/pki', '/etc/pki/deb-gpg']:
-        ensure => directory,
-      }
-    }
-
-    file { $legacy_gpg_path:
-      ensure => present,
-      owner  => 0,
-      group  => 0,
-      mode   => '0644',
-      source => "puppet:///modules/puppet_agent/${legacy_keyname}",
-    }
-
-    apt::key { 'legacy key':
-      id     => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
-      source => $legacy_gpg_path,
-    }
-
-    file { $gpg_path:
-      ensure => present,
-      owner  => 0,
-      group  => 0,
-      mode   => '0644',
-      source => "puppet:///modules/puppet_agent/${keyname}",
-    }
-
-    apt::source { 'pc_repo':
-      location => $source,
-      repos    => $::puppet_agent::collection,
-      key      => {
-        'id'     => '6F6B15509CF8E59E6E469F327F438280EF8D349F',
-        'source' => $gpg_path,
-      },
-      notify   => Exec['pc_repo_force'],
-    }
-
-    # apt_update doesn't inherit the future class dependency, so it
-    # can wait until the end of the run to exec. Force it to happen now.
-    exec { 'pc_repo_force':
-      command     => "/bin/echo 'forcing apt update for pc_repo ${::puppet_agent::collection}'",
-      refreshonly => true,
-      logoutput   => true,
-      subscribe   => Exec['apt_update'],
-    }
-
   }
 }

--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -1,37 +1,16 @@
 class puppet_agent::osfamily::redhat{
   assert_private()
 
-  if $::puppet_agent::is_pe == true {
-    $pe_server_version = pe_build_version()
-    # Treat Amazon Linux just like Enterprise Linux 6
-    $pe_repo_dir = ($::operatingsystem == 'Amazon') ? {
-      true    => "el-6-${::architecture}",
-      default =>  $::platform_tag,
+  if $::puppet_agent::absolute_source {
+    # Absolute sources are expected to be actual packages (not repos)
+    # so when absolute_source is set just download the package to the
+    # system and finish with this class.
+    $source = $::puppet_agent::absolute_source
+    class { '::puppet_agent::prepare::package':
+      source => $source,
     }
-    if $::puppet_agent::source {
-      $source = $::puppet_agent::source
-    } else {
-      $source = "https://${::puppet_master_server}:8140/packages/${pe_server_version}/${pe_repo_dir}"
-    }
-    # In Puppet Enterprise, agent packages are served by the same server
-    # as the master, which can be using either a self signed CA, or an external CA.
-    # In order for yum to authenticate to the yumrepo on the PE Master, it will need
-    # to be configured to pass in the agents certificates. By the time this code is called,
-    # the module has already moved the certs to $ssl_dir/{certs,private_keys}, which
-    # happen to be the default in PE already.
-
-    $_ssl_dir = $::puppet_agent::params::ssldir
-    $_sslcacert_path = "${_ssl_dir}/certs/ca.pem"
-    $_sslclientcert_path = "${_ssl_dir}/certs/${::clientcert}.pem"
-    $_sslclientkey_path = "${_ssl_dir}/private_keys/${::clientcert}.pem"
-    # Due to the file paths changing on the PE Master, the 3.8 repository is no longer valid.
-    # On upgrade, remove the repo file so that a dangling reference is not left behind returning
-    # a 404 on subsequent runs.
-    yumrepo { 'puppetlabs-pepackages':
-      ensure => absent,
-    }
-  }
-  else {
+    contain puppet_agent::prepare::package
+  } else {
     case $::operatingsystem {
       'Fedora': {
         $platform_and_version = "fedora/${::operatingsystemmajrelease}"
@@ -43,89 +22,124 @@ class puppet_agent::osfamily::redhat{
         $platform_and_version = "el/${::operatingsystemmajrelease}"
       }
     }
-    if $::puppet_agent::source {
-      $source = $::puppet_agent::source
+    if ($::puppet_agent::is_pe and (!$::puppet_agent::use_alternate_sources)) {
+      $pe_server_version = pe_build_version()
+      # Treat Amazon Linux just like Enterprise Linux 6
+      $pe_repo_dir = ($::operatingsystem == 'Amazon') ? {
+        true    => "el-6-${::architecture}",
+        default =>  $::platform_tag,
+      }
+      if $::puppet_agent::source {
+        $source = "${::puppet_agent::source}/packages/${pe_server_version}/${pe_repo_dir}"
+      } elsif $::puppet_agent::alternate_pe_source {
+        $source = "${::puppet_agent::alternate_pe_source}/packages/${pe_server_version}/${pe_repo_dir}"
+      } else {
+        $source = "https://${::puppet_master_server}:8140/packages/${pe_server_version}/${pe_repo_dir}"
+      }
     } else {
-      $source = "http://yum.puppet.com/${::puppet_agent::collection}/${platform_and_version}/${::puppet_agent::arch}"
+      $source = "${::puppet_agent::yum_source}/${::puppet_agent::collection}/${platform_and_version}/${::puppet_agent::arch}"
     }
-    $_sslcacert_path = undef
-    $_sslclientcert_path = undef
-    $_sslclientkey_path = undef
-  }
 
-  # Fedora doesn't ship with a gpg binary, only gpg2
-  if $::operatingsystem == 'Fedora' {
-    $gpg_cmd = 'gpg2'
-  } else {
-    $gpg_cmd = 'gpg'
-  }
 
-  $legacy_keyname = 'GPG-KEY-puppetlabs'
-  $legacy_gpg_path = "/etc/pki/rpm-gpg/RPM-${legacy_keyname}"
-  $keyname = 'GPG-KEY-puppet'
-  $gpg_path = "/etc/pki/rpm-gpg/RPM-${keyname}"
-  $gpg_keys = "file://${legacy_gpg_path}
+    if ($::puppet_agent::is_pe  and (!$::puppet_agent::use_alternate_sources)) {
+      # In Puppet Enterprise, agent packages are served by the same server
+      # as the master, which can be using either a self signed CA, or an external CA.
+      # In order for yum to authenticate to the yumrepo on the PE Master, it will need
+      # to be configured to pass in the agents certificates. By the time this code is called,
+      # the module has already moved the certs to $ssl_dir/{certs,private_keys}, which
+      # happen to be the default in PE already.
+
+      $_ssl_dir = $::puppet_agent::params::ssldir
+      $_sslcacert_path = "${_ssl_dir}/certs/ca.pem"
+      $_sslclientcert_path = "${_ssl_dir}/certs/${::clientcert}.pem"
+      $_sslclientkey_path = "${_ssl_dir}/private_keys/${::clientcert}.pem"
+      # Due to the file paths changing on the PE Master, the 3.8 repository is no longer valid.
+      # On upgrade, remove the repo file so that a dangling reference is not left behind returning
+      # a 404 on subsequent runs.
+      yumrepo { 'puppetlabs-pepackages':
+        ensure => absent,
+      }
+    }
+    else {
+      $_sslcacert_path = undef
+      $_sslclientcert_path = undef
+      $_sslclientkey_path = undef
+    }
+
+    # Fedora doesn't ship with a gpg binary, only gpg2
+    if $::operatingsystem == 'Fedora' {
+      $gpg_cmd = 'gpg2'
+    } else {
+      $gpg_cmd = 'gpg'
+    }
+
+    $legacy_keyname = 'GPG-KEY-puppetlabs'
+    $legacy_gpg_path = "/etc/pki/rpm-gpg/RPM-${legacy_keyname}"
+    $keyname = 'GPG-KEY-puppet'
+    $gpg_path = "/etc/pki/rpm-gpg/RPM-${keyname}"
+    $gpg_keys = "file://${legacy_gpg_path}
   file://${gpg_path}"
 
-  if $::puppet_agent::manage_pki_dir == true {
-    file { ['/etc/pki', '/etc/pki/rpm-gpg']:
-      ensure => directory,
+    if $::puppet_agent::manage_pki_dir == true {
+      file { ['/etc/pki', '/etc/pki/rpm-gpg']:
+        ensure => directory,
+      }
     }
-  }
 
-  file { $legacy_gpg_path:
-    ensure => present,
-    owner  => 0,
-    group  => 0,
-    mode   => '0644',
-    source => "puppet:///modules/puppet_agent/${legacy_keyname}",
-  }
-
-  # Given the path to a key, see if it is imported, if not, import it
-  $legacy_gpg_pubkey = "gpg-pubkey-$(echo $(${gpg_cmd} --with-colons ${legacy_gpg_path} 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))"
-
-  exec {  "import-${legacy_keyname}":
-    path      => '/bin:/usr/bin:/sbin:/usr/sbin',
-    command   => "rpm --import ${legacy_gpg_path}",
-    unless    => "rpm -q ${legacy_gpg_pubkey}",
-    require   => File[$legacy_gpg_path],
-    logoutput => 'on_failure',
-  }
-
-  file { $gpg_path:
-    ensure => present,
-    owner  => 0,
-    group  => 0,
-    mode   => '0644',
-    source => "puppet:///modules/puppet_agent/${keyname}",
-  }
-
-  # Given the path to a key, see if it is imported, if not, import it
-  $gpg_pubkey = "gpg-pubkey-$(echo $(${gpg_cmd} --with-colons ${gpg_path} 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))"
-  exec {  "import-${keyname}":
-    path      => '/bin:/usr/bin:/sbin:/usr/sbin',
-    command   => "rpm --import ${gpg_path}",
-    unless    => "rpm -q ${gpg_pubkey}",
-    require   => File[$gpg_path],
-    logoutput => 'on_failure',
-  }
-
-  if $::puppet_agent::manage_repo == true {
-    $_proxy = $::puppet_agent::disable_proxy ? {
-      true    => '_none_',
-      default => undef,
+    file { $legacy_gpg_path:
+      ensure => present,
+      owner  => 0,
+      group  => 0,
+      mode   => '0644',
+      source => "puppet:///modules/puppet_agent/${legacy_keyname}",
     }
-    yumrepo { 'pc_repo':
-      baseurl             => $source,
-      descr               => "Puppet Labs ${::puppet_agent::collection} Repository",
-      enabled             => true,
-      gpgcheck            => '1',
-      gpgkey              => "${gpg_keys}",
-      proxy               => $_proxy,
-      sslcacert           => $_sslcacert_path,
-      sslclientcert       => $_sslclientcert_path,
-      sslclientkey        => $_sslclientkey_path,
-      skip_if_unavailable => $::puppet_agent::skip_if_unavailable,
+
+    # Given the path to a key, see if it is imported, if not, import it
+    $legacy_gpg_pubkey = "gpg-pubkey-$(echo $(${gpg_cmd} --with-colons ${legacy_gpg_path} 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))"
+
+    exec {  "import-${legacy_keyname}":
+      path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+      command   => "rpm --import ${legacy_gpg_path}",
+      unless    => "rpm -q ${legacy_gpg_pubkey}",
+      require   => File[$legacy_gpg_path],
+      logoutput => 'on_failure',
+    }
+
+    file { $gpg_path:
+      ensure => present,
+      owner  => 0,
+      group  => 0,
+      mode   => '0644',
+      source => "puppet:///modules/puppet_agent/${keyname}",
+    }
+
+    # Given the path to a key, see if it is imported, if not, import it
+    $gpg_pubkey = "gpg-pubkey-$(echo $(${gpg_cmd} --with-colons ${gpg_path} 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))"
+    exec {  "import-${keyname}":
+      path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+      command   => "rpm --import ${gpg_path}",
+      unless    => "rpm -q ${gpg_pubkey}",
+      require   => File[$gpg_path],
+      logoutput => 'on_failure',
+    }
+
+    if $::puppet_agent::manage_repo == true {
+      $_proxy = $::puppet_agent::disable_proxy ? {
+        true    => '_none_',
+        default => undef,
+      }
+      yumrepo { 'pc_repo':
+        baseurl             => $source,
+        descr               => "Puppet Labs ${::puppet_agent::collection} Repository",
+        enabled             => true,
+        gpgcheck            => '1',
+        gpgkey              => "${gpg_keys}",
+        proxy               => $_proxy,
+        sslcacert           => $_sslcacert_path,
+        sslclientcert       => $_sslclientcert_path,
+        sslclientkey        => $_sslclientkey_path,
+        skip_if_unavailable => $::puppet_agent::skip_if_unavailable,
+      }
     }
   }
 }

--- a/manifests/osfamily/suse.pp
+++ b/manifests/osfamily/suse.pp
@@ -5,104 +5,119 @@ class puppet_agent::osfamily::suse{
     fail("${::operatingsystem} not supported")
   }
 
-  if $::puppet_agent::source {
-    $source = $::puppet_agent::source
-  } elsif $::puppet_agent::is_pe {
-    $pe_server_version = pe_build_version()
-    $source = "https://${::puppet_master_server}:8140/packages/${pe_server_version}/${::platform_tag}"
+  if $::puppet_agent::absolute_source {
+    # Absolute sources are expected to be actual packages (not repos)
+    # so when absolute_source is set just download the package to the
+    # system and finish with this class.
+    $source = $::puppet_agent::absolute_source
+    class { '::puppet_agent::prepare::package':
+      source => $source,
+    }
+    contain puppet_agent::prepare::package
   } else {
-    $source = "https://yum.puppet.com/${::puppet_agent::collection}/sles/${::operatingsystemmajrelease}/${::puppet_agent::arch}"
-  }
-
-  case $::operatingsystemmajrelease {
-    '11', '12', '15': {
-      # Import the GPG key
-      $legacy_keyname  = 'GPG-KEY-puppetlabs'
-      $legacy_gpg_path = "/etc/pki/rpm-gpg/RPM-${legacy_keyname}"
-      $keyname         = 'GPG-KEY-puppet'
-      $gpg_path        = "/etc/pki/rpm-gpg/RPM-${keyname}"
-      $gpg_homedir     = '/root/.gnupg'
-
-      if getvar('::puppet_agent::manage_pki_dir') == true {
-        file { ['/etc/pki', '/etc/pki/rpm-gpg']:
-          ensure => directory,
-        }
+    if  ($::puppet_agent::is_pe and (!$::puppet_agent::use_alternate_sources)) {
+      $pe_server_version = pe_build_version()
+      if $::puppet_agent::source {
+        $source = "${::puppet_agent::source}/packages/${pe_server_version}/${::platform_tag}"
+      } elsif $::puppet_agent::alternate_pe_source {
+        $source = "${::puppet_agent::alternate_pe_source}/packages/${pe_server_version}/${::platform_tag}"
+      } else {
+        $source = "https://${::puppet_master_server}:8140/packages/${pe_server_version}/${::platform_tag}"
       }
+    } else {
+      $source = "${::puppet_agent::yum_source}/${::puppet_agent::collection}/sles/${::operatingsystemmajrelease}/${::puppet_agent::arch}"
+    }
 
-      file { $gpg_path:
-        ensure => present,
-        owner  => 0,
-        group  => 0,
-        mode   => '0644',
-        source => "puppet:///modules/puppet_agent/${keyname}",
-      }
+    case $::operatingsystemmajrelease {
+      '11', '12', '15': {
+        # Import the GPG key
+        $legacy_keyname  = 'GPG-KEY-puppetlabs'
+        $legacy_gpg_path = "/etc/pki/rpm-gpg/RPM-${legacy_keyname}"
+        $keyname         = 'GPG-KEY-puppet'
+        $gpg_path        = "/etc/pki/rpm-gpg/RPM-${keyname}"
+        $gpg_homedir     = '/root/.gnupg'
 
-      file { $legacy_gpg_path:
-        ensure => present,
-        owner  => 0,
-        group  => 0,
-        mode   => '0644',
-        source => "puppet:///modules/puppet_agent/${legacy_keyname}",
-      }
-
-      # Given the path to a key, see if it is imported, if not, import it
-      $legacy_gpg_pubkey = "gpg-pubkey-$(echo $(gpg --homedir ${gpg_homedir} --with-colons ${legacy_gpg_path} 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))"
-      $gpg_pubkey        = "gpg-pubkey-$(echo $(gpg --homedir ${gpg_homedir} --with-colons ${gpg_path} 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))"
-
-      exec { "import-${legacy_keyname}":
-        path      => '/bin:/usr/bin:/sbin:/usr/sbin',
-        command   => "rpm --import ${legacy_gpg_path}",
-        unless    => "rpm -q ${legacy_gpg_pubkey}",
-        require   => File[$legacy_gpg_path],
-        logoutput => 'on_failure',
-      }
-
-      exec { "import-${keyname}":
-        path      => '/bin:/usr/bin:/sbin:/usr/sbin',
-        command   => "rpm --import ${gpg_path}",
-        unless    => "rpm -q ${gpg_pubkey}",
-        require   => File[$gpg_path],
-        logoutput => 'on_failure',
-      }
-
-      if getvar('::puppet_agent::manage_repo') == true {
-        # Set up a zypper repository by creating a .repo file which mimics a ini file
-        $repo_file = '/etc/zypp/repos.d/pc_repo.repo'
-        $repo_name = 'pc_repo'
-        $agent_version = $::puppet_agent::package_version
-
-        # In Puppet Enterprise, agent packages are served by the same server
-        # as the master, which can be using either a self signed CA, or an external CA.
-        # Zypper has issues with validating a self signed CA, so for now disable ssl verification.
-        $repo_settings = {
-          'name'        => $repo_name,
-          'enabled'     => '1',
-          'autorefresh' => '0',
-          'baseurl'     => "${source}?ssl_verify=no",
-          'type'        => 'rpm-md',
-        }
-
-        $repo_settings.each |String $setting, String $value| {
-          ini_setting { "zypper ${repo_name} ${setting}":
-            ensure  => present,
-            path    => $repo_file,
-            section => $repo_name,
-            setting => $setting,
-            value   => $value,
-            before  => Exec["refresh-${repo_name}"],
+        if getvar('::puppet_agent::manage_pki_dir') == true {
+          file { ['/etc/pki', '/etc/pki/rpm-gpg']:
+            ensure => directory,
           }
         }
 
-        exec { "refresh-${repo_name}":
+        file { $gpg_path:
+          ensure => present,
+          owner  => 0,
+          group  => 0,
+          mode   => '0644',
+          source => "puppet:///modules/puppet_agent/${keyname}",
+        }
+
+        file { $legacy_gpg_path:
+          ensure => present,
+          owner  => 0,
+          group  => 0,
+          mode   => '0644',
+          source => "puppet:///modules/puppet_agent/${legacy_keyname}",
+        }
+
+        # Given the path to a key, see if it is imported, if not, import it
+        $legacy_gpg_pubkey = "gpg-pubkey-$(echo $(gpg --homedir ${gpg_homedir} --with-colons ${legacy_gpg_path} 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))"
+        $gpg_pubkey        = "gpg-pubkey-$(echo $(gpg --homedir ${gpg_homedir} --with-colons ${gpg_path} 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))"
+
+        exec { "import-${legacy_keyname}":
           path      => '/bin:/usr/bin:/sbin:/usr/sbin',
-          unless    => "zypper search -r ${repo_name} -s | grep puppet-agent | awk '{print \$7}' | grep \"^${agent_version}\"",
-          command   => "zypper refresh ${repo_name}",
+          command   => "rpm --import ${legacy_gpg_path}",
+          unless    => "rpm -q ${legacy_gpg_pubkey}",
+          require   => File[$legacy_gpg_path],
           logoutput => 'on_failure',
         }
+
+        exec { "import-${keyname}":
+          path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+          command   => "rpm --import ${gpg_path}",
+          unless    => "rpm -q ${gpg_pubkey}",
+          require   => File[$gpg_path],
+          logoutput => 'on_failure',
+        }
+
+        if getvar('::puppet_agent::manage_repo') == true {
+          # Set up a zypper repository by creating a .repo file which mimics a ini file
+          $repo_file = '/etc/zypp/repos.d/pc_repo.repo'
+          $repo_name = 'pc_repo'
+          $agent_version = $::puppet_agent::package_version
+
+          # In Puppet Enterprise, agent packages are served by the same server
+          # as the master, which can be using either a self signed CA, or an external CA.
+          # Zypper has issues with validating a self signed CA, so for now disable ssl verification.
+          $repo_settings = {
+            'name'        => $repo_name,
+            'enabled'     => '1',
+            'autorefresh' => '0',
+            'baseurl'     => "${source}?ssl_verify=no",
+            'type'        => 'rpm-md',
+          }
+
+          $repo_settings.each |String $setting, String $value| {
+            ini_setting { "zypper ${repo_name} ${setting}":
+              ensure  => present,
+              path    => $repo_file,
+              section => $repo_name,
+              setting => $setting,
+              value   => $value,
+              before  => Exec["refresh-${repo_name}"],
+            }
+          }
+
+          exec { "refresh-${repo_name}":
+            path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+            unless    => "zypper search -r ${repo_name} -s | grep puppet-agent | awk '{print \$7}' | grep \"^${agent_version}\"",
+            command   => "zypper refresh ${repo_name}",
+            logoutput => 'on_failure',
+          }
+        }
       }
-    }
-    default: {
-      fail("${::operatingsystem} ${::operatingsystemmajrelease} not supported")
+      default: {
+        fail("${::operatingsystem} ${::operatingsystemmajrelease} not supported")
+      }
     }
   }
 }

--- a/manifests/osfamily/windows.pp
+++ b/manifests/osfamily/windows.pp
@@ -1,16 +1,22 @@
 class puppet_agent::osfamily::windows{
   assert_private()
-  if $::puppet_agent::source {
+  if $::puppet_agent::absolute_source {
+    $source = $::puppet_agent::absolute_source
+  } elsif $::puppet_agent::source {
     $source = $::puppet_agent::source
-  } elsif $::puppet_agent::is_pe {
+  } elsif  ($::puppet_agent::is_pe and (!$::puppet_agent::use_alternate_sources)) {
     $pe_server_version = pe_build_version()
     $tag = $::puppet_agent::arch ? {
       'x64' => 'windows-x86_64',
       'x86' => 'windows-i386',
     }
-    $source = "puppet:///pe_packages/${pe_server_version}/${tag}/${::puppet_agent::package_name}-${::puppet_agent::arch}.msi"
+    if $::puppet_agent::alternate_pe_source {
+      $source = "${::puppet_agent::alternate_pe_source}/packages/${pe_server_version}/${tag}/${::puppet_agent::package_name}-${::puppet_agent::arch}.msi"
+    } else {
+      $source = "puppet:///pe_packages/${pe_server_version}/${tag}/${::puppet_agent::package_name}-${::puppet_agent::arch}.msi"
+    }
   } else {
-    $source = "https://downloads.puppet.com/windows/${::puppet_agent::collection}/${::puppet_agent::package_name}-${::puppet_agent::package_version}-${::puppet_agent::arch}.msi"
+    $source = "${::puppet_agent::windows_source}/windows/${::puppet_agent::collection}/${::puppet_agent::package_name}-${::puppet_agent::package_version}-${::puppet_agent::arch}.msi"
   }
 
   class { '::puppet_agent::prepare::package':

--- a/spec/classes/puppet_agent_osfamily_aix_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_aix_spec.rb
@@ -51,14 +51,14 @@ describe 'puppet_agent' do
     let(:facts) {
       common_facts.merge({
         architecture: "PowerPC_POWER8",
-        platform_tag: "aix-7.2-power",
+        platform_tag: "aix-6.1-power",
       })
     }
     let(:params) {
       {
         package_version: '5.10.100.1',
         collection: 'puppet5',
-        source: 'https://fake-source.com/aix/packages/puppet-agent-5.10.100.1-1.aix6.1.ppc.rpm',
+        source: 'https://fake-pe-master.com',
       }
     }
     before(:each) do
@@ -67,7 +67,7 @@ describe 'puppet_agent' do
     end
 
     it {
-      is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-5.10.100.1-1.aix6.1.ppc.rpm').with_source('https://fake-source.com/aix/packages/puppet-agent-5.10.100.1-1.aix6.1.ppc.rpm')
+      is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-5.10.100.1-1.aix6.1.ppc.rpm').with_source("https://fake-pe-master.com/packages/2000.0.0/aix-6.1-power/puppet-agent-5.10.100.1-1.aix6.1.ppc.rpm")
     }
   end
 

--- a/spec/classes/puppet_agent_osfamily_darwin_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_darwin_spec.rb
@@ -72,7 +72,7 @@ describe 'puppet_agent' do
       {
         package_version: '5.10.100.1',
         collection: 'puppet5',
-        source: 'https://fake-source.com/aix/packages/puppet-agent-5.10.100.1-1.osx10.13.dmg',
+        source: 'https://fake-pe-master.com',
       }
     }
     let(:facts) do
@@ -83,6 +83,6 @@ describe 'puppet_agent' do
         :macosx_productversion_major => '10.13'
       })
     end
-    it { is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-5.10.100.1-1.osx10.13.dmg").with_source('https://fake-source.com/aix/packages/puppet-agent-5.10.100.1-1.osx10.13.dmg') }
+    it { is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-5.10.100.1-1.osx10.13.dmg").with_source('https://fake-pe-master.com/packages/2000.0.0/osx-10.13-x86_64/puppet-agent-5.10.100.1-1.osx10.13.dmg') }
   end
 end

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -193,12 +193,12 @@ describe 'puppet_agent' do
         {
           :manage_repo => true,
           :package_version => package_version,
-          :source => 'https://fake-apt-mirror.com/packages/debian-7-x86_64'
+          :source => 'https://fake-apt-mirror.com'
         }
       }
 
       it { is_expected.to contain_apt__source('pc_repo').with({
-        'location' => 'https://fake-apt-mirror.com/packages/debian-7-x86_64',
+        'location' => 'https://fake-apt-mirror.com/packages/2000.0.0/debian-7-x86_64',
         'repos'    => 'PC1',
         'key'      => {
           'id'     => '6F6B15509CF8E59E6E469F327F438280EF8D349F',
@@ -259,12 +259,12 @@ describe 'puppet_agent' do
           :manage_repo => true,
           :package_version => package_version,
           :collection => 'puppet5',
-          :source => 'https://fake-apt-mirror.com/packages/debian-7-x86_64'
+          :apt_source => 'https://fake-apt-mirror.com/'
         }
       }
 
       it { is_expected.to contain_apt__source('pc_repo').with({
-        'location' => 'https://fake-apt-mirror.com/packages/debian-7-x86_64',
+        'location' => 'https://fake-apt-mirror.com/',
         'repos'    => 'puppet5',
         'key'      => {
           'id'     => '6F6B15509CF8E59E6E469F327F438280EF8D349F',

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -123,10 +123,10 @@ describe 'puppet_agent' do
           {
             :package_version => '5.2.0',
             :collection => 'puppet5',
-            :source => "http://fake-yum.com/#{urlbit.gsub('/f','/')}/x64"
+            :yum_source => "http://fake-yum.com"
           }
         }
-        it { is_expected.to contain_yumrepo('pc_repo').with_baseurl("http://fake-yum.com/#{urlbit.gsub('/f','/')}/x64") }
+        it { is_expected.to contain_yumrepo('pc_repo').with_baseurl("http://fake-yum.com/puppet5/#{urlbit.gsub('/f','/')}/x64") }
       end
     end
   end
@@ -159,12 +159,11 @@ describe 'puppet_agent' do
           {
             :package_version => '5.2.0',
             :manage_repo => true,
-            :source => "http://fake-yum.com/#{repodir}/x64"
+            :source => "http://fake-pe-master.com"
           }
         }
-        it { is_expected.to contain_yumrepo('pc_repo').with_baseurl("http://fake-yum.com/#{repodir}/x64") }
+        it { is_expected.to contain_yumrepo('pc_repo').with_baseurl("http://fake-pe-master.com/packages/2000.0.0/#{repodir}") }
       end
-
 
       context 'with manage_repo enabled' do
         let(:params)  {

--- a/spec/classes/puppet_agent_osfamily_solaris_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_solaris_spec.rb
@@ -68,13 +68,13 @@ describe 'puppet_agent' do
       let(:params) do
         {
           :package_version => package_version,
-          :source => "http://fake-solaris-source.com/packages/puppet-agent@#{sol11_package_version},5.11-1.i386.p5p"
+          :source => "http://fake-solaris-source.com"
         }
       end
       it do
         is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent@#{sol11_package_version},5.11-1.i386.p5p").with({
           'ensure' => 'present',
-          'source' => "http://fake-solaris-source.com/packages/puppet-agent@#{sol11_package_version},5.11-1.i386.p5p",
+          'source' => "http://fake-solaris-source.com/packages/2000.0.0/solaris-11-i386/puppet-agent@#{sol11_package_version},5.11-1.i386.p5p",
         })
       end
     end
@@ -209,13 +209,13 @@ describe 'puppet_agent' do
       let(:params) do
         {
           :package_version => package_version,
-          :source => "http://fake-solaris-source.com/packages/puppet-agent-#{package_version}-1.i386.pkg.gz"
+          :source => "http://fake-solaris-source.com"
         }
       end
       it do
         is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-#{package_version}-1.i386.pkg.gz").with({
           'ensure' => 'present',
-          'source' => "http://fake-solaris-source.com/packages/puppet-agent-#{package_version}-1.i386.pkg.gz",
+          'source' => "http://fake-solaris-source.com/packages/2000.0.0/solaris-10-i386/puppet-agent-#{package_version}-1.i386.pkg.gz",
         })
       end
     end

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -149,14 +149,14 @@ describe 'puppet_agent' do
               {
                 :manage_repo => true,
                 :package_version => package_version,
-                :source => "https://fake-sles-source.com/packages/sles-#{os_version}-x86_64",
+                :source => "https://fake-sles-source.com",
               }
             }
             it { is_expected.to contain_ini_setting("zypper pc_repo baseurl").with({
               'path'    => '/etc/zypp/repos.d/pc_repo.repo',
               'section' => 'pc_repo',
               'setting' => 'baseurl',
-              'value'   => "https://fake-sles-source.com/packages/sles-#{os_version}-x86_64?ssl_verify=no",
+              'value'   => "https://fake-sles-source.com/packages/2000.0.0/sles-#{os_version}-x86_64?ssl_verify=no",
             }) }
           end
 

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'puppet_agent', tag: 'win' do
             :aio_agent_version => '1.10.0'
           })}
 
-          it { is_expected.to contain_class('puppet_agent::windows::install') }
+          it { is_expected.to contain_class('puppet_agent::install::windows') }
           it { is_expected.to contain_exec('install_puppet.ps1').with_command(/\-Source \'C:\\ProgramData\\Puppetlabs\\packages\\puppet-agent-#{arch}.msi\'/) }
           it { is_expected.to contain_exec('fix inheritable SYSTEM perms') }
         end
@@ -95,10 +95,10 @@ RSpec.describe 'puppet_agent', tag: 'win' do
         end
       end
 
-      context 'source =>' do
+      context 'absolute_source =>' do
         describe 'https://alterernate.com/puppet-agent-999.1-x64.msi' do
           let(:params) { global_params.merge(
-            {:source => 'https://alternate.com/puppet-agent-999.1-x64.msi',})
+            {:absolute_source => 'https://alternate.com/puppet-agent-999.1-x64.msi',})
           }
           it {
             is_expected.to contain_file('C:\ProgramData\Puppetlabs\packages\puppet-agent-999.1-x64.msi').with_source('https://alternate.com/puppet-agent-999.1-x64.msi')
@@ -110,7 +110,7 @@ RSpec.describe 'puppet_agent', tag: 'win' do
 
         describe 'C:/tmp/puppet-agent-999.2-x64.msi' do
           let(:params) { global_params.merge(
-            {:source => 'C:/tmp/puppet-agent-999.2-x64.msi',})
+            {:absolute_source => 'C:/tmp/puppet-agent-999.2-x64.msi',})
           }
           it {
             is_expected.to contain_file('C:\ProgramData\Puppetlabs\packages\puppet-agent-999.2-x64.msi').with_source('C:/tmp/puppet-agent-999.2-x64.msi')
@@ -122,7 +122,7 @@ RSpec.describe 'puppet_agent', tag: 'win' do
 
         describe '\\\\garded\c$\puppet-agent-999.3-x64.msi' do
           let(:params) { global_params.merge(
-            {:source => "\\\\garded\\c$\\puppet-agent-999.3-x64.msi",})
+            {:absolute_source => "\\\\garded\\c$\\puppet-agent-999.3-x64.msi",})
           }
           it {
             is_expected.to contain_file('C:\ProgramData\Puppetlabs\packages\puppet-agent-999.3-x64.msi').with_source('\\\\garded\c$\puppet-agent-999.3-x64.msi')
@@ -143,7 +143,7 @@ RSpec.describe 'puppet_agent', tag: 'win' do
 
         describe 'puppet:///puppet_agent/puppet-agent-999.4-x86.msi' do
           let(:params) { global_params.merge(
-            {:source => 'puppet:///puppet_agent/puppet-agent-999.4-x86.msi'})
+            {:absolute_source => 'puppet:///puppet_agent/puppet-agent-999.4-x86.msi'})
           }
           it {
             is_expected.to contain_file('C:\ProgramData\Puppetlabs\packages\puppet-agent-999.4-x86.msi').with_source('puppet:///puppet_agent/puppet-agent-999.4-x86.msi')

--- a/tasks/install.json
+++ b/tasks/install.json
@@ -7,7 +7,27 @@
     },
     "collection": {
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
-      "type": "Optional[Enum[puppet5, puppet6, puppet]]"
+      "type": "Optional[Enum[puppet5, puppet6, puppet, puppet5-nightly, puppet6-nightly, puppet-nightly]]"
+    },
+    "yum_source": {
+      "description": "The source location to find yum repos (defaults to yum.puppet.com)",
+      "type": "Optional[String]"
+    },
+    "apt_source": {
+      "description": "The source location to find apt repos (defaults to apt.puppet.com)",
+      "type": "Optional[String]"
+    },
+    "mac_source": {
+      "description": "The source location to find mac packages (defaults to downloads.puppet.com)",
+      "type": "Optional[String]"
+    },
+    "windows_source": {
+      "description": "The source location to find windows packages (defaults to downloads.puppet.com)",
+      "type": "Optional[String]"
+    },
+    "install_options": {
+      "description": "optional install arguments to the windows installer (defaults to REINSTALLMODE=\"amus\")",
+      "type": "Optional[String]"
     }
   },
   "implementations": [

--- a/tasks/install_powershell.json
+++ b/tasks/install_powershell.json
@@ -8,7 +8,27 @@
     },
     "collection": {
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
-      "type": "Optional[Enum[puppet5, puppet6, puppet]]"
+      "type": "Optional[Enum[puppet5, puppet6, puppet, puppet5-nightly, puppet6-nightly, puppet-nightly]]"
+    },
+    "yum_source": {
+      "description": "The source location to find yum repos (defaults to yum.puppet.com)",
+      "type": "Optional[String]"
+    },
+    "apt_source": {
+      "description": "The source location to find apt repos (defaults to apt.puppet.com)",
+      "type": "Optional[String]"
+    },
+    "mac_source": {
+      "description": "The source location to find mac packages (defaults to downloads.puppet.com)",
+      "type": "Optional[String]"
+    },
+    "windows_source": {
+      "description": "The source location to find windows packages (defaults to downloads.puppet.com)",
+      "type": "Optional[String]"
+    },
+    "install_options": {
+      "description": "optional install arguments to the windows installer (defaults to REINSTALLMODE=\"amus\")",
+      "type": "Optional[String]"
     }
   }
 }

--- a/tasks/install_powershell.ps1
+++ b/tasks/install_powershell.ps1
@@ -1,7 +1,9 @@
 [CmdletBinding()]
 Param(
 	[String]$version,
-    [String]$collection = 'puppet'
+  [String]$collection = 'puppet',
+  [String]$windows_source = 'https://downloads.puppet.com',
+  [String]$install_options = 'REINSTALLMODE="amus"'
 )
 # If an error is encountered, the script will stop instead of the default of "Continue"
 $ErrorActionPreference = "Stop"
@@ -28,7 +30,7 @@ else {
     $msi_name = "puppet-agent-${arch}-latest.msi"
 }
 
-$msi_source = "https://downloads.puppetlabs.com/windows/${collection}/${msi_name}"
+$msi_source = "$windows_source/windows/${collection}/${msi_name}"
 
 $date_time_stamp = (Get-Date -format s) -replace ':', '-'
 $msi_dest = Join-Path ([System.IO.Path]::GetTempPath()) "puppet-agent-$arch.msi"
@@ -53,7 +55,7 @@ function DownloadPuppet {
 }
 
 function InstallPuppet {
-  $msiexec_args = "/qn /log $install_log /i $msi_dest /norestart"
+  $msiexec_args = "/qn /log $install_log /i $msi_dest /norestart $install_options"
   Write-Output "Installing the Puppet Agent on $env:COMPUTERNAME..."
   $msiexec_proc = [System.Diagnostics.Process]::Start('msiexec', $msiexec_args)
   $msiexec_proc.WaitForExit()

--- a/tasks/install_shell.json
+++ b/tasks/install_shell.json
@@ -9,7 +9,27 @@
     },
     "collection": {
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
-      "type": "Optional[Enum[puppet5, puppet6, puppet]]"
+      "type": "Optional[Enum[puppet5, puppet6, puppet, puppet5-nightly, puppet6-nightly, puppet-nightly]]"
+    },
+    "yum_source": {
+      "description": "The source location to find yum repos (defaults to yum.puppet.com)",
+      "type": "Optional[String]"
+    },
+    "apt_source": {
+      "description": "The source location to find apt repos (defaults to apt.puppet.com)",
+      "type": "Optional[String]"
+    },
+    "mac_source": {
+      "description": "The source location to find mac packages (defaults to downloads.puppet.com)",
+      "type": "Optional[String]"
+    },
+    "windows_source": {
+      "description": "The source location to find windows packages (defaults to downloads.puppet.com)",
+      "type": "Optional[String]"
+    },
+    "install_options": {
+      "description": "optional install arguments to the windows installer (defaults to REINSTALLMODE=\"amus\")",
+      "type": "Optional[String]"
     }
   }
 }

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -46,6 +46,24 @@ else
   collection='puppet'
 fi
 
+if [ -n "$PT_yum_source" ]; then
+  yum_source=$PT_yum_source
+else
+  yum_source='http://yum.puppet.com'
+fi
+
+if [ -n "$PT_apt_source" ]; then
+  apt_source=$PT_apt_source
+else
+  apt_source='http://apt.puppet.com'
+fi
+
+if [ -n "$PT_mac_source" ]; then
+  mac_source=$PT_mac_source
+else
+  mac_source='http://downloads.puppet.com'
+fi
+
 # Error if non-root
 if [ `id -u` -ne 0 ]; then
   echo "puppet_agent::install task must be run as root"
@@ -417,24 +435,24 @@ case $platform in
   "SLES")
     info "SLES platform! Lets get you an RPM..."
     gpg_key="${tmp_dir}/RPM-GPG-KEY-puppet"
-    do_download "https://yum.puppetlabs.com/RPM-GPG-KEY-puppet" "$gpg_key"
+    do_download "https://yum.puppet.com/RPM-GPG-KEY-puppet" "$gpg_key"
     rpm --import "$gpg_key"
     rm -f "$gpg_key"
     filetype="noarch.rpm"
     filename="${collection}-release-sles-${platform_version}.noarch.rpm"
-    download_url="https://yum.puppetlabs.com/${collection}/${filename}"
+    download_url="${yum_source}/${collection}/${filename}"
     ;;
   "el")
     info "Red hat like platform! Lets get you an RPM..."
     filetype="rpm"
     filename="${collection}-release-el-${platform_version}.noarch.rpm"
-    download_url="https://yum.puppetlabs.com/${collection}/${filename}"
+    download_url="${yum_source}/${collection}/${filename}"
     ;;
   "Fedora")
     info "Fedora platform! Lets get the RPM..."
     filetype="rpm"
     filename="${collection}-release-fedora-${platform_version}.noarch.rpm"
-    download_url="https://yum.puppetlabs.com/${collection}/${filename}"
+    download_url="${yum_source}/${collection}/${filename}"
     ;;
   "Debian")
     info "Debian platform! Lets get you a DEB..."
@@ -447,7 +465,7 @@ case $platform in
     esac
     filetype="deb"
     filename="${collection}-release-${deb_codename}.deb"
-    download_url="https://apt.puppetlabs.com/${filename}"
+    download_url="${apt_source}/${filename}"
     ;;
   "Ubuntu")
     info "Ubuntu platform! Lets get you a DEB..."
@@ -467,7 +485,7 @@ case $platform in
     esac
     filetype="deb"
     filename="${collection}-release-${deb_codename}.deb"
-    download_url="https://apt.puppetlabs.com/${filename}"
+    download_url="${apt_source}/${filename}"
     ;;
   "mac_os_x")
     info "OSX platform! Lets get you a DMG..."
@@ -477,7 +495,7 @@ case $platform in
     else
       filename="puppet-agent-${version}-1.osx${platform_version}.dmg"
     fi
-    download_url="https://downloads.puppetlabs.com/mac/${collection}/${platform_version}/x86_64/${filename}"
+    download_url="${mac_source}/mac/${collection}/${platform_version}/x86_64/${filename}"
     ;;
   *)
     critical "Sorry $platform is not supported yet!"


### PR DESCRIPTION
This commit adds new source parameters:
* absolute_source
* yum_source
* apt_source
* mac_source
* windows_source
* solaris_source
* aix_source
* use_alternate_sources
* alternate_master_source

Each source parameter will modify where the module attempts to pull packages
for different use cases.

Absolute_source: This parameter is for use cases where the package source
should be an absolute path on the filesystem. It's a common windows paradigm
to use a network share to serve files to systems behind a firewall. This param
should server that purpose.

(yum/apt/mac etc.)_source: these parameters are for use cases where someone has
mirrored the public downloads sites for puppet and they just need to change the
underlying base URL for grabbing packages. Hopefully this enables workflows
like using artifactory with PE to serve agents.

use_alternate_sources: This will force PE installs to use the yum/apt/mac etc.
sources rather than the pe_repo file share from the master. This should give
PE users the same functionality as FOSS users with respect to the (yum/apt/mac
etc.)_source params.

alternate_master_source: this parameter is for use cases where files should be
served from a server other than the PE master, but the files are still served
in the same directory structure you would see in a PE install. This should
serve use cases where either 1. a user wants to use a specific master to serve
all agent packages or 2. a situation in which pe_repo is deployed somewhere
other than the PE master

Additionally: the normal $source parameter has been modified to work in a
backwards compatible way to older versions of this module:

For unix/Mac agents, $source will replace the PE master base URL. For windows
agents, $source will be a fully qualified path to an MSI package.