### PR TITLE
(MODULES-8821) Update win install to use production environment

### DIFF
--- a/files/install_puppet.ps1
+++ b/files/install_puppet.ps1
@@ -256,7 +256,7 @@ $service_names=@(
   "mcollective"
 )
 try {
-  $state_dir = (puppet.bat config print statedir)
+  $state_dir = (puppet.bat config print statedir --environment production)
   Write-Log "Installation PID:$PID"
   $install_pid_lock = Join-Path -Path $state_dir -ChildPath 'puppet_agent_upgrade.pid'
   Lock-Installation $install_pid_lock


### PR DESCRIPTION
The windows installer uses the puppet command from the CLI to find the
statedir to put install state files in. When the default environment for
puppet is set to something other than production the command fails on older
agents (See: https://tickets.puppetlabs.com/browse/PUP-6739).

This commit simply updates the invocation of the puppet command to force the
production environment when finding the statedir.