### PR TITLE
(docs) Revise macOS limitations note.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -302,7 +302,7 @@ package `version` can be specified; if not, will install or upgrade to the lates
 
 ## Limitations
 
-Mac OS X Open Source packages are currently not supported.
+Mac OS X/macOS open source packages are not supported in puppet_agent module releases prior to v2.1.0.
 
 ### Known issues
 


### PR DESCRIPTION
v2.1.0 added macOS support. Revise the note under "Limitations" to acknowledge this.