### PR TITLE
installdir parameter not defined in install_shell task

### DIFF
--- a/tasks/install_shell.json
+++ b/tasks/install_shell.json
@@ -30,6 +30,10 @@
     "install_options": {
       "description": "optional install arguments to the windows installer (defaults to REINSTALLMODE=\"amus\")",
       "type": "Optional[String]"
+    },
+    "installdir": {
+      "description": "optional install arguments -  installer install directory ",
+      "type": "Optional[String]"
     }
   }
 }

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -69,6 +69,13 @@ if [ `id -u` -ne 0 ]; then
   echo "puppet_agent::install task must be run as root"
   exit 1
 fi
+#Add installdir parameter value 
+
+if [ -f "$PT_installdir" ]; then
+   install_dir=$PT_installdir
+else
+   installdir="/etc/puppetlabs/code/environments/production/modules"
+fi
 
 # Track to handle puppet5 to puppet6
 if [ -f /opt/puppetlabs/puppet/VERSION ]; then
@@ -79,10 +86,10 @@ fi
 
 # Retrieve Platform and Platform Version
 # Utilize facts implementation when available
-if [ -f "$PT__installdir/facts/tasks/bash.sh" ]; then
+if [ -f "$PT_installdir/facts/tasks/bash.sh" ]; then
   # Use facts module bash.sh implementation
-  platform=$(bash $PT__installdir/facts/tasks/bash.sh "platform")
-  platform_version=$(bash $PT__installdir/facts/tasks/bash.sh "release")
+  platform=$(bash $PT_installdir/facts/tasks/bash.sh "platform")
+  platform_version=$(bash $PT_installdir/facts/tasks/bash.sh "release")
 
   # Handle CentOS
   if test "x$platform" = "xCentOS"; then


### PR DESCRIPTION
installdir parameter not defined in install_shell task, Due to that `install_shell` task is failing with the following error. 

```
Error: Task finished with exit-code 1 
This module depends on the puppetlabs-facts module
```