### PR TITLE
Fix Yum URL path for RedHat systems still using the PC1 collection

### DIFF
--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -37,7 +37,11 @@ class puppet_agent::osfamily::redhat{
         $source = "https://${::puppet_master_server}:8140/packages/${pe_server_version}/${pe_repo_dir}"
       }
     } else {
-      $source = "${::puppet_agent::yum_source}/${::puppet_agent::collection}/${platform_and_version}/${::puppet_agent::arch}"
+      if $::puppet_agent::collection == 'PC1' {
+        $source = "${::puppet_agent::yum_source}/${platform_and_version}/${::puppet_agent::collection}/${::puppet_agent::arch}"
+      } else {
+        $source = "${::puppet_agent::yum_source}/${::puppet_agent::collection}/${platform_and_version}/${::puppet_agent::arch}"
+      }
     }
 
 


### PR DESCRIPTION
Currently, if you have a RedHat-based machine and you specify the **PC1** collection, you get a yum repository configuration with the `source` set to:

http://yum.puppet.com/PC1/el/6/x86_64

However, the correct URL should be:

http://yum.puppet.com/el/6/PC1/x86_64

This PR fixes the `source` to use the correct URL if **PC1** is the collection being used.