### PR TITLE
(MODULES-8923) autodetect package_version based upon the master

### DIFF
--- a/manifests/osfamily/aix.pp
+++ b/manifests/osfamily/aix.pp
@@ -44,14 +44,15 @@ class puppet_agent::osfamily::aix{
       $aix_ver_number = '6.1'
     }
   }
+
   if $::puppet_agent::absolute_source {
     $source = $::puppet_agent::absolute_source
   } elsif $::puppet_agent::alternate_pe_source {
-    $source = "${::puppet_agent::alternate_pe_source}/packages/${pe_server_version}/aix-${aix_ver_number}-power/${::puppet_agent::package_name}-${::puppet_agent::package_version}-1.aix${aix_ver_number}.ppc.rpm"
+    $source = "${::puppet_agent::alternate_pe_source}/packages/${pe_server_version}/aix-${aix_ver_number}-power/${::puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.aix${aix_ver_number}.ppc.rpm"
   } elsif $::puppet_agent::source {
-    $source = "${::puppet_agent::source}/packages/${pe_server_version}/aix-${aix_ver_number}-power/${::puppet_agent::package_name}-${::puppet_agent::package_version}-1.aix${aix_ver_number}.ppc.rpm"
+    $source = "${::puppet_agent::source}/packages/${pe_server_version}/aix-${aix_ver_number}-power/${::puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.aix${aix_ver_number}.ppc.rpm"
   } else {
-    $source = "${::puppet_agent::aix_source}/${pe_server_version}/aix-${aix_ver_number}-power/${::puppet_agent::package_name}-${::puppet_agent::package_version}-1.aix${aix_ver_number}.ppc.rpm"
+    $source = "${::puppet_agent::aix_source}/${pe_server_version}/aix-${aix_ver_number}-power/${::puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.aix${aix_ver_number}.ppc.rpm"
   }
 
   class { '::puppet_agent::prepare::package':

--- a/manifests/osfamily/darwin.pp
+++ b/manifests/osfamily/darwin.pp
@@ -6,15 +6,16 @@ class puppet_agent::osfamily::darwin{
   } elsif ($::puppet_agent::is_pe and (!$::puppet_agent::use_alternate_sources)) {
     $pe_server_version = pe_build_version()
     if $::puppet_agent::alternate_pe_source {
-      $source = "${::puppet_agent::alternate_pe_source}/packages/${pe_server_version}/${::platform_tag}/${puppet_agent::package_name}-${puppet_agent::package_version}-1.osx${$::macosx_productversion_major}.dmg"
+      $source = "${::puppet_agent::alternate_pe_source}/packages/${pe_server_version}/${::platform_tag}/${puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.osx${$::macosx_productversion_major}.dmg"
     } elsif $::puppet_agent::source {
-      $source = "${::puppet_agent::source}/packages/${pe_server_version}/${::platform_tag}/${puppet_agent::package_name}-${puppet_agent::package_version}-1.osx${$::macosx_productversion_major}.dmg"
+      $source = "${::puppet_agent::source}/packages/${pe_server_version}/${::platform_tag}/${puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.osx${$::macosx_productversion_major}.dmg"
     } else {
-      $source = "puppet:///pe_packages/${pe_server_version}/${::platform_tag}/${puppet_agent::package_name}-${puppet_agent::package_version}-1.osx${$::macosx_productversion_major}.dmg"
+      $source = "puppet:///pe_packages/${pe_server_version}/${::platform_tag}/${puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.osx${$::macosx_productversion_major}.dmg"
     }
   } else {
-    $source = "${::puppet_agent::mac_source}/mac/${::puppet_agent::collection}/${::macosx_productversion_major}/${::puppet_agent::arch}/${puppet_agent::package_name}-${puppet_agent::package_version}-1.osx${$::macosx_productversion_major}.dmg"
+    $source = "${::puppet_agent::mac_source}/mac/${::puppet_agent::collection}/${::macosx_productversion_major}/${::puppet_agent::arch}/${puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.osx${$::macosx_productversion_major}.dmg"
   }
+
   class { '::puppet_agent::prepare::package':
     source => $source,
   }

--- a/manifests/osfamily/suse.pp
+++ b/manifests/osfamily/suse.pp
@@ -87,7 +87,9 @@ class puppet_agent::osfamily::suse{
           # Set up a zypper repository by creating a .repo file which mimics a ini file
           $repo_file = '/etc/zypp/repos.d/pc_repo.repo'
           $repo_name = 'pc_repo'
-          $agent_version = $::puppet_agent::package_version
+
+          # 'auto' versus X.Y.Z
+          $_package_version = getvar('puppet_agent::master_or_package_version')
 
           # In Puppet Enterprise, agent packages are served by the same server
           # as the master, which can be using either a self signed CA, or an external CA.
@@ -113,7 +115,7 @@ class puppet_agent::osfamily::suse{
 
           exec { "refresh-${repo_name}":
             path      => '/bin:/usr/bin:/sbin:/usr/sbin',
-            unless    => "zypper search -r ${repo_name} -s | grep puppet-agent | awk '{print \$7}' | grep \"^${agent_version}\"",
+            unless    => "zypper search -r ${repo_name} -s | grep puppet-agent | awk '{print \$7}' | grep \"^${_package_version}\"",
             command   => "zypper refresh ${repo_name}",
             logoutput => 'on_failure',
           }

--- a/manifests/osfamily/windows.pp
+++ b/manifests/osfamily/windows.pp
@@ -1,5 +1,6 @@
 class puppet_agent::osfamily::windows{
   assert_private()
+
   if $::puppet_agent::absolute_source {
     $source = $::puppet_agent::absolute_source
   } elsif $::puppet_agent::source {
@@ -17,14 +18,15 @@ class puppet_agent::osfamily::windows{
     }
   } else {
     if $::puppet_agent::collection == 'PC1'{
-      $source = "${::puppet_agent::windows_source}/windows/${::puppet_agent::package_name}-${::puppet_agent::package_version}-${::puppet_agent::arch}.msi"
+      $source = "${::puppet_agent::windows_source}/windows/${::puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-${::puppet_agent::arch}.msi"
     } else {
-      $source = "${::puppet_agent::windows_source}/windows/${::puppet_agent::collection}/${::puppet_agent::package_name}-${::puppet_agent::package_version}-${::puppet_agent::arch}.msi"
+      $source = "${::puppet_agent::windows_source}/windows/${::puppet_agent::collection}/${::puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-${::puppet_agent::arch}.msi"
     }
   }
 
   class { '::puppet_agent::prepare::package':
     source => $source,
   }
+
   contain puppet_agent::prepare::package
 }

--- a/spec/classes/puppet_agent_osfamily_aix_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_aix_spec.rb
@@ -116,6 +116,27 @@ describe 'puppet_agent' do
     end
   end
 
+  context 'with package_version auto' do
+    let(:params) {
+      {
+        package_version: 'auto',
+      }
+    }
+    let(:facts) {
+      common_facts.merge({
+        serverversion: '5.10.200'
+      })
+    }
+    let(:rpmname) {"puppet-agent-5.10.200-1.aix7.1.ppc.rpm"}
+    it {
+      is_expected.to contain_package('puppet-agent').with({
+        'source'    => "/opt/puppetlabs/packages/#{rpmname}",
+        'ensure'    => '5.10.200',
+        'provider'  => 'rpm',
+      })
+    }
+  end
+
   context 'unsupported environments' do
     let(:params) {
       {

--- a/spec/classes/puppet_agent_osfamily_darwin_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_darwin_spec.rb
@@ -85,4 +85,23 @@ describe 'puppet_agent' do
     end
     it { is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-5.10.100.1-1.osx10.13.dmg").with_source('https://fake-pe-master.com/packages/2000.0.0/osx-10.13-x86_64/puppet-agent-5.10.100.1-1.osx10.13.dmg') }
   end
+
+  describe 'when using package_version auto' do
+    let(:params) {
+      {
+        package_version: 'auto',
+      }
+    }
+    let(:facts) do
+      facts.merge({
+        :is_pe                       => true,
+        :aio_agent_version           => '1.10.99',
+        :platform_tag                => 'osx-10.13-x86_64',
+        :macosx_productversion_major => '10.13',
+        :serverversion               => '5.10.200'
+      })
+    end
+    it { is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-5.10.200-1.osx10.13.dmg").with_source('puppet:///pe_packages/2000.0.0/osx-10.13-x86_64/puppet-agent-5.10.200-1.osx10.13.dmg') }
+  end
+
 end

--- a/spec/classes/puppet_agent_osfamily_windows_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_windows_spec.rb
@@ -43,4 +43,35 @@ describe 'puppet_agent' do
       }
     end
   end
+
+  [['x64', 'x86_64'], ['x86', 'i386']].each do |arch, tag|
+    describe "supported Windows #{arch} environment with auto" do
+      server_version = '1.10.100'
+      let(:params)  {{ package_version: 'auto' }}
+      let(:appdata) { 'C:\ProgramData' }
+      let(:facts) {{
+        :is_pe                => true,
+        :osfamily             => 'windows',
+        :operatingsystem      => 'windows',
+        :architecture         => arch,
+        :servername           => 'master.example.vm',
+        :clientcert           => 'foo.example.vm',
+        :puppet_confdir       => "#{appdata}\\Puppetlabs\\puppet\\etc",
+        :puppet_agent_appdata => appdata,
+        :env_temp_variable => 'C:/tmp',
+        :puppet_agent_pid     => 42,
+        :aio_agent_version    => '1.0.0',
+        :serverversion        => server_version
+      }}
+
+      it { is_expected.to contain_file("#{appdata}\\Puppetlabs") }
+      it { is_expected.to contain_file("#{appdata}\\Puppetlabs\\packages") }
+      it {
+        is_expected.to contain_file("#{appdata}\\Puppetlabs\\packages\\puppet-agent-#{arch}.msi").with(
+          'source' => "puppet:///pe_packages/#{pe_version}/windows-#{tag}/puppet-agent-#{arch}.msi"
+        )
+      }
+    end
+  end
+
 end

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -59,6 +59,13 @@ describe 'puppet_agent' do
           end
           it { is_expected.to contain_class('puppet_agent').with_package_version(nil) }
         end
+
+        context 'package_version is same as master when set to auto' do
+          let(:params) {{ :package_version => 'auto' }}
+          let(:node_params) {{ :serverversion => '7.6.5' }}
+          it { is_expected.to contain_class('puppet_agent::prepare').with_package_version('7.6.5') }
+          it { is_expected.to contain_class('puppet_agent::install').with_package_version('7.6.5') }
+        end
       end
     end
   end


### PR DESCRIPTION
With this commit, the user can specify `package_version` as 'master'
to specify that the package version should be the same as the compiling master.