### PR TITLE
(maint) Fix task acceptance tests for fedora 29

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ group :system_tests do
   gem "puppet-blacksmith", '~> 3.4',                                             :require => false
   # Bundler fails on 2.1.9 even though this group is excluded
   if ENV['GEM_BOLT']
-    gem 'bolt', '~> 1.9', require: false
+    gem 'bolt', '~> 1.15', require: false
     gem 'beaker-task_helper', '~> 1.5.2', require: false
   end
 end

--- a/task_spec/Rakefile
+++ b/task_spec/Rakefile
@@ -8,6 +8,6 @@ PuppetLint.configuration.send('disable_class_inherits_from_params_class')
 PuppetLint.configuration.send('disable_documentation')
 PuppetLint.configuration.send('disable_single_quote_string_with_variables')
 PuppetLint.configuration.send('disable_only_variable_string')
-PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+PuppetLint.configuration.ignore_paths = ['spec/**/*.pp', 'pkg/**/*.pp']
 
-task :task_acceptance => [:spec_prep, :beaker]
+task task_acceptance: [:spec_prep, :beaker]

--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -12,63 +12,76 @@ describe 'install task' do
     RSpec.configuration.module_path
   end
 
-  def config
+  def bolt_config
     { 'modulepath' => module_path }
   end
 
-  def inventory
+  def bolt_inventory
     hosts_to_inventory
   end
 
+  def target_platform
+    # These tests are configured such that there will only ever be a single host
+    # which is what is mapped to 'target' in hosts_to_inventory. This function allows
+    # retrieving the target platform for use in obtaining a valid puppet-agent version
+    hosts.first[:platform]
+  end
+
   it 'works with version and install tasks' do
+    puppet_5_version = case target_platform
+                       when %r{fedora-29}
+                         '5.5.10'
+                       else
+                         '5.5.3'
+                       end
     # test the agent isn't already installed and that the version task works
-    results = run_task('puppet_agent::version', 'target', {}, config: config, inventory: inventory)
+    results = run_task('puppet_agent::version', 'target', {})
     results.each do |res|
       expect(res).to include('status' => 'success')
       expect(res['result']['version']).to eq(nil)
     end
 
     # Try to install an older version
-    results = run_task( "puppet_agent::install", 'target', { 'collection' => 'puppet5', 'version' => '5.5.3' }, config: config, inventory: inventory)
+    results = run_task('puppet_agent::install', 'target', { 'collection' => 'puppet5', 'version' => puppet_5_version })
     results.each do |res|
       expect(res).to include('status' => 'success')
     end
 
     # It installed a version older than latest
-    results = run_task('puppet_agent::version', 'target', {}, config: config, inventory: inventory)
+    results = run_task('puppet_agent::version', 'target', {})
     results.each do |res|
       expect(res).to include('status' => 'success')
-      expect(res['result']['version']).to eq('5.5.3')
+      expect(res['result']['version']).to eq(puppet_5_version)
       expect(res['result']['source']).to be
     end
 
     # Run with no argument upgrades
-    results = run_task( "puppet_agent::install", 'target', { 'collection' => 'puppet5' }, config: config, inventory: inventory)
+    results = run_task('puppet_agent::install', 'target', { 'collection' => 'puppet5' })
     results.each do |res|
       expect(res).to include('status' => 'success')
     end
 
     # Verify that it upgraded
-    results = run_task('puppet_agent::version', 'target', {}, config: config, inventory: inventory)
+    results = run_task('puppet_agent::version', 'target', {})
     results.each do |res|
       expect(res).to include('status' => 'success')
-      expect(res['result']['version']).not_to eq('5.5.3')
-      expect(res['result']['version']).to match(/^5\.\d+\.\d+/)
+      expect(res['result']['version']).not_to eq(puppet_5_version)
+      expect(res['result']['version']).to match(%r{^5\.\d+\.\d+})
       expect(res['result']['source']).to be
     end
 
     # Upgrade from puppet5 to puppet6
-    results = run_task( "puppet_agent::install", 'target', { 'collection' => 'puppet6' }, config: config, inventory: inventory)
+    results = run_task('puppet_agent::install', 'target', { 'collection' => 'puppet6' })
     results.each do |res|
       expect(res).to include('status' => 'success')
     end
 
     # Verify that it upgraded
-    results = run_task('puppet_agent::version', 'target', {}, config: config, inventory: inventory)
+    results = run_task('puppet_agent::version', 'target', {})
     results.each do |res|
       expect(res).to include('status' => 'success')
-      expect(res['result']['version']).not_to match(/^5\.\d+\.\d+/)
-      expect(res['result']['version']).to match(/^6\.\d+\.\d+/)
+      expect(res['result']['version']).not_to match(%r{^5\.\d+\.\d+})
+      expect(res['result']['version']).to match(%r{^6\.\d+\.\d+})
       expect(res['result']['source']).to be
     end
   end

--- a/task_spec/spec/spec_helper_acceptance.rb
+++ b/task_spec/spec/spec_helper_acceptance.rb
@@ -18,6 +18,5 @@ RSpec.configure do |c|
 
   # should we just use rspec_puppet
   c.add_setting :module_path
-  c.module_path  = File.join(base_dir, 'fixtures', 'modules')
-
+  c.module_path = File.join(base_dir, 'fixtures', 'modules')
 end


### PR DESCRIPTION
This commit updates the task acceptance tests to use appropriate puppet-agent versions to install and upgrade from the puppet 5 collection. It also utilizes new a new feature in the BoltSpec::Run module allowing bolt configuration to occur outside of individual method calls.