### PR TITLE
puppet_agent::service: option to not start the service on puppet run

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,8 +3,16 @@
 # This class is meant to be called from puppet_agent.
 # It ensures that managed services are running.
 #
-class puppet_agent::service {
+class puppet_agent::service (
+  Boolean $autostart = true,
+){
   assert_private()
+
+  if $autostart {
+    $_puppet_service_ensure = running
+  } else {
+    $_puppet_service_ensure = undef
+  }
 
   # Starting with puppet6 collections we no longer carry the mcollective service
   if $::puppet_agent::collection != 'PC1' and $::puppet_agent::collection != 'puppet5' {
@@ -36,7 +44,7 @@ class puppet_agent::service {
   } else {
     $_service_names.each |$service| {
       service { $service:
-        ensure     => running,
+        ensure     => $_puppet_service_ensure,
         enable     => true,
         hasstatus  => true,
         hasrestart => true,


### PR DESCRIPTION
We needed a way to not start puppet on testing other environments.

We usually run in `production` but from time to time we need to stop puppet and use `--environment foobar` to check things, where we might need some time to investigate changes. Starting puppet automatically here is not what we want.

If this is already possible, please gladly point me in the direction where I can find the documentation/code!