### PR TITLE
Add Debian package pin to stop the version changing on apt upgrade

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -62,6 +62,11 @@ class puppet_agent::install(
           $_package_version = $package_version
         } else {
           $_package_version = "${package_version}-1${::lsbdistcodename}"
+          apt::pin { "pin ${::puppet_agent::package_name} package":
+            packages => $::puppet_agent::package_name,
+            priority => 1000,
+            version  => $_package_version,
+          }
         }
         $_provider = 'apt'
         $_source = undef


### PR DESCRIPTION
When on Debian and a package version is specified we should also create a Debian package pin to stop `apt upgrade` from changing the version just for the next puppet run to change it back.