### PR TITLE
(MODULES-9173) Mcollective service restarting when PA upgrade is done.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,7 +10,7 @@ class puppet_agent::params {
     $service_names = []
   } else {
     # Mcollective will be removed from this list in the service manifest if
-    # the puppet version is > 6.0.0
+    # the puppet version is >= 6.0.0
     $service_names = ['puppet', 'mcollective']
   }
   if $::osfamily == 'windows' {

--- a/templates/solaris_install.sh.erb
+++ b/templates/solaris_install.sh.erb
@@ -1,13 +1,18 @@
 function start_service() {
   service="${1:?}"
-  /opt/puppetlabs/bin/puppet resource service "${service:?}" ensure=running
+  /opt/puppetlabs/bin/puppet resource service "${service:?}" ensure=running enable=true
 }
-service_was_running_before_agent_update = false
-if /opt/puppetlabs/bin/puppet resource service "${service_name:?}" | grep "ensure => 'running'" ; then
-   service_was_running_before_agent_update = true
+
+<% @service_names.each do |service_name| -%>
+<%= service_name %>_was_running = false
+if /opt/puppetlabs/bin/puppet resource service "<%= service_name %>" | grep "ensure => 'running'" ; then
+  <%= service_name %>_was_running = true
 fi
+<% end -%>
+
 # Remove old package
 /opt/puppetlabs/bin/puppet resource package puppet-agent ensure=absent adminfile=<%= @adminfile %>
+
 # Install package
 pkgadd -a <%= @adminfile %> -d <%= @sourcefile %> -G <%= @install_options.join(' ') %> -n puppet-agent
 
@@ -15,8 +20,8 @@ pkgadd -a <%= @adminfile %> -d <%= @sourcefile %> -G <%= @install_options.join('
 # services on its own since that only happens when the service manifests change, which is
 # highly unlikely in most agent upgrade scenarios.
 
-<% @service_names.each do |service_name| %>
-  if $service_was_running_before_agent_update ; then
-    start_service <%= service_name %>
-  fi
-<% end %>
+<% @service_names.each do |service_name| -%>
+if $<%= service_name %>_was_running ; then
+  start_service <%= service_name %>
+fi
+<% end -%>

--- a/templates/solaris_install.sh.erb
+++ b/templates/solaris_install.sh.erb
@@ -1,11 +1,13 @@
 function start_service() {
   service="${1:?}"
-  /opt/puppetlabs/bin/puppet resource service "${service:?}" ensure=running enable=true
+  /opt/puppetlabs/bin/puppet resource service "${service:?}" ensure=running
 }
-
+service_was_running_before_agent_update = false
+if /opt/puppetlabs/bin/puppet resource service "${service_name:?}" | grep "ensure => 'running'" ; then
+   service_was_running_before_agent_update = true
+fi
 # Remove old package
 /opt/puppetlabs/bin/puppet resource package puppet-agent ensure=absent adminfile=<%= @adminfile %>
-
 # Install package
 pkgadd -a <%= @adminfile %> -d <%= @sourcefile %> -G <%= @install_options.join(' ') %> -n puppet-agent
 
@@ -14,5 +16,7 @@ pkgadd -a <%= @adminfile %> -d <%= @sourcefile %> -G <%= @install_options.join('
 # highly unlikely in most agent upgrade scenarios.
 
 <% @service_names.each do |service_name| %>
-start_service <%= service_name %>
+  if $service_was_running_before_agent_update ; then
+    start_service <%= service_name %>
+  fi
 <% end %>


### PR DESCRIPTION
This PR fixes the following:

When and upgrade is done for solaris 10 we enable the service only if the service was running before.