### PR TITLE
(maint) Allow stdlib 6.x

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,13 +2,16 @@ fixtures:
   forge_modules:
     stdlib:
       repo: "puppetlabs/stdlib"
-      ref: "5.1.0"
+      ref: "6.0.0"
     inifile:
       repo: "puppetlabs/inifile"
       ref: "2.4.0"
     apt:
       repo: "puppetlabs/apt"
-      ref: "6.0.0"
+      ref: "7.0.1"
+    translate:
+      repo: "puppetlabs/translate"
+      ref: "1.2.0"
     yumrepo_core:
       repo: "puppetlabs/yumrepo_core"
     facts:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
   - rvm: 2.5.3
     env: CHECK="validate lint spec"
   - rvm: 2.5.3
+    env: PUPPET_GEM_VERSION="~> 6.0" CHECK=spec
+  - rvm: 2.5.3
     env: PUPPET_GEM_VERSION="~> 5.0" CHECK=spec
   - rvm: 2.3.8
     env: PUPPET_GEM_VERSION="~> 4.10" CHECK=spec

--- a/metadata.json
+++ b/metadata.json
@@ -115,9 +115,9 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 5.1.0 < 6.0.0"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 5.1.0 < 7.0.0"},
     {"name":"puppetlabs-inifile","version_requirement":">= 2.4.0 <= 3.0.0"},
-    {"name":"puppetlabs-apt","version_requirement":">= 6.0.0 < 7.0.0"},
+    {"name":"puppetlabs-apt","version_requirement":">= 7.0.1 < 8.0.0"},
     {"name":"puppetlabs-facts","version_requirement":">= 0.5.0 < 1.0.0"}
   ]
 }


### PR DESCRIPTION
A number of modules are now allowing stdlib 6.x and we expect some will require it. It would be great to get a new release after this PR so that a version of puppet_agent is available supporting stdlib 6.x. Thanks.