### PR TITLE
(MODULES-8921) Implement puppet_agent::run task

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -43,6 +43,7 @@
     - [Tasks](#tasks)
       - [`puppet_agent::version`](#puppet_agentversion)
       - [`puppet_agent::install`](#puppet_agentinstall)
+      - [`puppet_agent::run`](#puppet_agentrun)
   - [Limitations](#limitations)
     - [Known issues](#known-issues)
   - [Development](#development)
@@ -303,6 +304,26 @@ Installs the puppet-agent package. Currently only supports Linux variants: Debia
 package `version` can be specified; if not, will install or upgrade to the latest Puppet 5 version available.
 
 **Note**: The `puppet_agent::install_shell` task requires the `facts::bash` implementation from the [facts](https://forge.puppet.com/puppetlabs/facts) module. Both the `puppet_agent` and `facts` modules are packaged with Bolt. For use outside of Bolt make sure the `facts` module is installed to the same `modules` directory as `puppet_agent`.
+
+#### `puppet_agent::run`
+
+Performs a one-time run of the Puppet agent. By default the run is invoked with a standard set of command-line options equivalent to `puppet agent -t`. Passing of any/all command-line options is supported.
+
+Default options:
+
+```json
+{
+  "onetime": true,
+  "verbose": true,
+  "daemonize": false,
+  "usecacheonfailure": false,
+  "detailed-exitcodes": true,
+  "splay": false,
+  "show_diff": true
+}
+```
+
+**Note**: Pre-validation of passed command-line options is not performed. If a command-line option is invalid or typo'd, Puppet will be called, but will fail with an error indicating incorrect invocation.
 
 ## Limitations
 

--- a/tasks/run.json
+++ b/tasks/run.json
@@ -1,0 +1,11 @@
+{
+  "description": "Run Puppet agent",
+  "parameters": {
+    "options": {
+      "type": "Hash",
+      "description": "Hash of Puppet settings to pass. e.g.: {\"modulepath\"=>\"/expl/path\", \"job-id\"=>\"100\", \"noop\"=>true}"
+    }
+  },
+  "input_method": "stdin",
+  "files": ["ruby_task_helper/files/task_helper.rb"]
+}

--- a/tasks/run.rb
+++ b/tasks/run.rb
@@ -1,0 +1,83 @@
+#!/usr/bin/env ruby
+
+require_relative "../../ruby_task_helper/files/task_helper.rb"
+require 'etc'
+require 'open3'
+
+# The HOME environment variable is important when invoking Puppet. If HOME is not
+# already set, set it.
+ENV['HOME'] ||= Etc.getpwuid.dir
+
+class Run < TaskHelper
+  def task(options: {}, **kwargs)
+    cmd = []
+    cmd << puppet_executable << 'agent'
+
+    default_options = {
+      'onetime'            => true,
+      'verbose'            => true,
+      'daemonize'          => false,
+      'usecacheonfailure'  => false,
+      'detailed-exitcodes' => true,
+      'splay'              => false,
+      'show_diff'          => true,
+    }
+
+    default_options.merge(options).each do |opt, val|
+      case val
+      when true
+        cmd << "--#{opt}"
+      when false
+        cmd << "--no-#{opt}"
+      else
+        cmd << "--#{opt}" << val
+      end
+    end
+
+    output, status = Open3.capture2e(*cmd)
+
+    result = {
+      output: output,
+      exitcode: status.exitstatus,
+      command: cmd.join(' ')
+    }
+
+    case status.exitstatus
+    when 0, 2
+      result
+    when 4, 6
+      raise TaskHelper::Error.new("Puppet agent run succeeded, but some resources failed",
+                                  "puppet_agent/resource-error",
+                                  result)
+    else
+      raise TaskHelper::Error.new("Puppet agent run failed or wasn't attempted",
+                                  "puppet_agent/run-error",
+                                  result)
+    end
+  end 
+
+  def puppet_executable
+    preferred = if windows?
+                  'C:/Program Files/Puppet Labs/Puppet/bin/puppet.bat'
+                else
+                  '/opt/puppetlabs/bin/puppet'
+                end
+
+    # Invoke the preferred executable if it exists. Otherwise, expect/require
+    # that puppet be in the PATH and can be invoked as "puppet".
+    File.exist?(preferred) ? preferred : 'puppet'
+  end
+
+  def windows?
+    # Ruby only sets File::ALT_SEPARATOR on Windows and the Ruby standard
+    # library uses that to test what platform it's on. This method can be used
+    # to determine the behavior of the underlying system without requiring
+    # features to be initialized and without side effect.
+    !!File::ALT_SEPARATOR
+  end
+
+end
+
+if __FILE__ == $0
+  Run.run
+end


### PR DESCRIPTION
This provides a task to perform on-demand runs of the Puppet agent, with the ability to pass command-line options.