### PR TITLE
(PE-26530) Update spec and task acceptance tests with Fedora 30

### DIFF
--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -18,7 +18,7 @@ describe 'puppet_agent' do
     }
   end
 
-  [['Fedora', 'fedora/f29', 29], ['CentOS', 'el/7', 7], ['Amazon', 'el/6', 6]].each do |os, urlbit, osmajor|
+  [['Fedora', 'fedora/f30', 30], ['CentOS', 'el/7', 7], ['Amazon', 'el/6', 6]].each do |os, urlbit, osmajor|
     context "with #{os} and #{urlbit}" do
       let(:facts) do
         super().merge(:operatingsystem  => os, :operatingsystemmajrelease => osmajor)

--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -31,6 +31,8 @@ describe 'install task' do
     puppet_5_version = case target_platform
                        when %r{fedora-29}
                          '5.5.10'
+                       when %r{fedora-30}
+                         '5.5.16'
                        else
                          '5.5.3'
                        end


### PR DESCRIPTION
To ensure Task Acceptance Tests pass with Fedora 30 we need to add the available puppet5 version:

```
[root@pogb5jjn91gy53y ~]# yum repoquery -a --repoid=puppet5
Puppet 5 Repository fedora 30 - x86_64                                                                                     
puppet-agent-0:5.5.16-1.fc30.x86_64
puppet-bolt-0:1.24.0-1.fc30.x86_64
puppet-bolt-0:1.25.0-1.fc30.x86_64
puppet-bolt-0:1.26.0-1.fc30.x86_64
puppet5-release-0:5.0.0-7.fc30.noarch
```