### PR TITLE
(MODULES-9497) install_puppet.ps1 stale .pid file

### DIFF
--- a/files/install_puppet.ps1
+++ b/files/install_puppet.ps1
@@ -147,8 +147,15 @@ function Script:Lock-Installation {
   begin {
     Write-Log "Locking installation"
     if (Test-Path $install_pid_lock) {
-      Write-Log "Another process has control of $install_pid_lock! Cannot lock, exiting..."
-      throw
+      # if the PID found in $install_pid_lock file is not running, this means
+      # the installation can take control of the file, and assign the new running PID
+      if((Get-Process -Id (Get-Content $install_pid_lock) -ErrorAction SilentlyContinue) -eq $null){
+        Write-Log "Process with PID found in $install_pid_lock is no longer running! Continuing installation and assigning new PID!"
+        $PID | Out-File -FilePath $install_pid_lock
+      }else{
+        Write-Log "Another process has control of $install_pid_lock! Cannot lock, exiting..."
+        throw
+      }
     } else {
       $PID | Out-File -NoClobber -FilePath $install_pid_lock
     }
@@ -345,7 +352,6 @@ try {
   }
   "$_" | Out-File -FilePath (Join-Path -Path $state_dir -ChildPath 'puppet_agent_upgrade_failure.log')
 } finally {
-  Write-Log "Finally block"
   Reset-PuppetServices $services_before
   Unlock-Installation $install_pid_lock
 }

--- a/files/install_puppet.ps1
+++ b/files/install_puppet.ps1
@@ -345,6 +345,7 @@ try {
   }
   "$_" | Out-File -FilePath (Join-Path -Path $state_dir -ChildPath 'puppet_agent_upgrade_failure.log')
 } finally {
+  Write-Log "Finally block"
   Reset-PuppetServices $services_before
   Unlock-Installation $install_pid_lock
 }


### PR DESCRIPTION
When a agent upgrade fails for some reason, the
puppet_agent_upgrade.pid file is not deleted, and the next time
the install_puppet.ps1 runs, it fails again and again as it cannot start
the installation because of the stale .pid file.
 
Now, the install_puppet.ps1 checks if the PID inside the .pid file is
still running, and if not, it will replace the PID inside the file and
continue the installation.