### PR TITLE
(MODULES-9698) Update facts module used for testing install task

### DIFF
--- a/task_spec/.fixtures.yml
+++ b/task_spec/.fixtures.yml
@@ -2,6 +2,6 @@ fixtures:
   forge_modules:
     facts:
       repo: "puppetlabs/facts"
-      ref: "0.5.1"
+      ref: "0.6.0"
   symlinks:
     puppet_agent: "#{File.absolute_path(File.join(source_dir, '..'))}"


### PR DESCRIPTION
Update the version of puppetlabs-facts to match what is shipped with the latest bolt version.