### PR TITLE
Changing WaitForExit value to 8 minutes 480000 milliseconds. Process fails to end in 2 minutes causing upgrade installations to fail.

### DIFF
--- a/files/install_puppet.ps1
+++ b/files/install_puppet.ps1
@@ -277,7 +277,7 @@ try {
     Write-Log "Waiting for puppet to stop, PID:$PuppetPID"
     $pup_process = Get-Process -ID $PuppetPID -ErrorAction SilentlyContinue
     if ($pup_process) {
-      if (!$pup_process.WaitForExit(120000)){
+      if (!$pup_process.WaitForExit(480000)){
         Write-Log "ERROR: Timed out waiting for puppet!"
         throw
       }


### PR DESCRIPTION
Changing WaitForExit value to 8 minutes (480000 milliseconds) versus 2 minutes (120000 ms). Providing additional time for pxp-agent.exe processes to end successfully. Have experienced issues where process doesn't end in 2 minutes causing the upgrade installation to fail.

Accidentally committed to master initially, but reverted change:  d1c56342489cffd62dbad99c3b74af3575f85f01