### PR TITLE
(MODULES-10052) parameterize WaitForExit timeout in puppet_agent install script

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -40,6 +40,7 @@
         - [`install_dir`](#install_dir)
         - [`install_options`](#install_options)
         - [`msi_move_locked_files`](#msi_move_locked_files)
+        - [`wait_for_pxp_agent_exit`](#wait_for_pxp_agent_exit)
     - [Tasks](#tasks)
       - [`puppet_agent::version`](#puppet_agentversion)
       - [`puppet_agent::install`](#puppet_agentinstall)
@@ -288,6 +289,14 @@ This is only applicable for Windows operating systems. There may be instances wh
 
 ``` puppet
   msi_move_locked_files => true
+```
+
+#### `wait_for_pxp_agent_exit`
+
+This is only applicable for Windows operating systems and pertains to /files/install_puppet.ps1 script. This parameterizes the module to define the wait time for the PXP agent to end successfully. The default value is 2 minutes and the timeout value must be defined in milliseconds. Example below, 8 minutes is equal to 480000.
+
+``` puppet
+  wait_for_pxp_agent_exit => 480000
 ```
 
 ### Tasks

--- a/files/install_puppet.ps1
+++ b/files/install_puppet.ps1
@@ -23,6 +23,8 @@
   Provide any extra argmuments to the MSI installation
 .Parameter UseLockedFilesWorkaround
   Set to $true to enable execution of the puppetres.dll move workaround. See https://tickets.puppetlabs.com/browse/MODULES-4207
+.Parameter WaitForPXPAgentExit
+  Time in milliseconds wait for PXP agent process to exit. Default time is 2 minutes (120000) 
 #>
 [CmdletBinding()]
 param(
@@ -40,7 +42,8 @@ param(
   [String] $PuppetStartType,
   [AllowEmptyString()]
   [String] $InstallArgs,
-  [switch] $UseLockedFilesWorkaround
+  [switch] $UseLockedFilesWorkaround,
+  [Int32] $WaitForPXPAgentExit=120000
 )
 # Find-InstallDir, Move-PuppetresDLL and Reset-PuppetresDLL serve as a workaround for older
 # installations of puppet: we used to need to move puppetres.dll out of the way during puppet
@@ -303,8 +306,8 @@ try {
   Write-Log "Waiting for pxp-agent processes to stop"
   Get-Process -Name "pxp-agent" -ErrorAction SilentlyContinue | ForEach-Object {
     if ($_) {
-      # wait on each process for 2 minutes (120000 milliseconds)
-      if (!$_.WaitForExit(120000)){
+      # Wait for each PXP agent process default wait time is 2 minutes.
+      if (!$_.WaitForExit($WaitForPXPAgentExit)){
         Write-Log "ERROR: Timed out waiting for pxp-agent!"
         throw
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -85,7 +85,10 @@
 #   This is only applicable for Windows operating systems. There may be instances where
 #   file locks cause unncessary service restarts.  By setting to true, the module
 #   will move files prior to installation that are known to cause file locks.
-#
+# [wait_for_pxp_agent_exit]
+#   This parameter is only applicable for Windows operating systems and pertains to the 
+#   /files/install_agent.ps1 script. This parameterizes the module to define the wait time
+#   for the PXP agent to end successfully. The default value is set 2 minutes.
 class puppet_agent (
   $arch                    = $::architecture,
   $collection              = $::puppet_agent::params::collection,
@@ -110,6 +113,7 @@ class puppet_agent (
   $install_options         = [],
   $skip_if_unavailable     = 'absent',
   $msi_move_locked_files   = false,
+  $wait_for_pxp_agent_exit = undef,
 ) inherits ::puppet_agent::params {
 
   if (getvar('::aio_agent_version') == undef) {

--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -31,6 +31,12 @@ class puppet_agent::install::windows(
     $_move_dll_workaround = undef
   }
 
+  if $::puppet_agent::wait_for_pxp_agent_exit {
+    $_pxp_agent_wait = "-WaitForPXPAgentExit ${puppet_agent::wait_for_pxp_agent_exit}"
+  } else {
+    $_pxp_agent_wait = undef
+  }
+
   $_timestamp = strftime('%Y_%m_%d-%H_%M')
   $_logfile = windows_native_path("${::env_temp_variable}/puppet-${_timestamp}-installer.log")
 
@@ -60,7 +66,8 @@ class puppet_agent::install::windows(
                           -PuppetMaster '${::puppet_master_server}' \
                           -PuppetStartType '${_agent_startup_mode}' \
                           -InstallArgs '${_install_options}' \
-                          ${_move_dll_workaround}",
+                          ${_move_dll_workaround} \
+                          ${_pxp_agent_wait}",
     unless  => "${::system32}\\WindowsPowerShell\\v1.0\\powershell.exe \
                   -ExecutionPolicy Bypass \
                   -NoProfile \

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -222,8 +222,36 @@ RSpec.describe 'puppet_agent', tag: 'win' do
           }
         end
       end
-    end
+  
+      context 'wait_for_pxp_agent_exit =>' do
+        describe 'default' do
+          it {
+            is_expected.not_to contain_exec('install_puppet.ps1').with_command(/\-WaitForPXPAgentExit/)
+          }
+        end
 
+        describe 'specify false' do
+          let(:params) { global_params.merge(
+            {:wait_for_pxp_agent_exit => false,})
+          }
+
+          it {
+            is_expected.not_to contain_exec('install_puppet.ps1').with_command(/\-WaitForPXPAgentExit/)
+          }
+        end
+
+        describe 'specify true' do
+          let(:params) { global_params.merge(
+            {:wait_for_pxp_agent_exit => true,})
+          }
+
+          it {
+            is_expected.to contain_exec('install_puppet.ps1').with_command(/\-WaitForPXPAgentExit/)
+          }
+        end
+      end
+    end
+  
     context 'rubyplatform' do
       facts = {
         :architecture => 'x64',


### PR DESCRIPTION
Changing WaitForExit value to 8 minutes (42000 ms) versus 2 minutes (120000 ms). 

Additional time for the pxp-agent.exe processes to end successfully. Have experienced issues where the process doesn't end in 2 minutes causing the upgrade installation to fail.