### PR TITLE
(MODULES-9846) fix install using cached catalog

### DIFF
--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -61,6 +61,16 @@ class puppet_agent::install::windows(
                           -PuppetStartType '${_agent_startup_mode}' \
                           -InstallArgs '${_install_options}' \
                           ${_move_dll_workaround}",
+    unless  => "${::system32}\\WindowsPowerShell\\v1.0\\powershell.exe \
+                  -ExecutionPolicy Bypass \
+                  -NoProfile \
+                  -NoLogo \
+                  -NonInteractive \
+                  -Command {\$CurrentVersion = [string](facter.bat -p aio_agent_version); \
+                            if (\$CurrentVersion -eq '${puppet_agent::_expected_package_version}') { \
+                              exit 0; \
+                            } \
+                            exit 1; }.Invoke()",
     path    => $::path,
     require => [
       Puppet_agent_upgrade_error['puppet_agent_upgrade_failure.log'],

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -73,6 +73,17 @@ RSpec.describe 'puppet_agent', tag: 'win' do
         end
       end
 
+      context 'package_version =>' do
+        describe '5.6.7' do
+          let(:params) { global_params.merge(
+            {:package_version => '5.6.7'})
+          }
+          it {
+            is_expected.to contain_exec('install_puppet.ps1').with_unless(/\-Command {\$CurrentVersion = \[string\]\(facter.bat \-p aio_agent_version\);/)
+            is_expected.to contain_exec('install_puppet.ps1').with_unless(/\-Command.*if \(\$CurrentVersion \-eq '5\.6\.7'\) { +exit 0; *} *exit 1; }\.Invoke\(\)/)
+          }
+        end
+      end
       context 'install_options =>' do
         describe 'OPTION1=value1 OPTION2=value2' do
           let(:params) { global_params.merge(


### PR DESCRIPTION
In case a cached catalog requesting puppet agent installation is
applied, the install script executes msi install and service
restart each time is run.

With this correction, the puppet agent package version is checked
against aio_agent_version fact and install continues only if
there is no match.