### PR TITLE
(GH-1204) Add option to stop the puppet agent service after install

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -44,7 +44,9 @@ describe 'install task' do
     end
 
     # Try to install an older version
-    results = run_task('puppet_agent::install', 'target', { 'collection' => 'puppet5', 'version' => puppet_5_version })
+    results = run_task('puppet_agent::install', 'target', { 'collection' => 'puppet5',
+                                                            'version' => puppet_5_version,
+                                                            'stop_service' => true })
     results.each do |res|
       expect(res).to include('status' => 'success')
     end
@@ -56,6 +58,14 @@ describe 'install task' do
       expect(res['result']['version']).to eq(puppet_5_version)
       expect(res['result']['source']).to be
     end
+
+    service = if target_platform =~ /win/
+                run_command('c:/"program files"/"puppet labs"/puppet/bin/puppet resource service puppet', 'target')
+              else
+                run_command('/opt/puppetlabs/bin/puppet resource service puppet', 'target')
+              end
+    output = service[0]['result']['stdout']
+    expect(output).to include("ensure => 'stopped'")
 
     # Run with no argument upgrades
     results = run_task('puppet_agent::install', 'target', { 'collection' => 'puppet5' })

--- a/tasks/install.json
+++ b/tasks/install.json
@@ -28,6 +28,10 @@
     "install_options": {
       "description": "optional install arguments to the windows installer (defaults to REINSTALLMODE=\"amus\")",
       "type": "Optional[String]"
+    },
+    "stop_service": {
+      "description": "Whether to stop the puppet agent service after install",
+      "type": "Optional[Boolean]"
     }
   },
   "implementations": [

--- a/tasks/install_powershell.json
+++ b/tasks/install_powershell.json
@@ -29,6 +29,10 @@
     "install_options": {
       "description": "optional install arguments to the windows installer (defaults to REINSTALLMODE=\"amus\")",
       "type": "Optional[String]"
+    },
+    "stop_service": {
+      "description": "Whether to stop the puppet agent service after install",
+      "type": "Optional[Boolean]"
     }
   }
 }

--- a/tasks/install_powershell.ps1
+++ b/tasks/install_powershell.ps1
@@ -3,7 +3,8 @@ Param(
 	[String]$version,
   [String]$collection = 'puppet',
   [String]$windows_source = 'https://downloads.puppet.com',
-  [String]$install_options = 'REINSTALLMODE="amus"'
+  [String]$install_options = 'REINSTALLMODE="amus"',
+  [Bool]$stop_service = $False
 )
 # If an error is encountered, the script will stop instead of the default of "Continue"
 $ErrorActionPreference = "Stop"
@@ -65,6 +66,9 @@ function InstallPuppet {
 }
 
 function Cleanup {
+    if($stop_service -eq 'true') {
+      C:\"Program Files"\"Puppet Labs"\Puppet\bin\puppet resource service puppet ensure=stopped enable=false
+    }
     Write-Output "Deleting $msi_dest and $install_log"
     Remove-Item -Force $msi_dest
     Remove-Item -Force $install_log

--- a/tasks/install_shell.json
+++ b/tasks/install_shell.json
@@ -30,6 +30,10 @@
     "install_options": {
       "description": "optional install arguments to the windows installer (defaults to REINSTALLMODE=\"amus\")",
       "type": "Optional[String]"
+    },
+    "stop_service": {
+      "description": "Whether to stop the puppet agent service after install",
+      "type": "Optional[Boolean]"
     }
   }
 }

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -525,6 +525,10 @@ do_download "$download_url" "$download_filename"
 
 install_file $filetype "$download_filename"
 
+if [[ $PT_stop_service = true ]]; then
+  /opt/puppetlabs/bin/puppet resource service puppet ensure=stopped enable=false
+fi
+
 #Cleanup
 if test "x$tmp_dir" != "x"; then
   rm -r "$tmp_dir"


### PR DESCRIPTION
This adds a parameter to the `puppet_agent::install` task that, when
true, will stop the puppet service after install. The parameter defaults
to false. The option is available for both unix and windows platforms