### PR TITLE
(maint) Update bash implementation metadata to require facts implemen…

### DIFF
--- a/tasks/install_shell.json
+++ b/tasks/install_shell.json
@@ -31,5 +31,6 @@
       "description": "optional install arguments to the windows installer (defaults to REINSTALLMODE=\"amus\")",
       "type": "Optional[String]"
     }
-  }
+  },
+  "files": ["facts/tasks/bash.sh"]
 }


### PR DESCRIPTION
…tation

Previously, only the install metatdata file included the `files` key for inlcuding the facts bash implementation file. This commit updates the metadata so that if the task is called explicitly, the files are included.