### PR TITLE
Pin Debian package to prevent unintentional upgrade

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -62,6 +62,7 @@ class puppet_agent::install(
           $_package_version = $package_version
         } else {
           $_package_version = "${package_version}-1${::lsbdistcodename}"
+          include ::apt
           apt::pin { "pin ${::puppet_agent::package_name} package":
             packages => $::puppet_agent::package_name,
             priority => 1001,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -64,7 +64,7 @@ class puppet_agent::install(
           $_package_version = "${package_version}-1${::lsbdistcodename}"
           apt::pin { "pin ${::puppet_agent::package_name} package":
             packages => $::puppet_agent::package_name,
-            priority => 1000,
+            priority => 1001,
             version  => $_package_version,
           }
         }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -62,6 +62,11 @@ class puppet_agent::install(
           $_package_version = $package_version
         } else {
           $_package_version = "${package_version}-1${::lsbdistcodename}"
+          apt::pin { "pin ${::puppet_agent::package_name} package":
+            packages => $::puppet_agent::package_name,
+            priority => 1000,
+            version  => $_package_version,
+          }
         }
         $_provider = 'apt'
         $_source = undef

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe 'puppet_agent' do
+  package_name = 'puppet-agent'
+
   facts = {
     :lsbdistid            => 'Debian',
     :osfamily             => 'Debian',
@@ -218,6 +220,30 @@ describe 'puppet_agent' do
       it { is_expected.not_to contain_apt__source('pc_repo') }
     end
 
+    context "when requesting a specific version" do
+      let(:params) {
+        {
+          :package_version => package_version
+        }
+      }
+
+      it { is_expected.to contain_apt__pin("pin #{package_name} package").with({
+        'packages' => package_name,
+        'priority' => 1001,
+        'version'  => "#{package_version}-1#{facts[:lsbdistcodename]}",
+      }) }
+    end
+
+    context "when not requesting a specific version" do
+      let(:params) {
+        {
+          :package_version => 'auto'
+        }
+      }
+
+      it { is_expected.not_to contain_apt__pin('pin #{package_name} package') }
+    end
+
     it { is_expected.to contain_class("puppet_agent::osfamily::debian") }
 
   end
@@ -281,6 +307,30 @@ describe 'puppet_agent' do
 
       it { is_expected.not_to contain_apt__key('legacy key') }
       it { is_expected.not_to contain_apt__source('pc_repo') }
+    end
+
+    context "when requesting a specific version" do
+      let(:params) {
+        {
+          :package_version => package_version
+        }
+      }
+
+      it { is_expected.to contain_apt__pin("pin #{package_name} package").with({
+        'packages' => package_name,
+        'priority' => 1001,
+        'version'  => "#{package_version}-1#{facts[:lsbdistcodename]}",
+      }) }
+    end
+
+    context "when not requesting a specific version" do
+      let(:params) {
+        {
+          :package_version => 'auto'
+        }
+      }
+
+      it { is_expected.not_to contain_apt__pin('pin #{package_name} package') }
     end
 
     it { is_expected.to contain_class("puppet_agent::osfamily::debian") }

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -80,7 +80,6 @@ describe 'puppet_agent' do
         }
       }
 
-      it { is_expected.not_to contain_class('apt') }
       it { is_expected.not_to contain_exec('pc_repo_force') }
       it { is_expected.not_to contain_apt__setting('conf-pe-repo') }
 
@@ -132,7 +131,6 @@ describe 'puppet_agent' do
           }
         }
 
-        it { is_expected.not_to contain_class('apt') }
         it { is_expected.not_to contain_exec('pc_repo_force') }
 
         it { is_expected.not_to contain_apt__setting('conf-pc_repo') }


### PR DESCRIPTION
This is a revised version of #415.

Original description (@ddryden)
> When on Debian and a package version is specified we should also create a Debian package pin to stop apt upgrade from changing the version just for the next puppet run to change it back.

/cc @ciprianbadescu