### PR TITLE
(maint) fix failing tests due to rspec changes

### DIFF
--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -298,7 +298,7 @@ describe 'puppet_agent' do
       end
       let(:params) { global_params }
 
-      it { is_expected.to raise_error(Puppet::Error, %r{Nexenta not supported}) }
+      it { expect { catalogue }.to raise_error(Puppet::Error, %r{Nexenta not supported}) }
     end
   end
 end


### PR DESCRIPTION
This test was failing due to some changes on
rspec-expectactions gems.
More info here: https://github.com/rspec/rspec-expectations/issues/1134