### PR TITLE
(MODULES-9981) Add Amazon Linux 2 support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -299,7 +299,7 @@ detected>"}`. If a version cannot be found, returns `{"version": null}`.
 
 #### `puppet_agent::install`
 
-Installs the puppet-agent package. Currently only supports Linux variants: Debian, Ubuntu, SLES, RHEL/CentOS/Fedora. A specific
+Installs the puppet-agent package. Currently only supports Linux variants: Debian, Ubuntu, SLES, RHEL/CentOS/Fedora, Amazon Linux 2. A specific
 package `version` can be specified; if not, will install or upgrade to the latest Puppet 5 version available.
 
 **Note**: The `puppet_agent::install_shell` task requires the `facts::bash` implementation from the [facts](https://forge.puppet.com/puppetlabs/facts) module. Both the `puppet_agent` and `facts` modules are packaged with Bolt. For use outside of Bolt make sure the `facts` module is installed to the same `modules` directory as `puppet_agent`.

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -192,6 +192,11 @@ case $platform in
   "SLES")
     platform_version=$major_version
     ;;
+  "Amzn")
+    case $platform_version in
+      "2") platform_version="7";;
+    esac
+    ;;
 esac
 
 # Find which version of puppet is currently installed if any
@@ -459,6 +464,12 @@ case $platform in
     ;;
   "el")
     info "Red hat like platform! Lets get you an RPM..."
+    filetype="rpm"
+    filename="${collection}-release-el-${platform_version}.noarch.rpm"
+    download_url="${yum_source}/${filename}"
+    ;;
+  "Amzn")
+    info "Amazon platform! Lets get you an RPM..."
     filetype="rpm"
     filename="${collection}-release-el-${platform_version}.noarch.rpm"
     download_url="${yum_source}/${filename}"

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -192,7 +192,7 @@ case $platform in
   "SLES")
     platform_version=$major_version
     ;;
-  "Amzn")
+  "Amzn"|"Amazon Linux")
     case $platform_version in
       "2") platform_version="7";;
     esac
@@ -468,7 +468,7 @@ case $platform in
     filename="${collection}-release-el-${platform_version}.noarch.rpm"
     download_url="${yum_source}/${filename}"
     ;;
-  "Amzn")
+  "Amzn"|"Amazon Linux")
     info "Amazon platform! Lets get you an RPM..."
     filetype="rpm"
     filename="${collection}-release-el-${platform_version}.noarch.rpm"


### PR DESCRIPTION
This adds Amazon Linux 2 support in tasks/install_shell.sh. Tested
manually on Amazon Linux 2.