### PR TITLE
(MODULES-27043) Puppet agent upgrade for windows FIPS

### DIFF
--- a/manifests/osfamily/windows.pp
+++ b/manifests/osfamily/windows.pp
@@ -8,8 +8,10 @@ class puppet_agent::osfamily::windows{
   } elsif  ($::puppet_agent::is_pe and (!$::puppet_agent::use_alternate_sources)) {
     $pe_server_version = pe_build_version()
     $tag = $::puppet_agent::arch ? {
-      'x64' => 'windows-x86_64',
-      'x86' => 'windows-i386',
+      'x64' => $::fips_enabled ? {
+          true => 'windowsfips-x64',
+          default => 'windows-x86_64' },
+      'x86' => 'windows-i386'
     }
     if $::puppet_agent::alternate_pe_source {
       $source = "${::puppet_agent::alternate_pe_source}/packages/${pe_server_version}/${tag}/${::puppet_agent::package_name}-${::puppet_agent::arch}.msi"

--- a/spec/classes/puppet_agent_osfamily_windows_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_windows_spec.rb
@@ -29,7 +29,7 @@ describe 'puppet_agent' do
         :clientcert           => 'foo.example.vm',
         :puppet_confdir       => "#{appdata}\\Puppetlabs\\puppet\\etc",
         :puppet_agent_appdata => appdata,
-        :env_temp_variable => 'C:/tmp',
+        :env_temp_variable    => 'C:/tmp',
         :puppet_agent_pid     => 42,
         :aio_agent_version    => '1.0.0',
       }}
@@ -58,7 +58,7 @@ describe 'puppet_agent' do
         :clientcert           => 'foo.example.vm',
         :puppet_confdir       => "#{appdata}\\Puppetlabs\\puppet\\etc",
         :puppet_agent_appdata => appdata,
-        :env_temp_variable => 'C:/tmp',
+        :env_temp_variable    => 'C:/tmp',
         :puppet_agent_pid     => 42,
         :aio_agent_version    => '1.0.0',
         :serverversion        => server_version
@@ -74,4 +74,36 @@ describe 'puppet_agent' do
     end
   end
 
+  describe "supported Windows with fips mode enabled" do
+    server_version = '1.10.100'
+    let(:arch) { 'x64' }
+    let(:tag) { 'x64' }
+    let(:params)  { { package_version: 'auto' } }
+    let(:appdata) { 'C:\ProgramData' }
+    let(:facts) do
+      {
+        :is_pe                => true,
+        :osfamily             => 'windows',
+        :operatingsystem      => 'windows',
+        :architecture         => arch,
+        :servername           => 'master.example.vm',
+        :clientcert           => 'foo.example.vm',
+        :puppet_confdir       => "#{appdata}\\Puppetlabs\\puppet\\etc",
+        :puppet_agent_appdata => appdata,
+        :env_temp_variable    => 'C:/tmp',
+        :puppet_agent_pid     => 42,
+        :aio_agent_version    => '1.0.0',
+        :serverversion        => server_version,
+        :fips_enabled         => true
+      }
+    end
+
+    it { is_expected.to contain_file("#{appdata}\\Puppetlabs") }
+    it { is_expected.to contain_file("#{appdata}\\Puppetlabs\\packages") }
+    it do
+      is_expected.to contain_file("#{appdata}\\Puppetlabs\\packages\\puppet-agent-#{arch}.msi").with(
+        'source' => "puppet:///pe_packages/#{pe_version}/windowsfips-#{tag}/puppet-agent-#{arch}.msi"
+      )
+    end
+  end
 end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -20,6 +20,7 @@ RSpec.configure do |c|
     :path                        => nil,
     :puppet_agent_appdata        => nil,
     :system32                    => nil,
+    :fips_enabled                => false,
 
     :puppet_ssldir   => '/dev/null/ssl',
     :puppet_config   => '/dev/null/puppet.conf',


### PR DESCRIPTION
This commit ensures that the correct version of puppet agent is
installed on windows platforms that are FIPS compliant based on the
enabled_fips fact.