### PR TITLE
(MODULES-10038) nightly build download location fix

### DIFF
--- a/tasks/install_powershell.ps1
+++ b/tasks/install_powershell.ps1
@@ -31,6 +31,11 @@ else {
     $msi_name = "puppet-agent-${arch}-latest.msi"
 }
 
+# Change windows_source only if the collection is a nightly build, and the source was not explicitly specified.
+if (($collection -like '*nightly*') -And -Not ($PSBoundParameters.ContainsKey('windows_source'))) {
+  $windows_source = 'https://nightlies.puppet.com/downloads'
+}
+
 $msi_source = "$windows_source/windows/${collection}/${msi_name}"
 
 $date_time_stamp = (Get-Date -format s) -replace ':', '-'


### PR DESCRIPTION
This commit fixes the path from where to download puppet-agent if the
requested collections is a nightly build.
If the windows_source is explicitly specified as a parameter, it will
use it instead.