### PR TITLE
update SUSE autorefresh parameter

### DIFF
--- a/manifests/osfamily/suse.pp
+++ b/manifests/osfamily/suse.pp
@@ -97,7 +97,7 @@ class puppet_agent::osfamily::suse{
           $repo_settings = {
             'name'        => $repo_name,
             'enabled'     => '1',
-            'autorefresh' => '0',
+            'autorefresh' => '1',
             'baseurl'     => "${source}?ssl_verify=no",
             'type'        => 'rpm-md',
           }


### PR DESCRIPTION
During a recent update to PE 2018.1.9 we encountered an issue with
SUSE systems not being able to download the updated agent, because
the repository would not refresh itself. This changes sets the
autorefresh parameter to true to match other SUSE repos.