### PR TITLE
(MODULES-10308) Allow downgrades when using apt

### DIFF
--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -433,12 +433,12 @@ install_file() {
       apt-get update -y
 
       if test "$version" = 'latest'; then
-        apt-get install -y puppet-agent
+        apt-get install -y puppet-agent --allow-downgrades
       else
         if test "x$deb_codename" != "x"; then
-          apt-get install -y "puppet-agent=${puppet_agent_version}-1${deb_codename}"
+          apt-get install -y "puppet-agent=${puppet_agent_version}-1${deb_codename}" --allow-downgrades
         else
-          apt-get install -y "puppet-agent=${puppet_agent_version}"
+          apt-get install -y "puppet-agent=${puppet_agent_version}" --allow-downgrades
         fi
       fi
       ;;


### PR DESCRIPTION
This updates the install task to allow for downgrading the Puppet agent
when installing with `apt`. This aligns the behavior of the task with
other package handlers, such as `rpm`, that allow for downgrading the
Puppet agent version.

Part of https://github.com/puppetlabs/bolt/issues/1208