### PR TITLE
(MODULES-10454) Install 'latest' only when no agent is present

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -75,6 +75,20 @@ describe 'install task' do
       expect(res).to include('status' => 'success')
     end
 
+    # Verify that it did nothing
+    results = run_task('puppet_agent::version', 'target', {})
+    results.each do |res|
+      expect(res).to include('status' => 'success')
+      expect(res['result']['version']).to eq(puppet_5_version)
+      expect(res['result']['source']).to be
+    end
+
+    # Run with latest upgrades
+    results = run_task('puppet_agent::install', 'target', { 'collection' => 'puppet5', 'version' => 'latest' })
+    results.each do |res|
+      expect(res).to include('status' => 'success')
+    end
+
     # Verify that it upgraded
     results = run_task('puppet_agent::version', 'target', {})
     results.each do |res|
@@ -85,7 +99,7 @@ describe 'install task' do
     end
 
     # Upgrade from puppet5 to puppet6
-    results = run_task('puppet_agent::install', 'target', { 'collection' => 'puppet6' })
+    results = run_task('puppet_agent::install', 'target', { 'collection' => 'puppet6', 'version' => 'latest' })
     results.each do |res|
       expect(res).to include('status' => 'success')
     end

--- a/tasks/install.json
+++ b/tasks/install.json
@@ -36,6 +36,6 @@
   },
   "implementations": [
     {"name": "install_shell.sh", "requirements": ["shell"], "files": ["facts/tasks/bash.sh"], "input_method": "environment"},
-    {"name": "install_powershell.ps1", "requirements": ["powershell"]}
+    {"name": "install_powershell.ps1", "requirements": ["powershell"], "files": ["puppet_agent/tasks/version_powershell.ps1"]}
   ]
 }

--- a/tasks/install_powershell.json
+++ b/tasks/install_powershell.json
@@ -34,5 +34,6 @@
       "description": "Whether to stop the puppet agent service after install",
       "type": "Optional[Boolean]"
     }
-  }
+  },
+  "files": ["puppet_agent/tasks/version_powershell.ps1"]
 }

--- a/tasks/install_powershell.ps1
+++ b/tasks/install_powershell.ps1
@@ -24,10 +24,24 @@ catch [System.Management.Automation.CommandNotFoundException] {
   }
 }
 
+function Test-PuppetInstalled {
+  $result = & "$PSScriptRoot\version_powershell.ps1" | ConvertFrom-Json
+  return $result.version
+}
+
 if ($version) {
-    $msi_name = "puppet-agent-${version}-${arch}.msi"
+    if ($version -eq "latest") {
+      $msi_name = "puppet-agent-${arch}-latest.msi"
+    } else {
+      $msi_name = "puppet-agent-${version}-${arch}.msi"
+    }
 }
 else {
+    if (Test-PuppetInstalled) {
+      Write-Output "Puppet Agent detected and no version specified. Nothing to do."
+      Exit
+    }
+
     $msi_name = "puppet-agent-${arch}-latest.msi"
 }
 

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -102,6 +102,26 @@ else
   installed_version=uninstalled
 fi
 
+# Only install the agent in cases where no agent is present, or the version of the agent
+# has been explicitly defined and does not match the version of an installed agent.
+if [ -z "$version" ]; then
+  if [ "$installed_version" == "uninstalled" ]; then
+    info "Version parameter not defined and no agent detected. Assuming latest."
+    version=latest
+  else
+    info "Version parameter not defined and agent detected. Nothing to do."
+    exit 0
+  fi
+else
+  info "Version parameter defined: ${version}"
+  if [ "$version" == "$installed_version" ]; then
+    info "Version parameter defined: ${version}. Puppet Agent ${version} detected. Nothing to do."
+    exit 0
+  elif [ "$version" != "latest" ]; then
+    puppet_agent_version="$version"
+  fi
+fi
+
 # Retrieve Platform and Platform Version
 # Utilize facts implementation when available
 if [ -f "$PT__installdir/facts/tasks/bash.sh" ]; then
@@ -169,14 +189,6 @@ fi
 if test "x$platform" = "x"; then
   critical "Unable to determine platform version!"
   exit 1
-fi
-
-if test "x$version" = "x"; then
-  version="latest";
-  info "Version parameter not defined, assuming latest";
-else
-  info "Version parameter defined: $version";
-  puppet_agent_version=$version
 fi
 
 # Mangle $platform_version to pull the correct build


### PR DESCRIPTION
This modifies the behavior of the `puppet_agent::install` task so that
it only assumes that the latest version of the agent should be installed
when no agent is present on the system. Previously, if the `version`
parameter was undefined, the task would default to the latest version
and install it on the system, even if an agent was already present. This
would clobber any existing version of the agent, even unintentionally.

Part of puppetlabs/bolt#1208