### PR TITLE
(maint) fix Solaris tests

### DIFF
--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -34,6 +34,7 @@ describe 'puppet_agent' do
       elsif os =~ %r{solaris}
         {
           is_pe: true,
+          puppet_agent_pid: 298,
         }
       elsif os =~ %r{aix}
         {


### PR DESCRIPTION
rspec-puppet-facts added a new feature that discovers
the facter data that needs to get from facterdb based on
agent version. Because Solaris tests rely on `puppet_agent_pid`
fact which changed between facter version from facterdb, tests were
unreliable.

This commit explicitly sets `puppet_agent_pid` on Solaris.