### PR TITLE
(MODULES-10514) Remove use of version_powershell task in install task

### DIFF
--- a/tasks/install.json
+++ b/tasks/install.json
@@ -36,6 +36,6 @@
   },
   "implementations": [
     {"name": "install_shell.sh", "requirements": ["shell"], "files": ["facts/tasks/bash.sh"], "input_method": "environment"},
-    {"name": "install_powershell.ps1", "requirements": ["powershell"], "files": ["puppet_agent/tasks/version_powershell.ps1"]}
+    {"name": "install_powershell.ps1", "requirements": ["powershell"]}
   ]
 }

--- a/tasks/install_powershell.json
+++ b/tasks/install_powershell.json
@@ -34,6 +34,5 @@
       "description": "Whether to stop the puppet agent service after install",
       "type": "Optional[Boolean]"
     }
-  },
-  "files": ["puppet_agent/tasks/version_powershell.ps1"]
+  }
 }

--- a/tasks/install_powershell.ps1
+++ b/tasks/install_powershell.ps1
@@ -25,8 +25,13 @@ catch [System.Management.Automation.CommandNotFoundException] {
 }
 
 function Test-PuppetInstalled {
-  $result = & "$PSScriptRoot\version_powershell.ps1" | ConvertFrom-Json
-  return $result.version
+  $rootPath = 'HKLM:\SOFTWARE\Puppet Labs\Puppet'
+  try { 
+    if (Get-ItemProperty -Path $rootPath) { RETURN $true }
+  }
+  catch {
+    RETURN $false
+  }
 }
 
 if ($version) {


### PR DESCRIPTION
This removes the use of the `version_powershell` task in the
`install_powershell` task. Previously, this task was used to determine
whether the `puppet-agent` package was already installed. However, some
features used to run the script and parse its output are not available
in versions of powershell older than 3.0.

The `install_powershell` task instead uses behavior similar to the
`version_powershell` task by checking the system's registry entries to
check if the `puppet-agent` package is installed.