### PR TITLE
(maint) Remove config field from bolt_plugin.json

### DIFF
--- a/bolt_plugin.json
+++ b/bolt_plugin.json
@@ -1,6 +1,5 @@
 {
   "hooks": {
     "puppet_library": { "task": "puppet_agent::install" }
-  },
-  "config": { }
+  }
 }


### PR DESCRIPTION
The `config` field in a plugin's `bolt_plugin.json` file is deprecated
in Bolt 2.0 This removes the field from the `puppet_agent` plugin so it
does not raise an error.

Part of puppetlabs/bolt#1598