### PR TITLE
(maint) Ensure apt-transport-https is installed before installing agent

### DIFF
--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -441,6 +441,11 @@ install_file() {
         fi
       fi
 
+      # Packages are downloaded from the https site, so make sure the correct transport is installed
+      if ! dpkg -l apt-transport-https; then
+        apt-get install --yes apt-transport-https
+      fi
+
       dpkg -i "$2"
       apt-get update -y
 


### PR DESCRIPTION
The `puppet5` apt repo was recently updated to pull from the https site.
In order to install the `puppet-agent` package from this collection, the
`apt-transport-https` package must be installed on the target. This
updates the `puppet_agent::install` task to check if this package is
installed and install it if it is not.