### PR TITLE
Add Raspbian support

### DIFF
--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -445,7 +445,7 @@ install_file() {
       apt-get update -y
 
       if test "$version" = 'latest'; then
-        apt-get install -y puppet-agent
+        apt-get install -y puppet
       else
         if test "x$deb_codename" != "x"; then
           apt-get install -y "puppet-agent=${puppet_agent_version}-1${deb_codename}"

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -204,7 +204,7 @@ case $platform in
       *) platform_version=$major_version;;
     esac
     ;;
-  "Debian")
+  "Debian"|"Raspbian")
     case $major_version in
       "5") platform_version="6";;
       "6") platform_version="6";;
@@ -503,8 +503,8 @@ case $platform in
     filename="${collection}-release-fedora-${platform_version}.noarch.rpm"
     download_url="${yum_source}/${filename}"
     ;;
-  "Debian")
-    info "Debian platform! Lets get you a DEB..."
+  "Debian"|"Raspbian")
+    info "${platform} platform! Lets get you a DEB..."
     case $major_version in
       "5") deb_codename="lenny";;
       "6") deb_codename="squeeze";;


### PR DESCRIPTION
Raspbian is based on Debian and uses the exact same package manager and
repositories.

Without this patch I get the following error running e.g. `bolt apply manifests/site.pp --targets raspberrypi.lan`:

```json
[
  {
    "target": "raspberrypi.lan",
    "action": "task",
    "object": "puppet_agent::install",
    "status": "failure",
    "result": {
      "_output": "20:46:20 +0000 INFO: Version parameter not defined and no agent detected. Assuming latest.\n20:46:21 +0000 INFO: Downloading Puppet latest for Raspbian...\n20:46:21 +0000 CRIT: Sorry Raspbian is not supported yet!\n",
      "_error": {
        "kind": "puppetlabs.tasks/task-error",
        "issue_code": "TASK_ERROR",
        "msg": "The task failed with exit code 1",
        "details": {
          "exit_code": 1
        }
      }
    },
    "node": "raspberrypi.lan"
  }
]
```

I have not yet tried out this change because I am uncertain on how to depend on my local version of `puppet-agent` when running `bolt`, but I will try some more and report back my findings.

EDIT: I managed to install it now using `bolt puppetfile install` and try it out. It does not work sadly.. Do you have any ideas on how to get it working? The new error message follows for the interested:

```json
[
  {
    "target": "raspberrypi.lan",
    "action": "task",
    "object": "puppet_agent::install",
    "status": "failure",
    "result": {
      "_output": "21:08:29 +0000 INFO: Version parameter not defined and no agent detected. Assuming latest.\n21:08:30 +0000 INFO: Downloading Puppet latest for Raspbian...\n21:08:30 +0000 INFO: Raspbian platform! Lets get you a DEB...\n21:08:30 +0000 INFO: Downloading http://apt.puppet.com/puppet-release-buster.deb\n21:08:30 +0000 INFO:   to file /tmp/install.sh.20195.20547/puppet-release-buster.deb\n21:08:30 +0000 INFO: Trying wget...\n21:08:30 +0000 INFO: installing puppetlabs apt repo with dpkg...\n(Reading database ... 41879 files and directories currently installed.)\nPreparing to unpack .../puppet-release-buster.deb ...\nUnpacking puppet-release (1.0.0-7buster) over (1.0.0-7buster) ...\nSetting up puppet-release (1.0.0-7buster) ...\nHit:1 http://raspbian.raspberrypi.org/raspbian buster InRelease\nHit:2 http://archive.raspberrypi.org/debian buster InRelease\nHit:3 http://apt.puppetlabs.com buster InRelease\nReading package lists...\nReading package lists...\nBuilding dependency tree...\nReading state information...\nPackage puppet-agent is not available, but is referred to by another package.\nThis may mean that the package is missing, has been obsoleted, or\nis only available from another source\n\n21:08:36 +0000 CRIT: Installation failed\n",
      "_error": {
        "kind": "puppetlabs.tasks/task-error",
        "issue_code": "TASK_ERROR",
        "msg": "The task failed with exit code 1",
        "details": {
          "exit_code": 1
        }
      }
    },
    "node": "raspberrypi.lan"
  }
]
```