### PR TITLE
Check that user is root only if installation is required

### DIFF
--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -89,12 +89,6 @@ else
   mac_source='http://downloads.puppet.com'
 fi
 
-# Error if non-root
-if [ `id -u` -ne 0 ]; then
-  echo "puppet_agent::install task must be run as root"
-  exit 1
-fi
-
 # Track to handle puppet5 to puppet6
 if [ -f /opt/puppetlabs/puppet/VERSION ]; then
   installed_version=`cat /opt/puppetlabs/puppet/VERSION`
@@ -120,6 +114,12 @@ else
   elif [ "$version" != "latest" ]; then
     puppet_agent_version="$version"
   fi
+fi
+
+# Error if non-root
+if [ `id -u` -ne 0 ]; then
+  echo "puppet_agent::install task must be run as root"
+  exit 1
 fi
 
 # Retrieve Platform and Platform Version


### PR DESCRIPTION
As `bolt` only [collects](https://puppet.com/docs/bolt/latest/applying_manifest_blocks.html#how-manifest-blocks-are-applied) custom facts in `apply_prep` task, which first [makes](https://github.com/puppetlabs/bolt/blob/master/bolt-modules/boltlib/lib/puppet/functions/apply_prep.rb#L109) sure that the agent is installed, failing fast makes it impossible to gather custom facts when running as non-root even if the agent is already installed.