### PR TITLE
(MODULES-10110) Handle Amazon Linux 2 as el-7

### DIFF
--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -16,7 +16,12 @@ class puppet_agent::osfamily::redhat{
         $platform_and_version = "fedora/${::operatingsystemmajrelease}"
       }
       'Amazon': {
-        $platform_and_version = 'el/6'
+        if ("${::operatingsystemmajrelease}" == '2') {
+          $amz_el_version = '7'
+        } else {
+          $amz_el_version = '6'
+        }
+        $platform_and_version = "el/${amz_el_version}"
       }
       default: {
         $platform_and_version = "el/${::operatingsystemmajrelease}"
@@ -24,9 +29,9 @@ class puppet_agent::osfamily::redhat{
     }
     if ($::puppet_agent::is_pe and (!$::puppet_agent::use_alternate_sources)) {
       $pe_server_version = pe_build_version()
-      # Treat Amazon Linux just like Enterprise Linux 6
+      # Treat Amazon Linux just like Enterprise Linux
       $pe_repo_dir = ($::operatingsystem == 'Amazon') ? {
-        true    => "el-6-${::architecture}",
+        true    => "el-${amz_el_version}-${::architecture}",
         default =>  $::platform_tag,
       }
       if $::puppet_agent::source {

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -18,7 +18,7 @@ describe 'puppet_agent' do
     }
   end
 
-  [['Fedora', 'fedora/f31', 31], ['CentOS', 'el/7', 7], ['Amazon', 'el/6', 6]].each do |os, urlbit, osmajor|
+  [['Fedora', 'fedora/f31', 31], ['CentOS', 'el/7', 7], ['Amazon', 'el/6', 2017], ['Amazon', 'el/7', 2]].each do |os, urlbit, osmajor|
     context "with #{os} and #{urlbit}" do
       let(:facts) do
         super().merge(:operatingsystem  => os, :operatingsystemmajrelease => osmajor)


### PR DESCRIPTION
Since the rhel macro from RPM reports Amazon Linux 2 as being RedHat 7:
```
[root@[redacted] ~]# rpm -E %{rhel}
--
7
```
This PR updates the pc_repo used for Amazon Linux 2 from el-6 to el-7 
