### PR TITLE
(packaging) Update inifile dependency to allow all 4.x versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -120,7 +120,7 @@
   ],
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 5.1.0 < 7.0.0"},
-    {"name":"puppetlabs-inifile","version_requirement":">= 2.4.0 <= 4.0.0"},
+    {"name":"puppetlabs-inifile","version_requirement":">= 2.4.0 < 5.0.0"},
     {"name":"puppetlabs-apt","version_requirement":">= 7.0.1 < 8.0.0"},
     {"name":"puppetlabs-facts","version_requirement":">= 0.5.0 < 1.0.0"}
   ]


### PR DESCRIPTION
A prior change ensured that puppet_agent didn't use inifile version 3.2.0. That version comparison seems to have been preserved when moving to any 3.x version in a non-sensical way (allowing 4.0.0 but not anything later). Switch to allowing all versions prior to an unreleased breaking 5.0 version.