### PR TITLE
(MODULES-10594) Remove pidlock if service states cannot be restored

### DIFF
--- a/files/install_puppet.ps1
+++ b/files/install_puppet.ps1
@@ -249,8 +249,12 @@ function Script:Reset-PuppetServices {
       # service before upgrade, but no mcollective service after
       if (Get-Service $service.Name -ErrorAction SilentlyContinue) {
         Write-Log "Restoring service state for $($service.Name)"
-        Set-Service $service.Name -StartupType $service.StartType
-        Set-Service $service.Name -Status $service.Status
+        try {
+          Set-Service $service.Name -StartupType $service.StartType -ErrorAction Stop
+          Set-Service $service.Name -Status $service.Status -ErrorAction Stop
+        } catch {
+          Write-Log "Could not restore service state for $($service.Name). $_"
+        }
       } else {
         Write-Log "Get-Service failed to fetch $($service.Name), continuing..."
       }


### PR DESCRIPTION
If one of the services managed by this module cannot be started, an error is thrown and the pidlock file is not removed.
This PR  makes sure the error is logged in a format similar to the other exceptions and that the pidlock file is removed in case of a Set-Service failure.