### PR TITLE
(maint) Fix task acceptance for osx 10.14 & 10.15

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -35,6 +35,10 @@ describe 'install task' do
                          '5.5.16'
                        when %r{fedora-31}
                          '5.5.18'
+                       when %r{osx-10.14}
+                         '5.5.12'
+                       when %r{osx-10.15}
+                         '5.5.19'
                        else
                          '5.5.3'
                        end


### PR DESCRIPTION
Change versions to upgrade from for OS X 10.14 and 10.15.

OS X 10.15 should be enabled in CI after puppet 5.5.20 is released, so it would have a version to upgrade from.