### PR TITLE
Add support for absolute_source in puppet_agent::install task

### DIFF
--- a/tasks/install.json
+++ b/tasks/install.json
@@ -9,6 +9,10 @@
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
       "type": "Optional[Enum[puppet6, puppet7, puppet, puppet6-nightly, puppet7-nightly, puppet-nightly]]"
     },
+    "absolute_source": {
+      "description": "The absolute source location to find the Puppet agent package",
+      "type": "Optional[String]"
+    },
     "yum_source": {
       "description": "The source location to find yum repos (defaults to yum.puppet.com)",
       "type": "Optional[String]"

--- a/tasks/install_powershell.json
+++ b/tasks/install_powershell.json
@@ -10,6 +10,10 @@
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
       "type": "Optional[Enum[puppet6, puppet7, puppet, puppet6-nightly, puppet7-nightly, puppet-nightly]]"
     },
+    "absolute_source": {
+      "description": "The absolute source location to find the Puppet agent package",
+      "type": "Optional[String]"
+    },
     "yum_source": {
       "description": "The source location to find yum repos (defaults to yum.puppet.com)",
       "type": "Optional[String]"

--- a/tasks/install_powershell.ps1
+++ b/tasks/install_powershell.ps1
@@ -2,6 +2,7 @@
 Param(
 	[String]$version,
   [String]$collection = 'puppet',
+  [String]$absolute_source,
   [String]$windows_source = 'https://downloads.puppet.com',
   [String]$install_options = 'REINSTALLMODE="amus"',
   [Bool]$stop_service = $False,
@@ -99,7 +100,12 @@ if (($collection -like '*nightly*') -And -Not ($PSBoundParameters.ContainsKey('w
   $windows_source = 'https://nightlies.puppet.com/downloads'
 }
 
-$msi_source = "$windows_source/windows/${collection}/${msi_name}"
+if ($absolute_source) {
+    $msi_source = "$absolute_source"
+}
+else {
+    $msi_source = "$windows_source/windows/${collection}/${msi_name}"
+}
 
 $date_time_stamp = (Get-Date -format s) -replace ':', '-'
 $msi_dest = Join-Path ([System.IO.Path]::GetTempPath()) "puppet-agent-$arch.msi"

--- a/tasks/install_shell.json
+++ b/tasks/install_shell.json
@@ -11,6 +11,10 @@
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
       "type": "Optional[Enum[puppet6, puppet7, puppet, puppet6-nightly, puppet7-nightly, puppet-nightly]]"
     },
+    "absolute_source": {
+      "description": "The absolute source location to find the Puppet agent package",
+      "type": "Optional[String]"
+    },
     "yum_source": {
       "description": "The source location to find yum repos (defaults to yum.puppet.com)",
       "type": "Optional[String]"

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -584,7 +584,7 @@ info "Downloading Puppet $version for ${platform}..."
 case $platform in
   "SLES")
     info "SLES platform! Lets get you an RPM..."
-    
+
     if [[ $PT__noop != true ]]; then
       for key in "puppet" "puppet-20250406"; do
         gpg_key="${tmp_dir}/RPM-GPG-KEY-${key}"
@@ -687,6 +687,10 @@ case $platform in
     exit 1
     ;;
 esac
+
+if [[ -n "$PT_absolute_source" ]]; then
+  download_url=$PT_absolute_source
+fi
 
 if [[ $PT__noop != true ]]; then
   download_filename="${tmp_dir}/${filename}"


### PR DESCRIPTION
When using a synced Pulp repo against Puppets repositories (apt.puppet.com and yum.puppet.com); it's not possible to use the `yum_source` or the `apt_source` parameters; since the installer package is not available at the relative location which is constructed by the `puppet_agent::install` task.

This PR adds support for an `absolute_source` as parameter to the `puppet_agent::install` task.