### PR TITLE
(MODULES-10636) Fixed mcollective being included as a default service to manage, in clientversion >= 6.0.0

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -7,7 +7,7 @@ class puppet_agent::service{
   assert_private()
 
   # Starting with puppet6 collections we no longer carry the mcollective service
-  if $::puppet_agent::collection != 'PC1' and $::puppet_agent::collection != 'puppet5' {
+  if versioncmp("${::clientversion}", '6.0.0') >= 0 {
     $_service_names = delete($::puppet_agent::service_names, 'mcollective')
   } else {
     $_service_names = $::puppet_agent::service_names


### PR DESCRIPTION
mcollective was being inappropriately left as a default service to manage. Issue seems to be occurring, because `collection` is not being defined on OSS installations: https://github.com/puppetlabs/puppetlabs-puppet_agent/blob/master/manifests/params.pp#L50

This was resulting with the following error, when `service_names` parameter was not explicitly defined as a parameter

> change from 'stopped' to 'running' failed: Systemd start for mcollective failed!