### PR TITLE
(MODULES-10661) Add OS X 10.15 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -108,7 +108,9 @@
       "operatingsystem": "OSX",
       "operatingsystemrelease": [
         "10.12",
-        "10.13"
+        "10.13",
+        "10.14",
+        "10.15"
        ]
     }
   ],

--- a/spec/classes/puppet_agent_osfamily_darwin_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_darwin_spec.rb
@@ -30,7 +30,7 @@ describe 'puppet_agent' do
   describe 'supported environment' do
     let(:params) {{ package_version: package_version }}
     context "when running a supported OSX" do
-      ["osx-10.12-x86_64", "osx-10.13-x86_64", "osx-10.14-x86_64"].each do |tag|
+      ["osx-10.12-x86_64", "osx-10.13-x86_64", "osx-10.14-x86_64", "osx-10.15-x86_64"].each do |tag|
         context "on #{tag} with no aio_version" do
           let(:osmajor) { tag.split('-')[1] }
 


### PR DESCRIPTION
Tested with PE by upgrading from agent version 6.13.0 to 6.15.0.