### PR TITLE
(MODULES-10655) Fix up/downgrade of agent to specified version

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -70,7 +70,7 @@ class puppet_agent::install(
       $_install_options = $install_options
       if $::puppet_agent::absolute_source {
         # absolute_source means we use rpm on EL/suse based platforms
-        $_package_version = 'present'
+        $_package_version = $package_version
         $_provider = 'rpm'
         # The source package should have been downloaded by puppet_agent::prepare::package to the local_packages_dir
         $_source = "${::puppet_agent::params::local_packages_dir}/${::puppet_agent::prepare::package::package_file_name}"

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -237,5 +237,38 @@ describe 'puppet_agent' do
 
       it { is_expected.to contain_class("puppet_agent::osfamily::redhat") }
     end
+
+    context 'when using absolute_source' do
+      let(:params)  {
+        {
+          :package_version => '6.12.0',
+          :absolute_source => "http://just-some-download/url:90/puppet-agent-6.12.0.rpm"
+        }
+      }
+
+      it { is_expected.to contain_class('Puppet_agent::Prepare::Package')
+        .with('source' => 'http://just-some-download/url:90/puppet-agent-6.12.0.rpm')
+      }
+
+      it { is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-6.12.0.rpm')
+        .with('path'     => '/opt/puppetlabs/packages/puppet-agent-6.12.0.rpm')
+        .with('ensure'   => 'present')
+        .with('owner'    => '0')
+        .with('group'    => '0')
+        .with('mode'     => '0644')
+        .with('source'   => 'http://just-some-download/url:90/puppet-agent-6.12.0.rpm')
+        .that_requires('File[/opt/puppetlabs/packages]')
+        .with('checksum' => 'sha256lite')
+      }
+
+      it { is_expected.to contain_package('puppet-agent')
+        .with('ensure'          => '6.12.0')
+        .with('install_options' => '[]')
+        .with('provider'        => 'rpm')
+        .with('source'          => '/opt/puppetlabs/packages/puppet-agent-6.12.0.rpm')
+      }
+      
+    end
+
   end
 end


### PR DESCRIPTION
This fix will make sure then on RedHat like kernels, the `package_version` is used to determine if the agent should be downgraded or upgraded  when when using `absolute_source` parameter.