### PR TITLE
(MODULE-10662) Add Ubuntu 20.04 to puppet_agent::install task

### DIFF
--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -573,6 +573,7 @@ case $platform in
       "16.10") deb_codename="yakkety";;
       "17.04") deb_codename="zesty";;
       "18.04") deb_codename="bionic";;
+      "20.04") deb_codename="focal";;
     esac
     filetype="deb"
     filename="${collection}-release-${deb_codename}.deb"


### PR DESCRIPTION
This adds Ubuntu 20.04 as a supported platform to the
`puppet_agent::install` task.