### PR TITLE
(MODULES-10673) Update dependency for puppetlabs-facts

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -125,6 +125,6 @@
     {"name":"puppetlabs-stdlib","version_requirement":">= 5.1.0 < 7.0.0"},
     {"name":"puppetlabs-inifile","version_requirement":">= 2.4.0 < 5.0.0"},
     {"name":"puppetlabs-apt","version_requirement":">= 7.0.1 < 8.0.0"},
-    {"name":"puppetlabs-facts","version_requirement":">= 0.5.0 < 1.0.0"}
+    {"name":"puppetlabs-facts","version_requirement":">= 0.5.0 < 2.0.0"}
   ]
 }


### PR DESCRIPTION
puppetlabs-puppet_agent module required a puppetlabs-facts
version <1.0.0, which caused a warning as puppetlabs-facts is now at
version 1.0.0.

Removed the upper limit on version requirements for puppetlabs-facts.