### PR TITLE
(MODULES-10666) Stop agent run after an upgrade

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -338,6 +338,8 @@ There are a few known issues on Windows platforms:
 
 * MSI installation failures do not produce any error. If the install fails, puppet_agent continues to be applied to the agent. If this happens, you'll need to examine the MSI log file to determine the failure's cause. You can find the location of the log file in the debug output from either a puppet apply or an agent run; the log file name follows the pattern `puppet-<timestamp>-installer.log`.
 
+* Upgrading on most \*NIX platforms (Linux, AIX, Solaris 11) will end the run after the puppet-agent upgrade finishes. This is to avoid unexpected behavior if already loaded Ruby code happens to interact with newer code that came with the upgrade, or viceversa. If run as a daemon, Puppet will automatically start a new agent run after the upgrade finishes.
+
 Specifically in the 1.2.0 Release:
 * For Windows, you must trigger an agent run after upgrading so that Puppet can create the necessary directory structures.
 

--- a/lib/puppet/provider/puppet_agent_end_run/puppet_agent_end_run.rb
+++ b/lib/puppet/provider/puppet_agent_end_run/puppet_agent_end_run.rb
@@ -1,0 +1,35 @@
+Puppet::Type.type(:puppet_agent_end_run).provide :puppet_agent_end_run do
+  def end_run
+    false
+  end
+
+  def stop
+    if needs_upgrade?
+      run_mode = Puppet.run_mode.name
+
+      # Handle CLI runs of `puppet agent` and `apply`
+      if Puppet[:onetime] || run_mode != :agent
+        Puppet.notice("Stopping run after puppet-agent upgrade. Run puppet agent -t or apply your manifest again to finish the transaction.")
+      end
+
+      Puppet::Application.stop!
+
+      # Sending the HUP signal to the daemon causes it to restart and finish applying the catalog
+      if Puppet[:daemonize] && run_mode == :agent
+        at_exit { Process.kill(:HUP, Process.pid) }
+      end
+    end
+  end
+
+  private
+
+  def needs_upgrade?
+    current_version = Facter.value('aio_agent_version')
+    desired_version = @resource.name
+
+    # Ensure version has no git SHA or Debian codenames
+    desired_version = Gem::Version.new(desired_version).release.version
+
+    Puppet::Util::Package.versioncmp(desired_version, current_version) != 0
+  end
+end

--- a/lib/puppet/type/puppet_agent_end_run.rb
+++ b/lib/puppet/type/puppet_agent_end_run.rb
@@ -1,0 +1,30 @@
+require 'puppet/property/boolean'
+
+Puppet::Type.newtype(:puppet_agent_end_run) do
+  @doc = <<-DOC
+Stops the current Puppet run if a puppet-agent upgrade was
+performed. Used on platforms that manage the Puppet Agent upgrade with
+a package resource, as resources evaluated after an upgrade might
+cause unexpected behavior due to a mix of old and new Ruby code being
+loaded in memory.
+
+Platforms that shell out to external scripts for upgrading (Windows,
+macOS, and Solaris 10) do not need to use this type.
+DOC
+
+  newproperty(:end_run, :boolean => true, parent: Puppet::Property::Boolean) do
+    desc "Stops the current puppet run"
+
+    def insync?(is)
+      provider.stop
+      true
+    end
+
+    defaultto { true }
+  end
+
+  newparam(:name) do
+    desc "The desired puppet-agent version"
+    isnamevar
+  end
+end

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -91,6 +91,8 @@ class puppet_agent::install(
       install_options => $_install_options,
       provider        => $_provider,
       source          => $_source,
+      notify          => Puppet_agent_end_run[$_package_version],
     }
+    puppet_agent_end_run { $_package_version : }
   }
 }

--- a/manifests/install/solaris.pp
+++ b/manifests/install/solaris.pp
@@ -48,6 +48,8 @@ class puppet_agent::install::solaris(
     package { $::puppet_agent::package_name:
       ensure          => $package_version,
       install_options => $install_options,
+      notify          => Puppet_agent_end_run[$package_version],
     }
+    puppet_agent_end_run { $package_version : }
   }
 }


### PR DESCRIPTION
Previously, when evaluating additional resources after a puppet-agent
upgrade, we could get to a point where we had a mixture of old/new
Ruby code loaded in memory. This may cause unexpected behavior if the
new code tries to execute something not available in the already
loaded old code.

This commit introduces a new type/provider that is evaluated whenever
a puppet-agent upgrade happens on a platform managed with the package
resource (AIX, Debian, EL, Suse).

The newly added resource attempts to figure out if a Puppet upgrade
was performed, then stops the run altogether. If Puppet is being run
as a service, the HUP signal will have the daemon trigger a subsequent
Puppet run that will evaluate the remaining resources.

When running `puppet agent -t` manually, it is up to the user to rerun
the command after the puppet-agent upgrade.