### PR TITLE
(MODULES-10713) Fix agent upgrade on Solaris 11

### DIFF
--- a/lib/puppet/provider/puppet_agent_end_run/puppet_agent_end_run.rb
+++ b/lib/puppet/provider/puppet_agent_end_run/puppet_agent_end_run.rb
@@ -27,9 +27,6 @@ Puppet::Type.type(:puppet_agent_end_run).provide :puppet_agent_end_run do
     current_version = Facter.value('aio_agent_version')
     desired_version = @resource.name
 
-    # Ensure version has no git SHA or Debian codenames
-    desired_version = Gem::Version.new(desired_version).release.version
-
     Puppet::Util::Package.versioncmp(desired_version, current_version) != 0
   end
 end

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -86,13 +86,14 @@ class puppet_agent::install(
         $_source = undef
       }
     }
+    $_aio_package_version = $package_version.match(/^\d+\.\d+\.\d+(\.\d+)?/)[0]
     package { $::puppet_agent::package_name:
       ensure          => $_package_version,
       install_options => $_install_options,
       provider        => $_provider,
       source          => $_source,
-      notify          => Puppet_agent_end_run[$_package_version],
+      notify          => Puppet_agent_end_run[$_aio_package_version],
     }
-    puppet_agent_end_run { $_package_version : }
+    puppet_agent_end_run { $_aio_package_version : }
   }
 }

--- a/manifests/install/solaris.pp
+++ b/manifests/install/solaris.pp
@@ -45,11 +45,12 @@ class puppet_agent::install::solaris(
       }
     }
   } else {
+    $_aio_package_version = $package_version.match(/^\d+\.\d+\.\d+(\.\d+)?/)[0]
     package { $::puppet_agent::package_name:
       ensure          => $package_version,
       install_options => $install_options,
-      notify          => Puppet_agent_end_run[$package_version],
+      notify          => Puppet_agent_end_run[$_aio_package_version],
     }
-    puppet_agent_end_run { $package_version : }
+    puppet_agent_end_run { $_aio_package_version : }
   }
 }

--- a/spec/classes/puppet_agent_osfamily_solaris_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_solaris_spec.rb
@@ -69,7 +69,7 @@ EOF
     :clientcert                => 'foo.example.vm',
     :env_temp_variable         => '/tmp',
     :puppet_agent_pid          => 42,
-    :aio_agent_version         => package_version,
+    :aio_agent_version         => '1.10.100.90',
   }
   # Strips out strings in the version string on Solaris 11,
   # because pkg doesn't accept strings in version numbers. This
@@ -148,6 +148,7 @@ EOF
       it { should compile.with_all_deps }
       it { is_expected.to contain_file('/opt/puppetlabs') }
       it { is_expected.to contain_file('/opt/puppetlabs/packages') }
+      it { is_expected.to contain_puppet_agent_end_run(facts[:aio_agent_version]) }
       it do
         is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent@#{sol11_package_version},5.11-1.i386.p5p").with({
           'ensure' => 'present',

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -95,6 +95,20 @@ describe 'puppet_agent' do
           global_facts(facts, os)
         end
 
+        # Windows, Solaris 10 and OS X use scripts for upgrading agents
+        # We test Solaris 11 in its own class
+        if os !~ %r{windows|solaris|darwin}
+          context 'when using a dev build' do
+            let(:params) { { :package_version => '5.2.0.100.g23e53f2' } }
+            it { is_expected.to contain_puppet_agent_end_run('5.2.0.100') }
+          end
+
+          context 'when using a release build' do
+            let(:params) { { :package_version => '5.2.0' } }
+            it { is_expected.to contain_puppet_agent_end_run('5.2.0') }
+          end
+        end
+
         context 'when the aio_agent_version fact is undefined' do
           let(:facts) do
             global_facts(facts, os).merge(aio_agent_version: nil)


### PR DESCRIPTION
Due to Solaris p5p limitations, we munge dev build versions by stripping all letters (i.e.: 5.5.20.102.g9e5216a6 turns to 5.5.20.102.952166).
This causes `Gem::Version` to wrongly interpret the desired version on Solaris 11, making upgrades not idempotent.

Use a regex instead of `Gem::Version` to make `package_version` more like the `aio_agent_version` fact. Move this logic from the provider to the Puppet manifests in order to be able to properly spec test this.