### PR TITLE
(MODULES-10768) Add task and plan for running Puppet agent

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -41,6 +41,8 @@
         - [`install_options`](#install_options)
         - [`msi_move_locked_files`](#msi_move_locked_files)
         - [`wait_for_pxp_agent_exit`](#wait_for_pxp_agent_exit)
+    - [Plans](#plans)
+      - [`puppet_agent::run`](#puppet_agentrun)
     - [Tasks](#tasks)
       - [`puppet_agent::version`](#puppet_agentversion)
       - [`puppet_agent::install`](#puppet_agentinstall)
@@ -297,6 +299,31 @@ This is only applicable for Windows operating systems and pertains to /files/ins
 
 ``` puppet
   wait_for_pxp_agent_exit => 480000
+```
+
+### Plans
+
+#### `puppet_agent::run`
+
+Starts a Puppet agent run on the specified targets.
+
+**Parameters**
+
+- `targets`: A list of targets to start the Puppet agent run on.
+
+**Return value**
+
+Returns a `ResultSet` object. Targets that do not have an agent installed will have a failing
+`Result` object. For targets that have an agent installed and successfully ran the agent,
+the `Result` object will include the output of the agent run, the detailed exit code, and the
+contents of the run report.
+
+```
+{
+  "_output": <output>,
+  "exitcode": <exitcode>,
+  "report": <report>
+}
 ```
 
 ### Tasks

--- a/plans/run.pp
+++ b/plans/run.pp
@@ -1,0 +1,70 @@
+# Starts a Puppet agent run on the specified targets.
+# Note: This plan may cause issues when run in Puppet Enterprise.
+# @param targets The targets to start a Puppet agent run on.
+plan puppet_agent::run (
+  TargetSpec $targets
+) {
+  # Check which targets have the agent installed by checking
+  # the version of the agent. No point in trying to run the
+  # agent if it's not installed.
+  $version_results = run_task(
+    'puppet_agent::version',
+    $targets,
+    'Check for Puppet agent',
+    '_catch_errors' => true
+  )
+
+  # Create results with more descriptive error messages for any targets
+  # where the version task failed.
+  $version_error_results = $version_results.error_set.map |$result| {
+    $err = {
+      '_error' => {
+        'msg'     => "The task puppet_agent::version failed: ${result.error.message}. Unable to determine if the Puppet agent is installed.",
+        'kind'    => 'puppet_agent/agent-version-error',
+        'details' => {}
+      }
+    }
+
+    Result.new($result.target, $err)
+  }
+
+  # Filter targets by those that have an agent installed and
+  # those that don't. The puppet_agent::version task will return
+  # version:null for any targets that don't have an agent.
+  $agentless_results = $version_results.ok_set.filter_set |$result| {
+    $result['version'] == undef
+  }
+
+  $agent_results = $version_results.ok_set.filter_set |$result| {
+    $result['version'] != undef
+  }
+
+  # Create fail results for agentless targets.
+  $agentless_error_results = $agentless_results.map |$result| {
+    $err = {
+      '_error' => {
+        'msg'     => 'Puppet agent is not installed on the target. Run the puppet_agent::install task on these targets to install the Puppet agent.',
+        'kind'    => 'puppet_agent/agent-not-installed',
+        'details' => {}
+      }
+    }
+
+    Result.new($result.target, $err)
+  }
+
+  # Run the agent on all targets that have the agent installed.
+  $run_results = run_task(
+    'puppet_agent::run',
+    $agent_results.targets,
+    'Run Puppet agent',
+    '_catch_errors' => true
+  )
+
+  # Merge all of the results into a single ResultSet so each
+  # target has a result.
+  return ResultSet.new(
+    $version_error_results +
+    $agentless_error_results +
+    $run_results.results
+  )
+}

--- a/tasks/run.json
+++ b/tasks/run.json
@@ -1,0 +1,5 @@
+{
+  "description": "Run the Puppet agent. This task may cause problems if run in Puppet Enterprise.",
+  "parameters": {},
+  "private": true
+}

--- a/tasks/run.rb
+++ b/tasks/run.rb
@@ -1,0 +1,283 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+require 'yaml'
+require 'json'
+require 'puppet'
+
+module PuppetAgent
+  class Runner
+    def error_result(error_type, error_message)
+      {
+        '_error' => {
+          'msg'     => error_message,
+          'kind'    => error_type,
+          'details' => {}
+        }
+      }
+    end
+
+    def puppet_bin_present?
+      File.exist?(puppet_bin)
+    end    
+
+    def running?(lockfile)
+      File.exist?(lockfile)
+    end
+
+    def disabled?(lockfile)
+      File.exist?(lockfile)
+    end
+
+    # Returns the path to the Puppet agent executable
+    def puppet_bin
+      @puppet_bin ||= if Puppet.features.microsoft_windows?
+                        puppet_bin_windows
+                      else
+                        '/opt/puppetlabs/bin/puppet'
+                      end
+    end
+    
+    # Returns the path to the Puppet agent executable on Windows
+    def puppet_bin_windows
+      require 'win32/registry'
+
+      install_dir = begin
+                      Win32::Registry::HKEY_LOCAL_MACHINE.open('SOFTWARE\Puppet Labs\Puppet') do |reg|
+                        # Rescue missing key
+                        dir = reg['RememberedInstallDir64'] rescue ''
+                        # Both keys may exist, make sure the dir exists
+                        break dir if File.exist?(dir)
+                        # Rescue missing key
+                        reg['RememberedInstallDir'] rescue ''
+                      end
+                    rescue Win32::Registry::Error
+                      # Rescue missing registry path
+                      ''
+                    end
+      
+      File.join(install_dir, 'bin', 'puppet.bat')
+    end
+
+    # Prepare an environment fix-up to make up for its cleansing performed
+    # by the Puppet::Util::Execution.execute function.
+    # This fix-up is meant for running puppet under a non-root user;
+    # puppet cannot find the user's HOME directory otherwise.
+    def get_env_fix_up
+      # If running in a C or POSIX locale, ask Puppet to use UTF-8
+      base_env = {}
+      if Encoding.default_external == Encoding::US_ASCII
+        base_env = {"RUBYOPT" => "#{ENV['RUBYOPT']} -EUTF-8"}
+      end
+
+      @env_fix_up ||= if Puppet.features.microsoft_windows? || Process.euid == 0
+        # no environment fix-up is needed on windows or for root
+        base_env
+      else
+        begin
+          require 'etc'
+
+          pwentry = Etc.getpwuid(Process.euid)
+
+          {
+            "USER"    => pwentry.name,
+            "LOGNAME" => pwentry.name,
+            "HOME"    => pwentry.dir
+          }.merge base_env
+        rescue => e
+          # Give it a try without the environment fix-up.
+          myname = File.basename($0)
+          base_env
+        end
+      end
+    end
+
+    def force_unicode(s)
+      begin
+        # Later comparisons assume UTF-8. Convert to that encoding now.
+        s.encode(Encoding::UTF_8)
+      rescue Encoding::InvalidByteSequenceError, Encoding::UndefinedConversionError
+        # Found non-native characters, hope it's a UTF-8 string. Since this is Puppet, and
+        # incorrect characters probably means we're in a C or POSIX locale, this is usually safe.
+        s.force_encoding(Encoding::UTF_8)
+      end
+    end
+
+    # Wait for the lockfile to be removed. If it hasn't after 10 minutes, give up.
+    def wait_for_lockfile(lockfile, check_interval = 0.1, give_up_after = 10 * 60)
+      number_of_tries = give_up_after / check_interval
+      count = 0
+      while File.exist?(lockfile) && count < number_of_tries
+        sleep check_interval
+        count += 1
+      end
+    end
+
+    def get_start_time(last_run_report)
+      File.mtime(last_run_report) if File.exist?(last_run_report)
+    end
+
+    # Loads the last run report and generates a result from it.
+    def get_result_from_report(last_run_report, run_result, start_time)
+      unless File.exist?(last_run_report)
+        return error_result(
+          'puppet_agent/no-last-run-report-error',
+          'Did not detect report, Puppet agent may not be configured'
+        )
+      end
+
+      if start_time && File.mtime(last_run_report) == start_time
+        return error_result(
+          'puppet_agent/no-last-run-report-error',
+          'The Puppet run failed in an unexpected way'
+        )
+      end
+
+      begin
+        report = YAML.parse_file(last_run_report)
+
+        # Drop Ruby objects since these can't be parsed
+        report.root.each do |obj|
+          obj.tag = nil if obj.respond_to?(:tag=)
+        end
+
+        {
+          'report'   => report.to_ruby,
+          'exitcode' => run_result.exitstatus,
+          '_output'  => run_result
+        }
+      rescue => e
+        return error_result(
+          'puppet_agent/invalid-last-run-report-error',
+          "Report #{last_run_report} could not be loaded: #{e}"
+        )
+      end
+    end
+
+    # Returns the Puppet config for the specified keys. Used to locate the
+    # last run report, disabled lockfile, and catalog run lockfile.
+    def config_print(*keys)
+      command = [puppet_bin, "agent", "--configprint", keys.join(',')]
+
+      options = {
+        custom_environment: get_env_fix_up,
+        override_locale:    false
+      }
+
+      process_output = Puppet::Util::Execution.execute(command, options)
+
+      result = force_unicode(process_output.to_s)
+      if keys.count == 1
+        result.chomp
+      else
+        result.lines.inject({}) do |conf, line|
+          key, value = line.chomp.split(' = ', 2)
+          if key && value
+            conf[key] = value
+          end
+          conf
+        end
+      end
+    end
+
+    # Attempts to run the Puppet agent, returning the mtime for the last run report
+    # and the exit code from the Puppet agent run.
+    def try_run(last_run_report)
+      start_time = get_start_time(last_run_report)
+
+      command = [puppet_bin, 'agent', '-t', '--color', 'false']
+
+      options = {
+        failonfail:         false,
+        custom_environment: get_env_fix_up,
+        override_locale:    false
+      }
+
+      run_result = Puppet::Util::Execution.execute(command, options)
+
+      [start_time, run_result]
+    end
+
+    # Runs the Puppet agent and returns the last run report.
+    def run
+      unless puppet_bin_present?
+        return error_result(
+          'puppet_agent/no-puppet-bin-error',
+          "Puppet executable '#{puppet_bin}' does not exist"
+        )
+      end
+
+      puppet_config   = config_print('lastrunreport', 'agent_disabled_lockfile', 'agent_catalog_run_lockfile')
+      last_run_report = puppet_config['lastrunreport']
+
+      if last_run_report.nil? || last_run_report.empty?
+        return error_result(
+          'puppet_agent/no-last-run-report-error',
+          'Could not find the location of the last run report'
+        )
+      end
+
+      # Initially ignore the lockfile. It might be out-dated, so we give Puppet a chance
+      # to clean it up and run.
+      start_time, run_result = try_run(last_run_report)
+      if run_result.nil?
+        return error_result(
+          'puppet_agent/fail-to-start-error',
+          'Failed to start Puppet agent'
+        )
+      end
+
+      # If the run was successful, don't check for failure modes.
+      if run_result.exitstatus != 0
+        if disabled?(puppet_config['agent_disabled_lockfile'] || '')
+          return error_result(
+            'puppet_agent/agent-disabled-error',
+            'Puppet agent is disabled'
+          )
+        end
+
+        # Check for a lockfile. If present, wait until it's removed and try running again.
+        # There's a chance that our run finished with a real error rather than because Puppet was
+        # already running, but another run started immediately after. Since we have no
+        # language-agnostic way to tell, we accept that we might run twice in that case.
+        # The run could also finish immediately after we tried, and the lockfile be absent.
+        # In that case we'll fail with poor error reporting.
+        lockfile = puppet_config['agent_catalog_run_lockfile'] || ''
+        if running?(lockfile)
+          wait_for_lockfile(lockfile)
+
+          start_time, run_result = try_run(last_run_report)
+          if run_result.nil?
+            return error_result(
+              'puppet_agent/fail-to-start-error',
+              'Failed to start Puppet agent'
+            )
+          end
+
+          if run_result.exitstatus != 0
+            if disabled?(puppet_config['agent_disabled_lockfile'] || '')
+              return error_result(
+                'puppet_agent/agent-disabled-error',
+                'Puppet agent is disabled'
+              )
+            end
+
+            if running?(lockfile)
+              return error_result(
+                'puppet_agent/agent-locked-error',
+                'Puppet agent run is already in progress'
+              )
+            end
+          end
+        end
+      end
+
+      get_result_from_report(last_run_report, run_result, start_time)
+    end
+  end
+end
+
+if __FILE__ == $0
+  runner = PuppetAgent::Runner.new
+  puts JSON.dump(runner.run)
+end


### PR DESCRIPTION
This adds a new `puppet_agent::run` task that runs the Puppet agent on a
list of targets, and returns the run report contents as well as the
exit code for the agent run.

This also adds a `puppet_agent::run` plan which checks if the agent is
installed on each target and runs the `puppet_agent::run` task on each
target that has the agent installed. The plan returns a `ResultSet` that
includes fail results for targets that do not have the agent installed,
as well as the results from the `puppet_agent::run` task.