### PR TITLE
(MODULES-10799) Ensure upgradability from puppet 6 to 7 when remote filebuckets are enabled

### DIFF
--- a/lib/facter/settings.rb
+++ b/lib/facter/settings.rb
@@ -6,6 +6,12 @@ Facter.add('puppet_ssldir') do
   end
 end
 
+Facter.add('puppet_digest_algorithm') do
+  setcode do
+    Puppet.settings['digest_algorithm']
+  end
+end
+
 Facter.add('puppet_config') do
   setcode do
     Puppet.settings['config']

--- a/lib/puppet/functions/any_resources_of_type.rb
+++ b/lib/puppet/functions/any_resources_of_type.rb
@@ -1,0 +1,25 @@
+Puppet::Functions.create_function(:any_resources_of_type, Puppet::Functions::InternalFunction) do 
+  dispatch :any_resources_of_type do
+    scope_param
+
+    required_param 'String', :resource_type
+    optional_param 'Hash[Any, Any]', :parameters
+  end
+
+  def any_resources_of_type(scope, resource_type, parameters = nil)
+    scope.catalog.resources.any? do |resource|
+      # We should always iterate over Puppet::Parser::Resource
+      # instances here, and documentation states that types can be
+      # strings or symbols.
+      # https://www.rubydoc.info/gems/puppet/Puppet/Resource#initialize-instance_method
+      if resource.type.to_s.casecmp(resource_type).zero? # String#casecmp? is Ruby 2.4+
+        if parameters
+          # If the resource matched, but any of the params didn't, go to the next one
+          next if parameters.any? { |k, v| resource.to_hash[k.to_sym] != v }
+        end
+        true
+      end
+    end
+  end
+end
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -168,6 +168,14 @@ class puppet_agent (
 
     $aio_upgrade_required = versioncmp($::aio_agent_version, $_expected_package_version) < 0
 
+    if $aio_upgrade_required {
+      if any_resources_of_type('filebucket', { path => false }) {
+        if $settings::digest_algorithm != $::puppet_digest_algorithm {
+          fail("Remote filebuckets are enabled, but there was a agent/server digest algorithm mismatch. Server: ${settings::digest_algorithm}, agent: ${::puppet_digest_algorithm}. Either ensure the algorithms are matching, or disable remote filebuckets during the upgrade.")
+        }
+      }
+    }
+
     if $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '11' {
       # Strip letters from development builds. Unique to Solaris 11 packaging.
       $_version_without_letters = regsubst($master_or_package_version, '[a-zA-Z]', '', 'G')

--- a/spec/unit/facter/settings_spec.rb
+++ b/spec/unit/facter/settings_spec.rb
@@ -3,12 +3,21 @@ require 'spec_helper'
 describe 'settings' do
   let(:location) { File.expand_path('/dev/null') }
 
+  describe 'puppet_digest_algorithm fact' do
+    subject { Facter.fact(:puppet_digest_algorithm).value }
+    after(:each) { Facter.clear }
+
+    describe 'should be one of md5/sha256' do
+      it { is_expected.to match(%r{md5|sha256}) }
+    end
+  end
+
   describe 'puppet_ssldir fact' do
     subject { Facter.fact(:puppet_ssldir).value }
     after(:each) { Facter.clear }
 
     describe 'should point to an existing directory' do
-    it { is_expected.to eq("#{location}/ssl") }
+      it { is_expected.to eq("#{location}/ssl") }
     end
   end
 
@@ -17,7 +26,7 @@ describe 'settings' do
     after(:each) { Facter.clear }
 
     describe 'should point to an existing file' do
-    it { is_expected.to eq("#{location}/puppet.conf") }
+      it { is_expected.to eq("#{location}/puppet.conf") }
     end
   end
 
@@ -26,7 +35,7 @@ describe 'settings' do
     after(:each) { Facter.clear }
 
     describe 'should always be false' do
-    it { is_expected.to eq(false) }
+      it { is_expected.to eq(false) }
     end
   end
 

--- a/spec/unit/functions/any_resources_of_type_spec.rb
+++ b/spec/unit/functions/any_resources_of_type_spec.rb
@@ -1,0 +1,92 @@
+require 'spec_helper'
+require 'puppet/pops'
+require 'puppet/loaders'
+
+describe "the 'any_resources_of_type' function" do
+  after(:all) { Puppet::Pops::Loaders.clear }
+
+  # This loads the function once and makes it easy to call it
+  # It does not matter that it is not bound to the env used later since the function
+  # looks up everything via the scope that is given to it.
+  # The individual tests needs to have a fresh env/catalog set up
+  #
+  let(:loaders) { Puppet::Pops::Loaders.new(Puppet::Node::Environment.create(:testing, [File.expand_path(fixtures('modules'))])) }
+  let(:func) { loaders.private_environment_loader.load(:function, 'any_resources_of_type') }
+
+  # A fresh environment is needed for each test since tests create resources
+  let(:environment) { Puppet::Node::Environment.create(:testing, [File.expand_path(fixtures('modules'))]) }
+  let(:node) { Puppet::Node.new('yaynode', :environment => environment) }
+  let(:compiler) { Puppet::Parser::Compiler.new(node) }
+  let(:scope) { Puppet::Parser::Scope.new(compiler) }
+
+  def newresource(type, title, parameters = {})
+    resource = Puppet::Resource.new(type, title, :parameters => parameters)
+    compiler.add_resource(scope, resource)
+    resource
+  end
+
+  it 'raises if called without the "resource_type" argument' do
+    expect { func.call(scope) }.to raise_error(ArgumentError, %r{expects between.*got none})
+  end
+
+  it 'allows an optional "parameters" argument' do
+    expect { func.call(scope, 'title', { :param1 => 'value1' }) }.not_to raise_error
+  end
+
+  it 'raises if the "parameters" argument is not a hash' do
+    expect { func.call(scope, 'title', 'not_a_hash') }.to raise_error(ArgumentError, %r{parameter 'parameters' expects a Hash value, got String})
+  end
+
+  context 'when resources are defined' do
+    context 'when there are multiple resources' do
+      it 'iterates until a parameter matches' do
+        newresource('filebucket', 'bucket_1')
+        newresource('filebucket', 'bucket_2')
+        newresource('filebucket', 'bucket_3')
+        expect(func.call(scope, 'filebucket', :name => 'bucket_3')).to be_truthy
+      end
+    end
+
+    it 'finds by type name' do
+      newresource('filebucket', 'my_filebucket')
+      expect(func.call(scope, 'filebucket')).to be_truthy
+    end
+
+    it 'finds by capitalized type name' do
+      newresource('filebucket', 'my_filebucket')
+      expect(func.call(scope, 'Filebucket')).to be_truthy
+    end
+
+    it 'finds by type name and a parameter'  do
+      newresource('filebucket', 'my_filebucket')
+      expect(func.call(scope, 'filebucket', :name => 'my_filebucket')).to be_truthy
+    end
+
+    it 'finds by type name and multiple parameters'  do
+      newresource('filebucket', 'my_filebucket', :path => false)
+      expect(func.call(scope, 'filebucket', :name => 'my_filebucket', :path => false)).to be_truthy
+    end
+
+    it 'finds by type name and multiple parameters in any order'  do
+      newresource('filebucket', 'my_filebucket', :path => false)
+      expect(func.call(scope, 'filebucket', :path => false, :name => 'my_filebucket')).to be_truthy
+    end
+  end
+
+  context 'when no resources are defined' do
+    it 'does not find by type name' do
+      expect(func.call(scope, 'filebucket')).to be_falsey
+    end
+
+    it 'matches the type but not the parameters' do
+      newresource 'filebucket', 'my_filebucket'
+      expect(func.call(scope, 'filebucket', :name => 'not_my_filebucket')).to be_falsey
+    end
+
+    it 'matches the type but not all parameters'  do
+      newresource 'filebucket', 'my_filebucket', :path => false
+      expect(func.call(scope, 'filebucket', :name => 'my_filebucket', :path => '/path/to/bucket')).to be_falsey
+    end
+  end
+end
+


### PR DESCRIPTION
Puppet 7 changed the default digest algorithm to SHA256 in
https://github.com/puppetlabs/puppet/pull/8325. This could cause
failures when upgrading if remote filebuckets are also enabled.

Before performing the upgrade, check if remote filebuckets are enabled
and compare the digest algorithms of the agent/server. If they differ,
abort the upgrade.