### PR TITLE
(MODULES-10813) Mismatched versions stops install

### DIFF
--- a/files/helpers.ps1
+++ b/files/helpers.ps1
@@ -1,0 +1,18 @@
+<#
+.Synopsis
+  Write message to location of $Logfile
+.Parameter message
+  String containing the message to write
+.Parameter Logfile
+  File location where the installation will log output
+#>
+function Script:Write-Log {
+  param(
+    [Parameter(Mandatory=$true)]
+    [String] $message,
+    [String] $Logfile
+  )
+  begin {
+    "$(Get-Date -Format g) $message" | Out-File -FilePath $Logfile -Append
+  }
+}

--- a/files/install_puppet.ps1
+++ b/files/install_puppet.ps1
@@ -45,6 +45,9 @@ param(
   [switch] $UseLockedFilesWorkaround,
   [Int32] $WaitForPXPAgentExit=120000
 )
+
+. "$PSScriptRoot\helpers.ps1"
+
 # Find-InstallDir, Move-PuppetresDLL and Reset-PuppetresDLL serve as a workaround for older
 # installations of puppet: we used to need to move puppetres.dll out of the way during puppet
 # upgrades because the file would lock and cause network stack restarts.
@@ -80,7 +83,7 @@ function Script:Move-PuppetresDLL {
     # for the already installed package
     $InstallDir = Find-InstallDir
     if (Test-Path "$InstallDir\puppet\bin\puppetres.dll") {
-      Write-Log "Moving puppetres.dll to $temp_puppetres"
+      Write-Log "Moving puppetres.dll to $temp_puppetres" $Logfile
       Move-Item -Path "$InstallDir\puppet\bin\puppetres.dll" -Destination $temp_puppetres
       # Remove-Item -Path $temp_puppetres
     }
@@ -103,7 +106,7 @@ function Script:Reset-PuppetresDLL {
   )
   begin {
     if (!$temp_puppetres) {
-      Write-Log "puppetres.dll Never moved, continuing..."
+      Write-Log "puppetres.dll Never moved, continuing..." $Logfile
       return
     }
     # _Never_ use the $InstallDir top-level parameter to try and find the InstallDir
@@ -113,25 +116,9 @@ function Script:Reset-PuppetresDLL {
     # for the already installed package
     $InstallDir = Find-InstallDir
     if ((Test-Path $temp_puppetres) -and -not (Test-Path "$InstallDir\puppet\bin\puppetres.dll")) {
-      Write-Log "Restoring puppetres.dll"
+      Write-Log "Restoring puppetres.dll" $Logfile
       Move-Item -Path $temp_puppetres -Destination "$InstallDir\puppet\bin\puppetres.dll"
     }
-  }
-}
-
-<#
-.Synopsis
-  Write message to location of $Logfile
-.Parameter message
-  String containing the message to write
-#>
-function Script:Write-Log {
-  param(
-    [Parameter(Mandatory=$true)]
-    [String] $message
-  )
-  begin {
-    "$(Get-Date -Format g) $message" | Out-File -FilePath $Logfile -Append
   }
 }
 
@@ -148,21 +135,21 @@ function Script:Lock-Installation {
     [String] $install_pid_lock
   )
   begin {
-    Write-Log "Locking installation"
+    Write-Log "Locking installation" $Logfile
     if (Test-Path $install_pid_lock) {
       # if the PID found in $install_pid_lock file is not running, this means
       # the installation can take control of the file, and assign the new running PID
       if((Get-Process -Id (Get-Content $install_pid_lock) -ErrorAction SilentlyContinue) -eq $null){
-        Write-Log "Process with PID found in $install_pid_lock is no longer running! Continuing installation and assigning new PID!"
+        Write-Log "Process with PID found in $install_pid_lock is no longer running! Continuing installation and assigning new PID!" $Logfile
         $PID | Out-File -FilePath $install_pid_lock
       }else{
-        Write-Log "Another process has control of $install_pid_lock! Cannot lock, exiting..."
+        Write-Log "Another process has control of $install_pid_lock! Cannot lock, exiting..." $Logfile
         throw
       }
     } else {
       $PID | Out-File -NoClobber -FilePath $install_pid_lock
     }
-    Write-Log "Locked"
+    Write-Log "Locked" $Logfile
   }
 }
 
@@ -178,16 +165,16 @@ function Script:Unlock-Installation {
     [String] $install_pid_lock
   )
   begin {
-    Write-Log "Unlocking installation"
+    Write-Log "Unlocking installation" $Logfile
     if (Test-Path $install_pid_lock) {
       if ((Get-Content $install_pid_lock) -ne $PID) {
-        Write-Log "Another process has control of $install_pid_lock! Cannot unlock, exiting..."
+        Write-Log "Another process has control of $install_pid_lock! Cannot unlock, exiting..." $Logfile
       } else {
         try {
           Remove-Item -Force $install_pid_lock | Out-Null
-          Write-Log "Unlocked"
+          Write-Log "Unlocked" $Logfile
         } catch {
-          Write-Log $_
+          Write-Log $_ $Logfile
         }
       }
     }
@@ -215,10 +202,10 @@ function Script:Read-PuppetServices {
       # we need to use WMI to fetch it for older versions of windows
       if ($service_entry) {
         $start_type = (Get-WmiObject -Class Win32_Service -Property StartMode -Filter "Name='$service_name'").StartMode.Replace('Auto', 'Automatic')
-        Write-Log "Fetched Service $service_name status: $($service_entry.Status), StartType: $start_type"
+        Write-Log "Fetched Service $service_name status: $($service_entry.Status), StartType: $start_type" $Logfile
         $services += @{ 'Name' = $service_name; 'Status' = $service_entry.Status; 'StartType' = $start_type }
       } else {
-        Write-Log "Service $service_name does not exist, continuing..."
+        Write-Log "Service $service_name does not exist, continuing..." $Logfile
       }
     }
     return $services
@@ -240,7 +227,7 @@ function Script:Reset-PuppetServices {
   )
   begin{
     if (!$services) {
-      Write-Log "Services to reset is empty..."
+      Write-Log "Services to reset is empty..." $Logfile
       return
     }
     foreach ($service in $services) {
@@ -248,15 +235,15 @@ function Script:Reset-PuppetServices {
       # an upgrade from agent < 6 to agent >= 6 will have an mcollective
       # service before upgrade, but no mcollective service after
       if (Get-Service $service.Name -ErrorAction SilentlyContinue) {
-        Write-Log "Restoring service state for $($service.Name)"
+        Write-Log "Restoring service state for $($service.Name)" $Logfile
         try {
           Set-Service $service.Name -StartupType $service.StartType -ErrorAction Stop
           Set-Service $service.Name -Status $service.Status -ErrorAction Stop
         } catch {
-          Write-Log "Could not restore service state for $($service.Name). $_"
+          Write-Log "Could not restore service state for $($service.Name). $_" $Logfile
         }
       } else {
-        Write-Log "Get-Service failed to fetch $($service.Name), continuing..."
+        Write-Log "Get-Service failed to fetch $($service.Name), continuing..." $Logfile
       }
     }
   }
@@ -271,7 +258,7 @@ $service_names=@(
 )
 try {
   $state_dir = (puppet.bat config print statedir --environment production)
-  Write-Log "Installation PID:$PID"
+  Write-Log "Installation PID:$PID" $Logfile
   $install_pid_lock = Join-Path -Path $state_dir -ChildPath 'puppet_agent_upgrade.pid'
   Lock-Installation $install_pid_lock
   if ($PuppetPID) {
@@ -281,15 +268,15 @@ try {
     # stop all of our services. Otherwise if the catalog has additional resources
     # that manage our services (e.g. such as those from the PE module), then the
     # install will fail to proceed.
-    Write-Log "Waiting for puppet to stop, PID:$PuppetPID"
+    Write-Log "Waiting for puppet to stop, PID:$PuppetPID" $Logfile
     $pup_process = Get-Process -ID $PuppetPID -ErrorAction SilentlyContinue
     if ($pup_process) {
       if (!$pup_process.WaitForExit(120000)){
-        Write-Log "ERROR: Timed out waiting for puppet!"
+        Write-Log "ERROR: Timed out waiting for puppet!" $Logfile
         throw
       }
     } else {
-      Write-Log "Puppet Already finished"
+      Write-Log "Puppet Already finished" $Logfile
     }
   }
   $services_before = Read-PuppetServices $service_names
@@ -298,7 +285,7 @@ try {
   foreach($service in $service_names) {
     $serv_exists = Get-Service -Name $service -ErrorAction SilentlyContinue
     if ($serv_exists) {
-      Write-Log "Stopping $($service) before upgrade"
+      Write-Log "Stopping $($service) before upgrade" $Logfile
       Stop-Service $service
     }
   }
@@ -307,12 +294,12 @@ try {
   # There is a known problem for pxp-agent shutdown: there are cases where after service
   # shutdown pxp-agent processes are still open. See https://tickets.puppetlabs.com/browse/FM-7628
   # for more details on the symptoms of this.
-  Write-Log "Waiting for pxp-agent processes to stop"
+  Write-Log "Waiting for pxp-agent processes to stop" $Logfile
   Get-Process -Name "pxp-agent" -ErrorAction SilentlyContinue | ForEach-Object {
     if ($_) {
       # Wait for each PXP agent process default wait time is 2 minutes.
       if (!$_.WaitForExit($WaitForPXPAgentExit)){
-        Write-Log "ERROR: Timed out waiting for pxp-agent!"
+        Write-Log "ERROR: Timed out waiting for pxp-agent!" $Logfile
         throw
       }
     }
@@ -331,8 +318,8 @@ try {
     $msi_arguments += " PUPPET_AGENT_STARTUP_MODE=`"$PuppetStartType`""
   }
   $msi_arguments += " $InstallArgs"
-  Write-Log "Beginning MSI installation with Arguments: $msi_arguments"
-  Write-Log "****************************** Begin msiexec.exe output ******************************"
+  Write-Log "Beginning MSI installation with Arguments: $msi_arguments" $Logfile
+  Write-Log "****************************** Begin msiexec.exe output ******************************" $Logfile
   $startInfo = New-Object System.Diagnostics.ProcessStartInfo('msiexec.exe', $msi_arguments)
   $startInfo.UseShellExecute = $false
   $startInfo.CreateNoWindow = $true
@@ -345,15 +332,15 @@ try {
   # park current thread until the PS event is signaled upon process exit
   # OR the timeout has elapsed
   $waitResult = Wait-Event -SourceIdentifier $invocationId
-  Write-Log "****************************** End msiexec.exe output ******************************"
+  Write-Log "****************************** End msiexec.exe output ******************************" $Logfile
   if (($msi_process.ExitCode -eq 3010) -or ($msi_process.ExitCode -eq 1641) ){
-    Write-Log "WARNING: msiexec.exe returned $($msi_process.ExitCode) and has flagged the system for restart!!!"
+    Write-Log "WARNING: msiexec.exe returned $($msi_process.ExitCode) and has flagged the system for restart!!!" $Logfile
   } elseif ($msi_process.ExitCode -ne 0){
-    Write-Log "ERROR: msiexec.exe installation failed!!! Return code $($msi_process.ExitCode)"
+    Write-Log "ERROR: msiexec.exe installation failed!!! Return code $($msi_process.ExitCode)" $Logfile
     throw
   }
 } catch {
-  Write-Log "ERROR: $_"
+  Write-Log "ERROR: $_" $Logfile
   if ($UseLockedFilesWorkaround) {
     Reset-PuppetresDLL $temp_puppetres
   }

--- a/files/prerequisites_check.ps1
+++ b/files/prerequisites_check.ps1
@@ -22,6 +22,7 @@ param (
 Write-Log "Checking puppet-agent.msi version and expected puppet-agent version.." $Logfile
 try{
   if (!(Test-Path $Msi.FullName)) {
+    Write-Error "ERROR: File '${Msi.FullName}' does not exist"
     Write-Log "ERROR: File '${Msi.FullName}' does not exist" $Logfile
     throw
   }
@@ -43,6 +44,7 @@ try{
     $Msi_version = $record.GetType().InvokeMember( "StringData", "GetProperty", $Null, $record, 1 )
 
   } catch {
+    Write-Error "ERROR: Failed to get MSI file version: ${_}."
     Write-Log "ERROR: Failed to get MSI file version: ${_}." $Logfile
     throw
   }
@@ -50,6 +52,7 @@ try{
     Write-Log ".msi file version and expected puppet-agent version match (${Msi_version})" $Logfile
     exit 0
   } else {
+    Write-Output "ERROR: The expected puppet-agent version(${RequiredVersion}) does NOT match the .msi version ${Msi_version}.  Installation will STOP!"
     Write-Log "ERROR: The expected puppet-agent version(${RequiredVersion}) does NOT match the .msi version ${Msi_version}. Installation will STOP!" $Logfile
     throw
   }

--- a/files/prerequisites_check.ps1
+++ b/files/prerequisites_check.ps1
@@ -1,0 +1,59 @@
+<#
+.Synopsis
+  Read the ProductVersion from a Windows Installer MSI file
+.Description
+  This script will check if the versions from the .msi file and the $RequiredVersion match, to ensure that only
+  the .msi with the wanted version is installed.
+.Parameter RequiredVersion
+  The version that is required to be installed
+.Parameter Msi
+  The file name of the MSI file, or full path
+.Parameter Logfile
+  File location where the installation will log output
+#>
+param (
+    [String] $RequiredVersion,
+    [IO.FileInfo] $Msi,
+    [String] $Logfile
+)
+
+. "$PSScriptRoot\helpers.ps1"
+
+Write-Log "Checking puppet-agent.msi version and expected puppet-agent version.." $Logfile
+try{
+  if (!(Test-Path $Msi.FullName)) {
+    Write-Log "ERROR: File '${Msi.FullName}' does not exist" $Logfile
+    throw
+  }
+  $Msi_version = ""
+  try {
+    $windowsInstaller = New-Object -com WindowsInstaller.Installer
+    $database = $windowsInstaller.GetType().InvokeMember(
+        "OpenDatabase", "InvokeMethod", $Null,
+        $windowsInstaller, @($Msi.FullName, 0)
+    )
+
+    $q = "SELECT Value FROM Property WHERE Property = 'ProductVersion'"
+    $View = $database.GetType().InvokeMember(
+        "OpenView", "InvokeMethod", $Null, $database, ($q)
+    )
+
+    $View.GetType().InvokeMember("Execute", "InvokeMethod", $Null, $View, $Null)
+    $record = $View.GetType().InvokeMember( "Fetch", "InvokeMethod", $Null, $View, $Null )
+    $Msi_version = $record.GetType().InvokeMember( "StringData", "GetProperty", $Null, $record, 1 )
+
+  } catch {
+    Write-Log "ERROR: Failed to get MSI file version: ${_}." $Logfile
+    throw
+  }
+  if ($Msi_version -eq $RequiredVersion) {
+    Write-Log ".msi file version and expected puppet-agent version match (${Msi_version})" $Logfile
+    exit 0
+  } else {
+    Write-Log "ERROR: The expected puppet-agent version(${RequiredVersion}) does NOT match the .msi version ${Msi_version}. Installation will STOP!" $Logfile
+    throw
+  }
+} catch {
+  Write-Log "ERROR: $_" $Logfile
+  exit 1
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -167,6 +167,7 @@ class puppet_agent (
     }
 
     $aio_upgrade_required = versioncmp($::aio_agent_version, $_expected_package_version) < 0
+    $aio_downgrade_required = versioncmp($::aio_agent_version, $_expected_package_version) > 0
 
     if $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '11' {
       # Strip letters from development builds. Unique to Solaris 11 packaging.

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -34,7 +34,7 @@ class puppet_agent::install(
     }
   } elsif $::osfamily == 'windows' {
     # Prevent re-running the batch install
-    if $puppet_agent::aio_upgrade_required {
+    if ($puppet_agent::aio_upgrade_required) or ($puppet_agent::aio_downgrade_required){
       class { 'puppet_agent::install::windows':
         install_dir     => $install_dir,
         install_options => $install_options,

--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -43,12 +43,34 @@ class puppet_agent::install::windows(
   notice ("Puppet upgrade log file at ${_logfile}")
   debug ("Installing puppet from ${_msi_location}")
 
+  $_helpers = windows_native_path("${::env_temp_variable}/helpers.ps1")
+  file { $_helpers:
+    ensure  => file,
+    content => file('puppet_agent/helpers.ps1')
+  }
+
   $_installps1 = windows_native_path("${::env_temp_variable}/install_puppet.ps1")
   puppet_agent_upgrade_error { 'puppet_agent_upgrade_failure.log': }
   file { $_installps1:
     ensure  => file,
     content => file('puppet_agent/install_puppet.ps1')
   }
+
+  $_prerequisites_check = windows_native_path("${::env_temp_variable}/prerequisites_check.ps1")
+  file { $_prerequisites_check:
+    ensure  => file,
+    content => file('puppet_agent/prerequisites_check.ps1')
+  }
+
+  exec { 'prerequisites_check.ps1':
+    command => "${::system32}\\WindowsPowerShell\\v1.0\\powershell.exe \
+                  -NoProfile \
+                  -NoLogo \
+                  -NonInteractive \
+                  ${_prerequisites_check} ${::puppet_agent::_expected_package_version} ${_msi_location} ${_logfile}",
+    require => File[$_prerequisites_check]
+  }
+
   exec { 'install_puppet.ps1':
     # The powershell execution uses -Command and not -File because -File will interpolate the quotes
     # in a context like cmd.exe: https://docs.microsoft.com/en-us/powershell/scripting/components/console/powershell.exe-command-line-help?view=powershell-6#-file--
@@ -81,7 +103,8 @@ class puppet_agent::install::windows(
     path    => $::path,
     require => [
       Puppet_agent_upgrade_error['puppet_agent_upgrade_failure.log'],
-      File[$_installps1]
+      File[$_installps1],
+      Exec['prerequisites_check.ps1']
     ]
   }
 

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe 'puppet_agent', tag: 'win' do
           })}
 
           it { is_expected.not_to contain_file('c:\tmp\install_puppet.bat') }
+          it { is_expected.not_to contain_exec('prerequisites_check.ps1') }
           it { is_expected.not_to contain_exec('fix inheritable SYSTEM perms') }
         end
 
@@ -59,6 +60,7 @@ RSpec.describe 'puppet_agent', tag: 'win' do
 
           it { is_expected.not_to contain_file('c:\tmp\install_puppet.bat') }
           it { is_expected.not_to contain_exec('install_puppet.bat') }
+          it { is_expected.not_to contain_exec('prerequisites_check.ps1') }
         end
 
         context 'with out of date aio_agent_version' do
@@ -68,6 +70,7 @@ RSpec.describe 'puppet_agent', tag: 'win' do
           })}
 
           it { is_expected.to contain_class('puppet_agent::install::windows') }
+          it { is_expected.to contain_exec('prerequisites_check.ps1').with_command(/\ #{package_version} C:\\ProgramData\\Puppetlabs\\packages\\puppet-agent-#{arch}.msi C:\\tmp\\puppet-\d+_\d+_\d+-\d+_\d+-installer.log/) }
           it { is_expected.to contain_exec('install_puppet.ps1').with_command(/\-Source \'C:\\ProgramData\\Puppetlabs\\packages\\puppet-agent-#{arch}.msi\'/) }
           it { is_expected.to contain_exec('fix inheritable SYSTEM perms') }
         end


### PR DESCRIPTION
When performing a puppet-agent upgrade with PE, the .msi package
that will get downloaded by default is the puppet-agent version
of the server node.

If a different version than the one on the master is requested,
if no pe_repo is configured and available, it will install the version
on the master.

This PR fails if the desired version and version from the .msi match.
If they do not match the install_puppet.ps1 will fail before installing
an unwanted version.