### PR TITLE
(maint) Bump puppet agent version used in acceptance tests and fix them

### DIFF
--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -10,7 +10,7 @@ describe 'puppet_agent class' do
 
     it 'should work idempotently with no errors' do
       pp = <<-EOS
-      class { 'puppet_agent': package_version => '5.5.16', collection => 'puppet5' }
+      class { 'puppet_agent': package_version => '5.5.21', collection => 'puppet5' }
       EOS
 
       apply_manifest(pp, :catch_failures => true)
@@ -140,7 +140,7 @@ describe 'puppet_agent class' do
     context 'with mcollective configured' do
       before(:all) {
         setup_puppet_on default, :mcollective => true, :agent => true
-        manifest = 'class { "puppet_agent": package_version => "5.5.16", collection => "puppet5", service_names => ["mcollective"] }'
+        manifest = 'class { "puppet_agent": package_version => "5.5.21", collection => "puppet5", service_names => ["mcollective"] }'
         pp = "file { '#{master.puppet['codedir']}/environments/production/manifests/site.pp': ensure => file, content => '#{manifest}' }"
         apply_manifest_on(master, pp, :catch_failures => true)
       }
@@ -197,7 +197,7 @@ describe 'puppet_agent class' do
         end
 
         let(:manifest) do <<-EOS
-      class { 'puppet_agent': package_version => '5.5.16', collection => 'puppet5', before => File['/tmp/a'] }
+      class { 'puppet_agent': package_version => '5.5.21', collection => 'puppet5', before => File['/tmp/a'] }
       file { '/tmp/a': ensure => 'present' }
       EOS
         end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -42,7 +42,7 @@ unless ENV['BEAKER_provision'] == 'no'
   master['puppetservice'] = 'puppetserver'
   master['puppetserver-confdir'] = '/etc/puppetlabs/puppetserver/conf.d'
   master['type'] = 'aio'
-  install_puppet_agent_on master, {:version => ENV['PUPPET_CLIENT_VERSION'] || "5.5.14", :puppet_collection => 'puppet5'}
+  install_puppet_agent_on master, {:version => ENV['PUPPET_CLIENT_VERSION'] || "5.5.16", :puppet_collection => 'puppet5'}
 
   install_modules_on master
 
@@ -127,7 +127,7 @@ def setup_puppet_on(host, opts = {})
 
   puts "Setup aio puppet on #{host}"
   configure_type_defaults_on host
-  install_puppet_agent_on host, {:version => ENV['PUPPET_CLIENT_VERSION'] || '5.5.14', :puppet_collection => 'puppet5'}
+  install_puppet_agent_on host, {:version => ENV['PUPPET_CLIENT_VERSION'] || '5.5.16', :puppet_collection => 'puppet5'}
 
   puppet_opts = agent_opts(master.to_s)
   if host['platform'] =~ /windows/i

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -202,8 +202,11 @@ def teardown_puppet_on(host)
       clean_repo = "include apt\napt::source { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"
     when /fedora|el|centos/
       clean_repo = "yumrepo { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"
-    when /sles|osx/
+    when /osx/
       ensure_type = 'absent'
+    when /sles/
+      ensure_type = 'absent'
+      clean_repo = "file { '/etc/zypp/repos.d/pc_repo.repo': ensure => absent, notify => Package['puppet-agent'] }"
     else
       logger.notify("Not sure how to remove repos on #{host['platform']}")
       clean_repo = ''


### PR DESCRIPTION
The first release that included support for `Fedora 30` was Puppet Agent version `5.5.16`. Before this commit, the tests were using `5.5.14`.

Test teardown for SLES wasn't removing `pc_repo.repo`, causing unwanted Puppet Agent version installations.
