### PR TITLE
(maint) Fix commits rake task and speed up unit tests run on Windows GitHub Actions

### DIFF
--- a/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
@@ -10,7 +10,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }} 
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2019' ]
+        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
         puppet_version: [ 5, 6, 7 ]
         include:
           - puppet_version: 5
@@ -28,7 +28,7 @@ jobs:
             os_type: 'macOS'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest-universal-darwin.gem'
-          - os: 'windows-2019'
+          - os: 'windows-2016'
             os_type: 'Windows'
             env_set_cmd: '$env:'
             gem_file: 'puppet-latest-x64-mingw32.gem'

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout current PR code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Install ruby version ${{ env.ruby_version }}
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2019' ]
+        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
         puppet_version: [ 5, 6, 7 ]
         include:
           - puppet_version: 5
@@ -30,7 +30,7 @@ jobs:
             os_type: 'macOS'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest-universal-darwin.gem'
-          - os: 'windows-2019'
+          - os: 'windows-2016'
             os_type: 'Windows'
             env_set_cmd: '$env:'
             gem_file: 'puppet-latest-x64-mingw32.gem'

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }} 
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2019' ]
+        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
         puppet_version: [ 5, 6 ]
         include:
           - puppet_version: 5
@@ -24,7 +24,7 @@ jobs:
             os_type: 'Linux'
           - os: 'macos-10.15'
             os_type: 'macOS'
-          - os: 'windows-2019'
+          - os: 'windows-2016'
             os_type: 'Windows'
 
     runs-on: ${{ matrix.os }}

--- a/Rakefile
+++ b/Rakefile
@@ -45,12 +45,8 @@ end
 desc "verify that commit messages match CONTRIBUTING.md requirements"
 task(:commits) do
   # This rake task looks at the summary from every commit from this branch not
-  # in the branch targeted for a PR. This is accomplished by using the
-  # TRAVIS_COMMIT_RANGE environment variable, which is present in travis CI and
-  # populated with the range of commits the PR contains. If not available, this
-  # falls back to `master..HEAD` as a next best bet as `master` is unlikely to
-  # ever be absent.
-  commit_range = ENV['TRAVIS_COMMIT_RANGE'].nil? ? 'master..HEAD' : ENV['TRAVIS_COMMIT_RANGE'].sub(/\.\.\./, '..')
+  # in the branch targeted for a PR.
+  commit_range = 'HEAD^..HEAD'
   puts "Checking commits #{commit_range}"
   %x{git log --no-merges --pretty=%s #{commit_range}}.each_line do |commit_summary|
     # This regex tests for the currently supported commit summary tokens.


### PR DESCRIPTION
The `commits` rake task was failing due to the recent branch renaming (master->main) and the GitHub Actions Static Code Analysis job was fetching only the HEAD commit.

Unit tests seem to be running much faster on `Windows 2016` with `GitHub Actions` than `Windows 2019`.