### PR TITLE
(MODULES-10850) determine PSScriptRoot if it does not exist

### DIFF
--- a/files/install_puppet.ps1
+++ b/files/install_puppet.ps1
@@ -46,6 +46,8 @@ param(
   [Int32] $WaitForPXPAgentExit=120000
 )
 
+# $PSScript is only available in Powershell >= 3.
+if(!$PSScriptRoot){ $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent }
 . "$PSScriptRoot\helpers.ps1"
 
 # Find-InstallDir, Move-PuppetresDLL and Reset-PuppetresDLL serve as a workaround for older

--- a/files/prerequisites_check.ps1
+++ b/files/prerequisites_check.ps1
@@ -17,6 +17,8 @@ param (
     [String] $Logfile
 )
 
+# $PSScript is only available in Powershell >= 3.
+if(!$PSScriptRoot){ $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent }
 . "$PSScriptRoot\helpers.ps1"
 
 Write-Log "Checking puppet-agent.msi version and expected puppet-agent version.." $Logfile


### PR DESCRIPTION
$PSScriptRoot does not exist in PowerShell versions prior to 3.
This PR determines if this variable exists and if it does not, it sets the value