### PR TITLE
(MODULES-10851) Fix Windows nightly prerequisites check

### DIFF
--- a/files/prerequisites_check.ps1
+++ b/files/prerequisites_check.ps1
@@ -22,13 +22,20 @@ if(!$PSScriptRoot){ $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Par
 . "$PSScriptRoot\helpers.ps1"
 
 Write-Log "Checking puppet-agent.msi version and expected puppet-agent version.." $Logfile
-try{
+try {
   if (!(Test-Path $Msi.FullName)) {
     Write-Error "ERROR: File '${Msi.FullName}' does not exist"
     Write-Log "ERROR: File '${Msi.FullName}' does not exist" $Logfile
     throw
   }
   $Msi_version = ""
+
+  # MSI versions in dev/nightly builds are the same as released
+  # builds, so only match MAJOR.MINOR.PATCH.
+  if ($RequiredVersion -match "(\d+.\d+.\d+).\d+") {
+    $RequiredVersion = $Matches[1]
+  }
+
   try {
     $windowsInstaller = New-Object -com WindowsInstaller.Installer
     $database = $windowsInstaller.GetType().InvokeMember(


### PR DESCRIPTION
MODULES-10813 introduced a new powershell script that is executed on every Windows upgrade: `prerequisites_check.ps1`.

This script checks whether the version in the MSI matches what `$package_version` we want to install.

To install a nightly build, the user would pass something like `7.0.0.463.gf7e6640e` to `package_version`. This gets munged by the
puppet_agent module into `7.0.0.463` which is then given to the `prerequisites_check.ps1` script.

It appears that MSI packaging does not discern between released builds and nightly builds, as the versions reported by the MSI package are always of type `MAJOR.MINOR.PATCH`, so the script would compare `7.0.0` with `7.0.0.463`.

Change the script to always strip the commit number from the version when comparing.