### PR TITLE
(MODULES-10873) Add support for puppet7 collection

### DIFF
--- a/.github/workflows/task_acceptance_tests.yaml
+++ b/.github/workflows/task_acceptance_tests.yaml
@@ -15,7 +15,7 @@ jobs:
         os: [ 'centos-7', 'ubuntu-18.04' ]
 
     env:
-      ruby_version: 2.4
+      ruby_version: 2.5
       GEM_BOLT: true
       BEAKER_debug: true
       BEAKER_set: docker/${{ matrix.os }}

--- a/README.markdown
+++ b/README.markdown
@@ -152,7 +152,7 @@ The architecture version you wish to install. Defaults to `$::facts['architectur
 
 ##### `collection`
 
-The Puppet Collection to track, should be one of `puppet5` or `puppet6`.  Puppet collections contain the latest agents included in the collection's series, so `puppet5` will pull in the most recent Puppet 5 release (for example: 5.5.10) as also will `puppet6` for Puppet 6 (for example: 6.3.0).  **This parameter is required for installations not connected to Puppet Enterprise**
+The Puppet Collection to track, should be one of `puppet5`, `puppet6` or `puppet7`.  Puppet collections contain the latest agents included in the collection's series, so `puppet5` will pull in the most recent Puppet 5 release (for example: 5.5.10) as also will `puppet6` for Puppet 6 (for example: 6.3.0).  **This parameter is required for installations not connected to Puppet Enterprise**
 ``` puppet
   collection => 'puppet6'
 ```

--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -57,7 +57,7 @@ It also installs this module (from your local checkout) and its dependencies.
 The versions of puppet-agent and puppetserver installed on the master during
 the pre-suite can be controlled in two ways:
 
-- set `MASTER_COLLECTION` to 'pc1' (for puppet 4), 'puppet5', or 'puppet6' to
+- set `MASTER_COLLECTION` to 'pc1' (for puppet 4), 'puppet5', 'puppet6', 'puppet7' to
   install the latest releases from those streams, or
 - set `MASTER_PACKAGE_VERSION` to a specific version of puppet-agent (like
   '5.5.10') to install that agent package and a compatible puppetserver

--- a/acceptance/helpers.rb
+++ b/acceptance/helpers.rb
@@ -55,7 +55,7 @@ module Beaker
       # end
       #
       # test_name 'an agent upgrade test' do
-      #   require_master_collection max: 'puppet6'
+      #   require_master_collection max: 'puppet7'
       # end
       #
       # The first restriction will only run the test if the master's puppetserver is from

--- a/docker/bin/helpers/run-upgrade.sh
+++ b/docker/bin/helpers/run-upgrade.sh
@@ -19,11 +19,14 @@ case $puppet_major in
 6)
     to_collection=puppet6
     ;;
+7)
+    to_collection=puppet7
+    ;;
 *)
     echo "Invalid version supplied" 1>&2
     exit 1
 esac
-FACTER_to_version=${1:-6.2.0} FACTER_to_collection=${to_collection} /opt/puppetlabs/puppet/bin/puppet apply --debug --modulepath /tmp/modules /tmp/upgrade.pp
+FACTER_to_version=${1:-6.2.0} FACTER_to_collection=${to_collection} /opt/puppetlabs/puppet/bin/puppet apply --debug --trace --modulepath /tmp/modules /tmp/upgrade.pp
 # Make e.g. `puppet --version` work out of the box.
 PATH=/opt/puppetlabs/bin:$PATH \
     read -p "Explore the upgraded container? [y/N]: " choice && \

--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -43,13 +43,17 @@ RUN if [[ ${before} == 1.* ]]; then \
         wget -O puppet-pc1.rpm http://yum.puppet.com/puppetlabs-release-pc1-el-7.noarch.rpm && \
         rpm -i puppet-pc1.rpm; \
     elif [[ ${before} == 5.* ]]; then \
-        echo Installing PC1 repo; \
+        echo Installing puppet5 repo; \
         wget -O puppet5.rpm http://yum.puppet.com/puppet5-release-el-7.noarch.rpm && \
         rpm -i puppet5.rpm; \
     elif [[ ${before} == 6.* ]]; then \
-        echo Installing PC1 repo; \
+        echo Installing puppet6 repo; \
         wget -O puppet6.rpm http://yum.puppet.com/puppet6-release-el-7.noarch.rpm && \
         rpm -i puppet6.rpm; \
+    elif [[ ${before} == 7.* ]]; then \
+        echo Installing puppet7 repo; \
+        wget -O puppet7.rpm http://yum.puppet.com/puppet7-release-el-7.noarch.rpm && \
+        rpm -i puppet7.rpm; \
     else echo no; \
     fi
 

--- a/docker/centos/Dockerfile.versions
+++ b/docker/centos/Dockerfile.versions
@@ -5,13 +5,15 @@ RUN  yum update -y \
   && yum install -y wget git \
   && yum clean all
 
-# Install several repos: PC1 (puppet 4), puppet 5, and puppet 6.
+# Install several repos: PC1 (puppet 4), puppet 5, puppet 6, and puppet7.
 RUN wget -O puppet-pc1.rpm http://yum.puppet.com/puppetlabs-release-pc1-el-7.noarch.rpm && \
     rpm -i puppet-pc1.rpm --force --replacefiles && \
     wget -O puppet5.rpm http://yum.puppet.com/puppet5-release-el-7.noarch.rpm && \
     rpm -i puppet5.rpm --force --replacefiles && \
     wget -O puppet6.rpm http://yum.puppet.com/puppet6-release-el-7.noarch.rpm && \
-    rpm -i puppet6.rpm --force --replacefiles --nodeps
+    rpm -i puppet6.rpm --force --replacefiles --nodeps && \
+    wget -O puppet7.rpm http://yum.puppet.com/puppet7-release-el-7.noarch.rpm && \
+    rpm -i puppet7.rpm --force --replacefiles --nodeps
 
 # Print out available package versions for puppet-agent. If a specific version
 # is desired, pass that in with e.g. `--build-arg before=1.1.1`

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -40,7 +40,7 @@ COPY $0 /tmp/Dockerfile
 ARG before=1.10.14
 LABEL before=${before}
 
-# Install proper FROM repo: PC1 (puppet 4), puppet 5, or puppet 6.
+# Install proper FROM repo: PC1 (puppet 4), puppet 5, puppet 6, or puppet7.
 RUN if (echo "$before" | grep -Eq  ^1\..*$) ; then \
         echo Installing PC1 repo; \
         wget -O puppet-pc1.deb http://apt.puppetlabs.com/puppetlabs-release-pc1-xenial.deb && \
@@ -53,6 +53,10 @@ RUN if (echo "$before" | grep -Eq  ^1\..*$) ; then \
         echo Installing puppet6 repo; \
         wget -O puppet6.deb http://apt.puppetlabs.com/puppet6-release-xenial.deb && \
         dpkg -i puppet6.deb; \
+    elif (echo "$before" | grep -Eq  ^7\..*$) ; then \
+        echo Installing puppet7 repo; \
+        wget -O puppet7.deb http://apt.puppetlabs.com/puppet7-release-xenial.deb && \
+        dpkg -i puppet7.deb; \
     else echo no; \
     fi
 

--- a/docker/ubuntu/Dockerfile.versions
+++ b/docker/ubuntu/Dockerfile.versions
@@ -15,6 +15,8 @@ RUN wget -O puppet-pc1.deb http://apt.puppetlabs.com/puppetlabs-release-pc1-xeni
     dpkg -i --force-conflicts puppet5.deb && \
     wget -O puppet6.deb http://apt.puppetlabs.com/puppet6-release-xenial.deb && \
     dpkg -i --force-conflicts puppet6.deb && \
+    wget -O puppet7.deb http://apt.puppetlabs.com/puppet7-release-xenial.deb && \
+    dpkg -i --force-conflicts puppet7.deb && \
     apt-get update
 
 # Print out available package versions for puppet-agent. If a specific version

--- a/manifests/install/solaris.pp
+++ b/manifests/install/solaris.pp
@@ -16,7 +16,7 @@ class puppet_agent::install::solaris(
     # The following are expected to be available in the solaris_install.sh.erb template:
     $adminfile = '/opt/puppetlabs/packages/solaris-noask'
     $sourcefile = "/opt/puppetlabs/packages/${_unzipped_package_name}"
-    # Starting with puppet6 collections we no longer carry the mcollective service
+    # Starting with puppet6 and up collections we no longer carry the mcollective service
     if $::puppet_agent::collection != 'PC1' and $::puppet_agent::collection != 'puppet5' {
       $service_names = delete($::puppet_agent::service_names, 'mcollective')
     } else {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,7 +6,7 @@
 class puppet_agent::service{
   assert_private()
 
-  # Starting with puppet6 collections we no longer carry the mcollective service
+  # Starting with puppet6 and up collections we no longer carry the mcollective service
   if versioncmp("${::clientversion}", '6.0.0') >= 0 {
     $_service_names = delete($::puppet_agent::service_names, 'mcollective')
   } else {

--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -153,8 +153,8 @@ describe 'install task' do
         expect(output).to match(%r{ensure\s+=> 'stopped'})
       end
 
-      #Upgrade from puppet6 to puppet7 nightly
-      results = run_task('puppet_agent::install', 'target', { 'collection' => 'puppet7-nightly', 'version' => 'latest' })
+      #Upgrade from puppet6 to puppet7
+      results = run_task('puppet_agent::install', 'target', { 'collection' => 'puppet7', 'version' => 'latest' })
       results.each do |res|
         expect(res).to include('status' => 'success')
       end

--- a/tasks/install.json
+++ b/tasks/install.json
@@ -7,7 +7,7 @@
     },
     "collection": {
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
-      "type": "Optional[Enum[puppet5, puppet6, puppet, puppet5-nightly, puppet6-nightly, puppet7-nightly, puppet-nightly]]"
+      "type": "Optional[Enum[puppet5, puppet6, puppet7, puppet, puppet5-nightly, puppet6-nightly, puppet7-nightly, puppet-nightly]]"
     },
     "yum_source": {
       "description": "The source location to find yum repos (defaults to yum.puppet.com)",

--- a/tasks/install_powershell.json
+++ b/tasks/install_powershell.json
@@ -8,7 +8,7 @@
     },
     "collection": {
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
-      "type": "Optional[Enum[puppet5, puppet6, puppet, puppet5-nightly, puppet6-nightly, puppet7-nightly, puppet-nightly]]"
+      "type": "Optional[Enum[puppet5, puppet6, puppet7, puppet, puppet5-nightly, puppet6-nightly, puppet7-nightly, puppet-nightly]]"
     },
     "yum_source": {
       "description": "The source location to find yum repos (defaults to yum.puppet.com)",

--- a/tasks/install_shell.json
+++ b/tasks/install_shell.json
@@ -9,7 +9,7 @@
     },
     "collection": {
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
-      "type": "Optional[Enum[puppet5, puppet6, puppet, puppet5-nightly, puppet6-nightly, puppet7-nightly, puppet-nightly]]"
+      "type": "Optional[Enum[puppet5, puppet6, puppet7, puppet, puppet5-nightly, puppet6-nightly, puppet7-nightly, puppet-nightly]]"
     },
     "yum_source": {
       "description": "The source location to find yum repos (defaults to yum.puppet.com)",

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -39,11 +39,14 @@ exists() {
 assert_unmodified_apt_config() {
   puppet_list=/etc/apt/sources.list.d/puppet.list
   puppet6_list=/etc/apt/sources.list.d/puppet6.list
+  puppet7_list=/etc/apt/sources.list.d/puppet7.list
 
   if [[ -f $puppet_list ]]; then
     list_file=puppet_list
   elif [[ -f $puppet6_list ]]; then
     list_file=puppet6_list
+  elif [[ -f $puppet7_list ]]; then
+    list_file=puppet7_list
   fi
 
   # If puppet.list exists, get its md5sum on disk and its md5sum from the puppet-release package


### PR DESCRIPTION
This makes it possible to install puppet-agent from the puppet7 collection,
while keeping the current behavior of defaulting to puppet6.

Bump the github action to ruby 2.5 as puppet7 doesn't support earlier versions.

Add `--trace` argument to puppet apply run that performs the upgrade.