### PR TITLE
(MODULES-10879) Implement configuration management

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -58,7 +58,7 @@
 
 ## Overview
 
-A module for upgrading Puppet agents. Supports upgrading from Puppet 4 puppet-agent packages to later versions including Puppet 4, Puppet 5, and Puppet 6.
+A module for installing, running, upgrading, and managing the configuration of Puppet agents. Supports upgrading from Puppet 4 puppet-agent packages to later versions including Puppet 4, Puppet 5, and Puppet 6.
 
 Previous releases of this module, now unsupported, upgraded agents from later versions of Puppet 3 to Puppet 4.
 
@@ -67,6 +67,8 @@ Previous releases of this module, now unsupported, upgraded agents from later ve
 The puppet_agent module installs the appropriate official Puppet package repository (on systems that support repositories); migrates configuration required by Puppet to new locations used by puppet-agent; and installs the puppet-agent package, removing the previous Puppet installation.
 
 If a package_version parameter is provided, it will ensure that puppet-agent version is installed. The package_version parameter is required to perform upgrades starting from a puppet-agent package, also this parameter can be set to "auto", ensuring that agent version matches the version on the master without having to manually update package_version after upgrading the master(s).
+
+If a config parameter is provided, it will manage the defined agent configuration settings.
 
 ## Setup
 

--- a/README.markdown
+++ b/README.markdown
@@ -311,6 +311,17 @@ This is only applicable for Windows operating systems and pertains to /files/ins
   wait_for_pxp_agent_exit => 480000
 ```
 
+#### `config`
+
+An array of configuration data to enforce. Each configuration data item must be a Puppet\_agent::Config hash, which has keys for puppet.conf section, setting, and value.  This parameter is constrained to managing only a predetermined set of configuration settings. E.g. runinterval. The optional "ensure" key in a Puppet\_agent::Config hash can be used to ensure a setting is absent. In the example below, the runinterval setting in the main section is set to 1 hour, and a local environment setting is ensured absent.
+
+``` puppet
+  config => [{section => main, setting => runinterval, value => '1h'},
+             {section => main, setting => environment, ensure => absent}]
+```
+
+Valid agent settings are defined by the [`Puppet_agent::Config_setting`](types/config_setting.pp) type alias.
+
 ### Plans
 
 #### `puppet_agent::run`

--- a/manifests/configure.pp
+++ b/manifests/configure.pp
@@ -1,0 +1,19 @@
+class puppet_agent::configure {
+  assert_private()
+
+  $puppet_agent::config.each |$item| {
+    $ensure = $item['ensure'] ? {
+      undef   => present,
+      default => $item['ensure'],
+    }
+
+    ini_setting { "puppet-${item['section']}-${item['setting']}":
+      ensure  => $ensure,
+      section => $item['section'],
+      setting => $item['setting'],
+      value   => $item['value'],
+      path    => $puppet_agent::params::config,
+    }
+  }
+
+}

--- a/spec/classes/puppet_agent_configure_spec.rb
+++ b/spec/classes/puppet_agent_configure_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'puppet_agent::configure' do
+  let(:pre_condition) do
+    [ 'function assert_private() { }',
+      'class puppet_agent::params { $config = "/etc/puppetlabs/puppet/puppet.conf" }',
+      'include puppet_agent::params',
+      'include puppet_agent',
+    ]
+  end
+
+  context 'with empty config input' do
+    let(:pre_condition) do
+      [ super(),
+        'class puppet_agent { $config = [ ] }',
+      ]
+    end
+
+    it { is_expected.to compile }
+  end
+
+  context 'with settings input' do
+    let(:pre_condition) do
+      [ super(),
+        'class puppet_agent { $config = [{ "section" => "agent",
+                                           "setting" => "runinterval",
+                                           "value"   => "30m",
+                                           "ensure"  => "present" }] }',
+      ]
+    end
+
+    it { is_expected.to contain_ini_setting('puppet-agent-runinterval')
+                    .with({'section' => 'agent',
+                           'setting' => 'runinterval',
+                           'value'   => '30m',
+                           'ensure'  => 'present'}) }
+  end
+end

--- a/spec/classes/puppet_agent_configure_spec.rb
+++ b/spec/classes/puppet_agent_configure_spec.rb
@@ -6,29 +6,33 @@ describe 'puppet_agent::configure' do
   let(:pre_condition) do
     [ 'function assert_private() { }',
       'class puppet_agent::params { $config = "/etc/puppetlabs/puppet/puppet.conf" }',
+      'class puppet_agent { $config = $::test_config }',
       'include puppet_agent::params',
       'include puppet_agent',
     ]
   end
 
   context 'with empty config input' do
-    let(:pre_condition) do
-      [ super(),
-        'class puppet_agent { $config = [ ] }',
-      ]
+    let(:node_params) do
+      { 'test_config' => [ ] }
     end
 
     it { is_expected.to compile }
   end
 
   context 'with settings input' do
-    let(:pre_condition) do
-      [ super(),
-        'class puppet_agent { $config = [{ "section" => "agent",
-                                           "setting" => "runinterval",
-                                           "value"   => "30m",
-                                           "ensure"  => "present" }] }',
-      ]
+    let(:node_params) do
+      # Ensure this value matches something that's tested for in
+      # spec/type_aliases/config_spec.rb. It can't be checked here directly
+      # because loading the Puppet_agent::Config type alias would cause
+      # conflicts with our mocking of the puppet_agent class.
+      { 'test_config' => [{ "section" => "agent",
+                            "setting" => "runinterval",
+                            "value"   => "30m",
+                            "ensure"  => "present" },
+                          { "section" => "agent",
+                            "setting" => "environment",
+                            "ensure"  => "absent"}]}
     end
 
     it { is_expected.to contain_ini_setting('puppet-agent-runinterval')
@@ -36,5 +40,9 @@ describe 'puppet_agent::configure' do
                            'setting' => 'runinterval',
                            'value'   => '30m',
                            'ensure'  => 'present'}) }
+    it { is_expected.to contain_ini_setting('puppet-agent-environment')
+                    .with({'section' => 'agent',
+                           'setting' => 'environment',
+                           'ensure'  => 'absent'}) }
   end
 end

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -69,6 +69,7 @@ describe 'puppet_agent' do
             it { expect { catalogue }.not_to raise_error }
             it { is_expected.to contain_class('puppet_agent::prepare').with_package_version(version) }
             it { is_expected.to contain_class('puppet_agent::install').with_package_version(version) }
+            it { is_expected.to contain_class('puppet_agent::configure').that_requires('Class[puppet_agent::install]') }
           end
         end
       end
@@ -321,7 +322,7 @@ describe 'puppet_agent' do
 
             unless os =~ %r{windows}
               if os !~ %r{sles|solaris|aix}
-                it { is_expected.to contain_class('puppet_agent::service').that_requires('Class[puppet_agent::install]') }
+                it { is_expected.to contain_class('puppet_agent::service').that_requires('Class[puppet_agent::configure]') }
               end
             end
 

--- a/spec/type_aliases/config_spec.rb
+++ b/spec/type_aliases/config_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe 'Puppet_agent::Config' do
+  it { is_expected.to allow_values({ "section" => "agent",
+                                     "setting" => "runinterval",
+                                     "value"   => "30m",
+                                     "ensure"  => "present" },
+                                   { "section" => "agent",
+                                     "setting" => "environment",
+                                     "ensure"  => "absent"})}
+end

--- a/types/config.pp
+++ b/types/config.pp
@@ -1,0 +1,7 @@
+type Puppet_agent::Config = Variant[Struct[{section          => Enum[main, server, agent, user, master],
+                                            setting          => Puppet_agent::Config_setting,
+                                            value            => String,
+                                            Optional[ensure] => Enum[present, absent]}],
+                                    Struct[{section          => Enum[main, server, agent, user, master],
+                                            setting          => Puppet_agent::Config_setting,
+                                            Optional[ensure] => Enum[absent]}]]

--- a/types/config_setting.pp
+++ b/types/config_setting.pp
@@ -1,0 +1,13 @@
+# An enumerated list of settings which are permitted to be managed by this
+# module.
+type Puppet_agent::Config_setting = Enum[
+  environment,
+  http_connect_timeout,
+  http_read_timeout,
+  log_level,
+  runinterval,
+  show_diff,
+  splay,
+  splaylimit,
+  usecacheonfailure,
+]


### PR DESCRIPTION
I'm proposing this feature as a result of not being able to find a clear, supportable, and documented way to advise a PE customer how to manage agent configuration.

This commit introduces a parameter that can be used to manage agent configuration. This parameter is restricted to managing only specifically permitted settings. Initially, only runinterval.

Without this functionality, users can only manage agent configuration by independently writing their own ini_setting resources in their own code. This is inefficient and error-prone compared to supporting basic configuration management of the agent in the official Puppet agent supported module.

By supporting basic configuration management of settings in this module it will be easier and safer to configure the Puppet agent, as well as becoming easier to document a correct and maintainable way of doing so.