### PR TITLE
(maint) update apt to 7.4.2 for unit tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -8,7 +8,7 @@ fixtures:
       ref: "2.4.0"
     apt:
       repo: "puppetlabs/apt"
-      ref: "7.0.1"
+      ref: "7.4.2"
     translate:
       repo: "puppetlabs/translate"
       ref: "1.2.0"


### PR DESCRIPTION
Part of: tickets.puppetlabs.com/browse/PUP-10823

Facter 4 changed how the code from custom facts is evaluated,
this introduced a couple of changes needed for apt module,
more details here: puppetlabs/puppetlabs-apt@6786d50

Bump apt module to 7.4.2 to resolve performance issues when
running unit tests on Linux

This fix reduces the unit tests run on puppet6/ruby 2.5 from 55 minutes to 10 minutes