### PR TITLE
Add report parameter to bolt puppet_agent::run plan/task

### DIFF
--- a/plans/run.pp
+++ b/plans/run.pp
@@ -4,7 +4,7 @@
 # @param report Whether to include the last run report in the task output.
 plan puppet_agent::run (
   TargetSpec $targets,
-  Optional[Boolean] $report = true,
+  Boolean $report = true,
 ) {
   # Check which targets have the agent installed by checking
   # the version of the agent. No point in trying to run the

--- a/plans/run.pp
+++ b/plans/run.pp
@@ -1,8 +1,10 @@
 # Starts a Puppet agent run on the specified targets.
 # Note: This plan may cause issues when run in Puppet Enterprise.
 # @param targets The targets to start a Puppet agent run on.
+# @param report Whether to include the last run report in the task output.
 plan puppet_agent::run (
-  TargetSpec $targets
+  TargetSpec $targets,
+  Optional[Boolean] $report = true,
 ) {
   # Check which targets have the agent installed by checking
   # the version of the agent. No point in trying to run the
@@ -57,6 +59,7 @@ plan puppet_agent::run (
     'puppet_agent::run',
     $agent_results.targets,
     'Run Puppet agent',
+    'report' => $report,
     '_catch_errors' => true
   )
 

--- a/tasks/run.json
+++ b/tasks/run.json
@@ -3,7 +3,7 @@
   "parameters": {
     "report": {
       "description": "Whether to include the last run report in the output.",
-      "type": "Optional[Boolean]",
+      "type": "Boolean",
       "default": true
     }
   },

--- a/tasks/run.json
+++ b/tasks/run.json
@@ -1,5 +1,11 @@
 {
   "description": "Run the Puppet agent. This task may cause problems if run in Puppet Enterprise.",
-  "parameters": {},
+  "parameters": {
+    "report": {
+      "description": "Whether to include the last run report in the output.",
+      "type": "Optional[Boolean]",
+      "default": true
+    }
+  },
   "private": true
 }

--- a/tasks/run.rb
+++ b/tasks/run.rb
@@ -29,6 +29,10 @@ module PuppetAgent
       File.exist?(lockfile)
     end
 
+    def include_report?
+      JSON.parse(STDIN.read)['report']
+    end
+
     # Returns the path to the Puppet agent executable
     def puppet_bin
       @puppet_bin ||= if Puppet.features.microsoft_windows?
@@ -141,11 +145,12 @@ module PuppetAgent
           obj.tag = nil if obj.respond_to?(:tag=)
         end
 
-        {
-          'report'   => report.to_ruby,
+        run_report = {
           'exitcode' => run_result.exitstatus,
           '_output'  => run_result
         }
+        run_report.merge!('report' => report.to_ruby) if include_report?
+        run_report
       rescue => e
         return error_result(
           'puppet_agent/invalid-last-run-report-error',

--- a/tasks/run.rb
+++ b/tasks/run.rb
@@ -29,8 +29,8 @@ module PuppetAgent
       File.exist?(lockfile)
     end
 
-    def include_report?
-      JSON.parse(STDIN.read)['report']
+    def include_report?(params)
+      params['report']
     end
 
     # Returns the path to the Puppet agent executable
@@ -122,7 +122,7 @@ module PuppetAgent
     end
 
     # Loads the last run report and generates a result from it.
-    def get_result_from_report(last_run_report, run_result, start_time)
+    def get_result_from_report(last_run_report, run_result, start_time, params)
       unless File.exist?(last_run_report)
         return error_result(
           'puppet_agent/no-last-run-report-error',
@@ -149,7 +149,7 @@ module PuppetAgent
           'exitcode' => run_result.exitstatus,
           '_output'  => run_result
         }
-        run_report.merge!('report' => report.to_ruby) if include_report?
+        run_report.merge!('report' => report.to_ruby) if include_report?(params)
         run_report
       rescue => e
         return error_result(
@@ -212,6 +212,7 @@ module PuppetAgent
         )
       end
 
+      params = JSON.parse(STDIN.read)
       puppet_config   = config_print('lastrunreport', 'agent_disabled_lockfile', 'agent_catalog_run_lockfile')
       last_run_report = puppet_config['lastrunreport']
 
@@ -277,7 +278,7 @@ module PuppetAgent
         end
       end
 
-      get_result_from_report(last_run_report, run_result, start_time)
+      get_result_from_report(last_run_report, run_result, start_time, params)
     end
   end
 end


### PR DESCRIPTION
This PR adds a boolean parameter `report` to the `puppet_agent::run` plan and task. This parameter can be used to either include (default `true` for backwards compatibility) or exclude (`false`) the last_run_report in the `puppet_agent::run` task output.