### PR TITLE
(MODULES-10909) Commands retry on network connectivity failures 

### DIFF
--- a/tasks/install.json
+++ b/tasks/install.json
@@ -32,6 +32,11 @@
     "stop_service": {
       "description": "Whether to stop the puppet agent service after install",
       "type": "Optional[Boolean]"
+    },
+    "retry": {
+      "description": "The number of retries in case of network connectivity failures",
+      "type": "Optional[Integer]",
+      "default": 5
     }
   },
   "implementations": [

--- a/tasks/install_powershell.json
+++ b/tasks/install_powershell.json
@@ -33,6 +33,11 @@
     "stop_service": {
       "description": "Whether to stop the puppet agent service after install",
       "type": "Optional[Boolean]"
+    },
+    "retry": {
+      "description": "The number of retries in case of network connectivity failures",
+      "type": "Optional[Integer]",
+      "default": 5
     }
   }
 }

--- a/tasks/install_powershell.ps1
+++ b/tasks/install_powershell.ps1
@@ -4,7 +4,8 @@ Param(
   [String]$collection = 'puppet',
   [String]$windows_source = 'https://downloads.puppet.com',
   [String]$install_options = 'REINSTALLMODE="amus"',
-  [Bool]$stop_service = $False
+  [Bool]$stop_service = $False,
+  [Int]$retry = 5
 )
 # If an error is encountered, the script will stop instead of the default of "Continue"
 $ErrorActionPreference = "Stop"
@@ -104,20 +105,32 @@ $msi_dest = Join-Path ([System.IO.Path]::GetTempPath()) "puppet-agent-$arch.msi"
 $install_log = Join-Path ([System.IO.Path]::GetTempPath()) "$date_time_stamp-puppet-install.log"
 
 function DownloadPuppet {
-  Write-Verbose "Downloading the Puppet Agent for Puppet Enterprise on $env:COMPUTERNAME..."
-
+  Write-Output "Downloading the Puppet Agent installer on $env:COMPUTERNAME..."
   $webclient = New-Object system.net.webclient
 
   try {
     $webclient.DownloadFile($msi_source,$msi_dest)
   }
   catch [System.Net.WebException] {
-    # If we can't find the msi, then we may not be configured correctly
-    if($_.Exception.Response.StatusCode -eq [system.net.httpstatuscode]::NotFound) {
-        Throw "Failed to download the Puppet Agent installer: $msi_source"
+    For ($attempt_number = 1; $attempt_number -le $retry; $attempt_number++) {
+      try {
+        Write-Output "Retrying... [$attempt_number/$retry]"
+        $webclient.DownloadFile($msi_source,$msi_dest)
+        break
+      }
+      catch [System.Net.WebException] {
+        if($attempt_number -eq $retry) {
+          # If we can't find the msi, then we may not be configured correctly
+          if($_.Exception.Response.StatusCode -eq [system.net.httpstatuscode]::NotFound) {
+            Throw "Failed to download the Puppet Agent installer: $msi_source"
+          }
+
+          # Throw all other WebExceptions
+          Throw $_
+        }
+        Start-Sleep -s 1
+      }
     }
-    # Throw all other WebExceptions
-    Throw $_
   }
 }
 

--- a/tasks/install_shell.json
+++ b/tasks/install_shell.json
@@ -34,6 +34,11 @@
     "stop_service": {
       "description": "Whether to stop the puppet agent service after install",
       "type": "Optional[Boolean]"
+    },
+    "retry": {
+      "description": "The number of retries in case of network connectivity failures",
+      "type": "Optional[Integer]",
+      "default": 5
     }
   },
   "files": ["facts/tasks/bash.sh"]


### PR DESCRIPTION
Before this commit, the install tasks (`install_shell.sh` and `install_powershell.ps1`) exited at the first network connectivity failure. This change adds a retry mechanism to the `wget`, `curl`, `fetch`, `perl`, `yum`, `zypper`, `apt-get` (Linux) and `System.Net.Webclient.DownloadFile` (Windows) commands which waits one second between attempts. The number of attempts is `5` by default but can be configured via the new `retry` setting.