### PR TITLE
(MODULES-9798) Add Timeout Parameter for the Current Puppet Run

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -46,6 +46,7 @@
         - [`install_options`](#install_options)
         - [`msi_move_locked_files`](#msi_move_locked_files)
         - [`wait_for_pxp_agent_exit`](#wait_for_pxp_agent_exit)
+        - [`wait_for_puppet_run`](#wait_for_puppet_run)
     - [Plans](#plans)
       - [`puppet_agent::run`](#puppet_agentrun)
     - [Tasks](#tasks)
@@ -311,6 +312,14 @@ This is only applicable for Windows operating systems and pertains to /files/ins
 
 ``` puppet
   wait_for_pxp_agent_exit => 480000
+```
+
+#### `wait_for_puppet_run`
+
+This is only applicable for Windows operating systems and pertains to /files/install_puppet.ps1 script. This parameterizes the module to define the wait time for the current puppet agent run to end successfully. The default value is 2 minutes and the timeout value must be defined in milliseconds. Example below, 8 minutes is equal to 480000.
+
+``` puppet
+  wait_for_puppet_run => 480000
 ```
 
 #### `config`

--- a/files/install_puppet.ps1
+++ b/files/install_puppet.ps1
@@ -43,7 +43,8 @@ param(
   [AllowEmptyString()]
   [String] $InstallArgs,
   [switch] $UseLockedFilesWorkaround,
-  [Int32] $WaitForPXPAgentExit=120000
+  [Int32] $WaitForPXPAgentExit=120000,
+  [Int32] $WaitForPuppetRun=120000
 )
 
 # $PSScript is only available in Powershell >= 3.
@@ -273,7 +274,7 @@ try {
     Write-Log "Waiting for puppet to stop, PID:$PuppetPID" $Logfile
     $pup_process = Get-Process -ID $PuppetPID -ErrorAction SilentlyContinue
     if ($pup_process) {
-      if (!$pup_process.WaitForExit(120000)){
+      if (!$pup_process.WaitForExit($WaitForPuppetRun)){
         Write-Log "ERROR: Timed out waiting for puppet!" $Logfile
         throw
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,6 +89,10 @@
 #   This parameter is only applicable for Windows operating systems and pertains to the 
 #   /files/install_agent.ps1 script. This parameterizes the module to define the wait time
 #   for the PXP agent to end successfully. The default value is set 2 minutes.
+# [wait_for_puppet_run]
+#   This parameter is only applicable for Windows operating systems and pertains to the
+#   /files/install_agent.ps1 script. This parameterizes the module to define the wait time
+#   for the current puppet agent run to end successfully. The default value is set 2 minutes.
 # [config]
 #   An array of configuration data to enforce. Each configuration data item must be a
 #   Puppet_agent::Config hash, which has keys for puppet.conf section, setting, and value.
@@ -119,6 +123,7 @@ class puppet_agent (
   $skip_if_unavailable     = 'absent',
   $msi_move_locked_files   = false,
   $wait_for_pxp_agent_exit = undef,
+  $wait_for_puppet_run     = undef,
   Array[Puppet_agent::Config] $config = [],
 ) inherits ::puppet_agent::params {
 

--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -43,6 +43,12 @@ class puppet_agent::install::windows(
     $_pxp_agent_wait = undef
   }
 
+  if $::puppet_agent::wait_for_puppet_run {
+    $_puppet_run_wait = "-WaitForPuppetRun ${puppet_agent::wait_for_puppet_run}"
+  } else {
+    $_puppet_run_wait = undef
+  }
+
   $_timestamp = strftime('%Y_%m_%d-%H_%M')
   $_logfile = windows_native_path("${::env_temp_variable}/puppet-${_timestamp}-installer.log")
 
@@ -96,7 +102,8 @@ class puppet_agent::install::windows(
                           -PuppetStartType '${_agent_startup_mode}' \
                           -InstallArgs '${_install_options}' \
                           ${_move_dll_workaround} \
-                          ${_pxp_agent_wait}",
+                          ${_pxp_agent_wait} \
+                          ${_puppet_run_wait}",
     unless  => "${::system32}\\WindowsPowerShell\\v1.0\\powershell.exe \
                   -ExecutionPolicy Bypass \
                   -NoProfile \

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -267,23 +267,59 @@ RSpec.describe 'puppet_agent', tag: 'win' do
           }
         end
 
-        describe 'specify false' do
+        describe 'specify timeout value of 5 minutes' do
           let(:params) { global_params.merge(
-            {:wait_for_pxp_agent_exit => false,})
+            {:wait_for_pxp_agent_exit => 300000,})
           }
 
           it {
-            is_expected.not_to contain_exec('install_puppet.ps1').with_command(/\-WaitForPXPAgentExit/)
+            is_expected.to contain_exec('install_puppet.ps1').with_command(/\-WaitForPXPAgentExit 300000/)
+          }
+        end
+      end
+
+      context 'wait_for_puppet_run =>' do
+        describe 'default' do
+          it {
+            is_expected.not_to contain_exec('install_puppet.ps1').with_command(/\-WaitForPuppetRun/)
+          }
+        end
+
+        describe 'specify timeout of 10 minutes' do
+          let(:params) { global_params.merge(
+            {:wait_for_puppet_run => 600000,})
+          }
+
+          it {
+            is_expected.to contain_exec('install_puppet.ps1').with_command(/\-WaitForPuppetRun 600000/)
+          }
+        end
+      end
+
+      context 'wait_for_puppet_run =>' do
+        describe 'default' do
+          it {
+            is_expected.not_to contain_exec('install_puppet.ps1').with_command(/\-WaitForPuppetRun/)
+          }
+        end
+
+        describe 'specify false' do
+          let(:params) { global_params.merge(
+            {:wait_for_puppet_run => false,})
+          }
+
+          it {
+            is_expected.not_to contain_exec('install_puppet.ps1').with_command(/\-WaitForPuppetRun/)
           }
         end
 
         describe 'specify true' do
           let(:params) { global_params.merge(
-            {:wait_for_pxp_agent_exit => true,})
+            {:wait_for_puppet_run => true,})
           }
 
           it {
-            is_expected.to contain_exec('install_puppet.ps1').with_command(/\-WaitForPXPAgentExit/)
+            is_expected.to contain_exec('install_puppet.ps1').with_command(/\-WaitForPuppetRun/)
           }
         end
       end


### PR DESCRIPTION
- (Support-42796) Add ```wait_for_puppet_run``` parameter to configure the timeout value for the current puppet run.
Previously, if the puppet agent was to be upgraded but the current run took longer than 120000 ms (2 minutes) to complete, the agent upgrade script (install_puppet.ps1) would fail. This would happen even if the agent run would have otherwise completed without error.

- Fixed ```wait_for_pxp_agent_exit``` parameter tests. The parameter accepts an Int32, but the tests were passing booleans.