### PR TITLE
Fix upgrading Puppet on windows

### DIFF
--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -70,6 +70,7 @@ class puppet_agent::install::windows(
 
   exec { 'prerequisites_check.ps1':
     command => "${::system32}\\WindowsPowerShell\\v1.0\\powershell.exe \
+                  -ExecutionPolicy Bypass \
                   -NoProfile \
                   -NoLogo \
                   -NonInteractive \


### PR DESCRIPTION
Add a missing `-ExecutionPolicy bypass` to align with the other PowerShell invocations of the module and unbreak upgrading Puppet on windows.

This seems to be a regression following 9bd01ce0cacdd94ed13310f5b3ac7af5185c0c77, but I only experience the failure on freshly reinstalled windows nodes.  Older nodes seems to have a different default configuration, but it's not something that we change in our setup so I assume the change is on the Microsoft side.

After this change, new windows nodes with an old version of Puppet (7.1.0) can update to the latest version (7.3.0).