### PR TITLE
(MODULES-10945) Module spring cleaning 2021

### DIFF
--- a/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
@@ -52,6 +52,7 @@ jobs:
         run: |
           git config --global core.longpaths true
           bundle config set system 'true'
+          bundle config set --local without 'release'
           ${{ matrix.env_set_cmd }}PUPPET_GEM_VERSION=$(ruby -e 'puts /puppet\s+\((.+)\)/.match(`gem list -eld puppet`)[1]')
           bundle update --jobs 4 --retry 3
 

--- a/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
@@ -11,10 +11,8 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
-        puppet_version: [ 5, 6, 7 ]
+        puppet_version: [ 6, 7 ]
         include:
-          - puppet_version: 5
-            ruby: 2.4
           - puppet_version: 6
             ruby: 2.5
           - puppet_version: 7

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -29,6 +29,7 @@ jobs:
       - name: Prepare testing environment with bundler
         run: |
           git config --global core.longpaths true
+          bundle config set --local without 'release'
           bundle update --jobs 4 --retry 3
 
       - name: Run commits check

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Run checks
 
     env:
-      ruby_version: 2.5
+      ruby_version: 2.6
 
     runs-on: 'ubuntu-18.04'
     steps:

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -13,10 +13,8 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
-        puppet_version: [ 5, 6, 7 ]
+        puppet_version: [ 6, 7 ]
         include:
-          - puppet_version: 5
-            ruby: 2.4
           - puppet_version: 6
             ruby: 2.5
           - puppet_version: 7

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -54,6 +54,7 @@ jobs:
         run: |
           git config --global core.longpaths true
           bundle config set system 'true'
+          bundle config set --local without 'release'
           ${{ matrix.env_set_cmd }}PUPPET_GEM_VERSION=$(ruby -e 'puts /puppet\s+\((.+)\)/.match(`gem list -eld puppet`)[1]')
           bundle update --jobs 4 --retry 3
 

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
-        puppet_version: [ 5, 6 ]
+        puppet_version: [ 6, 7 ]
         include:
-          - puppet_version: 5
-            ruby: 2.4
           - puppet_version: 6
             ruby: 2.5
+          - puppet_version: 7
+            ruby: 2.7
 
           - os: 'ubuntu-18.04'
             os_type: 'Linux'

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -42,6 +42,7 @@ jobs:
       - name: Prepare testing environment with bundler
         run: |
           git config --global core.longpaths true
+          bundle config set --local without 'release'
           bundle update --jobs 4 --retry 3
 
       - name: Run unit tests

--- a/Gemfile
+++ b/Gemfile
@@ -69,14 +69,17 @@ group :system_tests do
   gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'])
   gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'])
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')
-  gem 'pdk', *location_for(ENV['PDK_GEM_VERSION'])
-  gem "puppet-blacksmith", '~> 3.4',                                             :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.7.0')
-  gem "puppet-blacksmith", '~> 6',                                               :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.7.0')
   # Bundler fails on 2.1.9 even though this group is excluded
   if ENV['GEM_BOLT']
     gem 'bolt', '~> 1.15', require: false
     gem 'beaker-task_helper', '~> 1.5.2', require: false
   end
+end
+
+group :release do
+  gem 'pdk', *location_for(ENV['PDK_GEM_VERSION'])
+  gem "puppet-blacksmith", '~> 3.4',                                             :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.7.0')
+  gem "puppet-blacksmith", '~> 6',                                               :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.7.0')
 end
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])

--- a/Gemfile
+++ b/Gemfile
@@ -27,38 +27,38 @@ minor_version = "#{ruby_version_segments[0]}.#{ruby_version_segments[1]}"
 #end
 
 group :development do
-  gem "facterdb", '~> 1.4',                                  :require => false
-  gem "mocha", '~> 1.1',                                     :require => false
-  gem "parser", '~> 2.5',                                    :require => false
-  gem "puppet-syntax", '~> 2.6',                             :require => false
-  gem "specinfra", '2.82.2',                                 :require => false
-  gem "diff-lcs", '~> 1.3',                                  :require => false
-  gem "faraday", '~> 0.17',                                  :require => false
-  gem "pry-byebug", '~> 3.8',                                :require => false
-  gem "pry", '~> 0.10',                                      :require => false
-  gem "method_source", '~> 0.8',                             :require => false
-  gem "rake", '~> 12',                                       :require => false
-  gem "parallel_tests", '>= 2.14.1', '< 2.14.3',             :require => false
-  gem "metadata-json-lint", '>= 2.0.2', '< 3.0.0',           :require => false
-  gem "rspec-puppet-facts", '~> 1.10.0',                     :require => false
-  gem "rspec_junit_formatter", '~> 0.2',                     :require => false
-  gem "rubocop", '~> 0.49.0',                                :require => false
-  gem "rubocop-rspec", '~> 1.16.0',                          :require => false
-  gem "rubocop-i18n", '~> 1.2.0',                            :require => false
-  gem "puppetlabs_spec_helper", '>= 2.9.0', '< 3.0.0',       :require => false
-  gem "puppet-module-posix-default-r#{minor_version}",       :require => false, :platforms => "ruby"
-  gem "puppet-module-win-default-r#{minor_version}",         :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
-  gem "rspec-puppet",                                        :require => true, git: "https://github.com/rodjek/rspec-puppet", tag: "v2.7.9"
-  gem 'rspec-expectations', '~> 3.9.0',                      :require => false
-  gem "json_pure", '<= 2.0.1',                               :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
-  gem "fast_gettext", '1.1.0',                               :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
-  gem "fast_gettext",                                        :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
+  gem "facterdb", '~> 1.4',                                  require: false
+  gem "mocha", '~> 1.1',                                     require: false
+  gem "parser", '~> 2.5',                                    require: false
+  gem "puppet-syntax", '~> 2.6',                             require: false
+  gem "specinfra", '2.82.2',                                 require: false
+  gem "diff-lcs", '~> 1.3',                                  require: false
+  gem "faraday", '~> 0.17',                                  require: false
+  gem "pry-byebug", '~> 3.8',                                require: false
+  gem "pry", '~> 0.10',                                      require: false
+  gem "method_source", '~> 0.8',                             require: false
+  gem "rake", '~> 12',                                       require: false
+  gem "parallel_tests", '>= 2.14.1', '< 2.14.3',             require: false
+  gem "metadata-json-lint", '>= 2.0.2', '< 3.0.0',           require: false
+  gem "rspec-puppet-facts", '~> 1.10.0',                     require: false
+  gem "rspec_junit_formatter", '~> 0.2',                     require: false
+  gem "rubocop", '~> 0.49.0',                                require: false
+  gem "rubocop-rspec", '~> 1.16.0',                          require: false
+  gem "rubocop-i18n", '~> 1.2.0',                            require: false
+  gem "puppetlabs_spec_helper", '>= 2.9.0', '< 3.0.0',       require: false
+  gem "puppet-module-posix-default-r#{minor_version}",       require: false, platforms: "ruby"
+  gem "puppet-module-win-default-r#{minor_version}",         require: false, platforms: ["mswin", "mingw", "x64_mingw"]
+  gem "rspec-puppet",                                        require: true, git: "https://github.com/rodjek/rspec-puppet", tag: "v2.7.9"
+  gem 'rspec-expectations', '~> 3.9.0',                      require: false
+  gem "json_pure", '<= 2.0.1',                               require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+  gem "fast_gettext", '1.1.0',                               require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
+  gem "fast_gettext",                                        require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
   gem "puppet-lint", '2.3.6'
 end
 
 group :system_tests do
-  gem "puppet-module-posix-system-r#{minor_version}",                            :require => false, :platforms => "ruby"
-  gem "puppet-module-win-system-r#{minor_version}",                              :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
+  gem "puppet-module-posix-system-r#{minor_version}",                            require: false, platforms: "ruby"
+  gem "puppet-module-win-system-r#{minor_version}",                              require: false, platforms: ["mswin", "mingw", "x64_mingw"]
   gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4')
   gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || ["~> 1.0", ">= 1.0.1"])
   gem "beaker-docker", '~> 0.3'
@@ -78,8 +78,8 @@ end
 
 group :release do
   gem 'pdk', *location_for(ENV['PDK_GEM_VERSION'])
-  gem "puppet-blacksmith", '~> 3.4',                                             :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.7.0')
-  gem "puppet-blacksmith", '~> 6',                                               :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.7.0')
+  gem "puppet-blacksmith", '~> 3.4',                                             require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.7.0')
+  gem "puppet-blacksmith", '~> 6',                                               require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.7.0')
 end
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])

--- a/Gemfile
+++ b/Gemfile
@@ -57,8 +57,8 @@ group :development do
 end
 
 group :system_tests do
-  gem "puppet-module-posix-system-r#{minor_version}",                            require: false, platforms: "ruby"
-  gem "puppet-module-win-system-r#{minor_version}",                              require: false, platforms: ["mswin", "mingw", "x64_mingw"]
+  gem "puppet-module-posix-system-r#{minor_version}", '~> 0.5',                  require: false, platforms: [:ruby]
+  gem "puppet-module-win-system-r#{minor_version}", '~> 0.5',                    require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4')
   gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || ["~> 1.0", ">= 1.0.1"])
   gem "beaker-docker", '~> 0.3'


### PR DESCRIPTION
Create a separate group in the `Gemfile` for `pdk` and `puppet-blacksmith` which are only used for releasing. In the workflow, avoid installing the release group.

Pin `puppet-module-posix-system` and `puppet-module-win-system` to an older version since the newer ones do not bundle some gems that we use in acceptance (i.e. `beaker-module_install_helper`), causing tests to fail.

Update the workflow that tests with released Puppet gems to also test with Puppet 7.

Bump Ruby version in the static code analysis workflow to 2.6, as 2.5 will be EOL soon.

Remove testing with Puppet 5 from the workflows since it reached EOL.