### PR TITLE
Work with Puppet 7

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -122,7 +122,7 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 5.1.0 < 7.0.0"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 5.1.0 < 8.0.0"},
     {"name":"puppetlabs-inifile","version_requirement":">= 2.4.0 < 5.0.0"},
     {"name":"puppetlabs-apt","version_requirement":">= 7.0.1 < 8.0.0"},
     {"name":"puppetlabs-facts","version_requirement":">= 0.5.0 < 2.0.0"}


### PR DESCRIPTION
This module was updated to claim support for Puppet 7, but stdlib
doesn't support Puppet 7 until it's 7.0 release. That results in errors
with Puppetfile Resolver that can't be resolved for Puppet 7
```
Puppetfile Resolver could not find compatible versions for possibility named "stdlib":
  In Puppetfile:
    puppetlabs-stdlib =7.0.0

    puppetlabs-puppet_agent =4.4.0 was resolved to Forge puppetlabs-puppet_agent-4.4.0, which depends on
      puppetlabs-stdlib >= 5.1.0 < 7.0.0Puppet
```

Adds stdlib 7 to the dependency range.