### PR TITLE
(MAINT) Bump upper bound of module dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -122,9 +122,9 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 5.1.0 < 7.0.0"},
-    {"name":"puppetlabs-inifile","version_requirement":">= 2.4.0 < 5.0.0"},
-    {"name":"puppetlabs-apt","version_requirement":">= 7.0.1 < 8.0.0"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 5.1.0 < 8.0.0"},
+    {"name":"puppetlabs-inifile","version_requirement":">= 2.4.0 < 6.0.0"},
+    {"name":"puppetlabs-apt","version_requirement":">= 7.0.1 < 9.0.0"},
     {"name":"puppetlabs-facts","version_requirement":">= 0.5.0 < 2.0.0"}
   ]
 }


### PR DESCRIPTION
Bump the upper bound of the module dependencies:
- `puppetlabs-stdlib`: `7.0.0` -> `8.0.0`
- `puppetlabs-inifile`: `5.0.0` -> `6.0.0`
- `puppetlabs-apt`: `8.0.0` -> `9.0.0`

All supported modules (including the three mentioned above) recently had a major release in order to incorporate support for Puppet 7.