### PR TITLE
(MODULES-10989) Remove puppet5 collection

### DIFF
--- a/tasks/install.json
+++ b/tasks/install.json
@@ -7,7 +7,7 @@
     },
     "collection": {
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
-      "type": "Optional[Enum[puppet5, puppet6, puppet7, puppet, puppet5-nightly, puppet6-nightly, puppet7-nightly, puppet-nightly]]"
+      "type": "Optional[Enum[puppet6, puppet7, puppet, puppet6-nightly, puppet7-nightly, puppet-nightly]]"
     },
     "yum_source": {
       "description": "The source location to find yum repos (defaults to yum.puppet.com)",

--- a/tasks/install_powershell.json
+++ b/tasks/install_powershell.json
@@ -8,7 +8,7 @@
     },
     "collection": {
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
-      "type": "Optional[Enum[puppet5, puppet6, puppet7, puppet, puppet5-nightly, puppet6-nightly, puppet7-nightly, puppet-nightly]]"
+      "type": "Optional[Enum[puppet6, puppet7, puppet, puppet6-nightly, puppet7-nightly, puppet-nightly]]"
     },
     "yum_source": {
       "description": "The source location to find yum repos (defaults to yum.puppet.com)",

--- a/tasks/install_shell.json
+++ b/tasks/install_shell.json
@@ -9,7 +9,7 @@
     },
     "collection": {
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
-      "type": "Optional[Enum[puppet5, puppet6, puppet7, puppet, puppet5-nightly, puppet6-nightly, puppet7-nightly, puppet-nightly]]"
+      "type": "Optional[Enum[puppet6, puppet7, puppet, puppet6-nightly, puppet7-nightly, puppet-nightly]]"
     },
     "yum_source": {
       "description": "The source location to find yum repos (defaults to yum.puppet.com)",


### PR DESCRIPTION
This removes the puppet5 collection from the list of available sources
for the puppet agent install task, since it's EOL. This also
updates the task spec to use puppet6 for testing and only test upgrading
from puppet 6 to puppet 7, not puppet 5 to puppet 6.