### PR TITLE
(MODULES-11048) task to remove local filebucket

### DIFF
--- a/tasks/delete_local_filebucket.json
+++ b/tasks/delete_local_filebucket.json
@@ -1,0 +1,10 @@
+{
+  "description": "Removes the local filebucket",
+  "parameters": {
+    "force": {
+      "description": "ignore nonexistent files and errors",
+      "type": "Optional[Boolean]"
+    }
+  },
+  "files": ["puppet_agent/files/rb_task_helper.rb"]
+}

--- a/tasks/delete_local_filebucket.rb
+++ b/tasks/delete_local_filebucket.rb
@@ -1,0 +1,63 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+require 'json'
+require 'puppet'
+
+params = JSON.parse(STDIN.read)
+force = params['force']
+require_relative File.join(params['_installdir'], 'puppet_agent', 'files', 'rb_task_helper.rb')
+
+module PuppetAgent
+  class DeleteLocalFilebucket
+    include PuppetAgent::RbTaskHelper
+
+    def initialize(force)
+      @force = force
+    end
+
+    def run
+      return error_result(
+        'puppet_agent/no-puppet-bin-error',
+        "Puppet executable '#{puppet_bin}' does not exist",
+      ) unless puppet_bin_present?
+
+      begin
+        path = clientbucketdir
+        if path && !path.empty? && (File.directory?(path) || force)
+          FileUtils.rm_r(Dir.glob("#{path}/*"), secure: true, force: force)
+          { "success": true }
+        else
+          error_result(
+          'puppet_agent/cannot-remove-error',
+          "clientbucketdir: '#{path}' does not exist or is not a directory"
+        )
+        end
+      rescue StandardError => e
+        error_result(
+          'puppet_agent/cannot-remove-error',
+          "#{e.class}: #{e.message}"
+        )
+      end
+    end
+
+    private
+
+    def clientbucketdir
+      options = {
+        failonfail: false,
+        override_locale: false,
+      }
+
+      command = "#{puppet_bin} config print clientbucketdir"
+      Puppet::Util::Execution.execute(command, options).strip
+    end
+
+    attr_reader :force
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  task = PuppetAgent::DeleteLocalFilebucket.new(force)
+  puts task.run
+end


### PR DESCRIPTION
This adds a task that removes the local filebucket
which was disabled by default in Puppet 7.
The location of filebucket is determined using the
`clientbucketdir` puppet config.

```
❯ bolt task show puppet_agent::delete_local_filebucket
puppet_agent::delete_local_filebucket
  Removes the local filebucket

Usage
  bolt task run puppet_agent::delete_local_filebucket --targets <targets>
  [force=<value>]

Parameters
  force  Optional[Boolean]
    ignore nonexistent files and errors
```

Tested on Windows:
```
$ ls  /cygdrive/c/ProgramData/PuppetLabs/puppet/cache/clientbucket
ls: cannot access /cygdrive/c/ProgramData/PuppetLabs/puppet/cache/clientbucket: No such file or directory

❯ bolt task run puppet_agent::delete_local_filebucket
 {"_error"=>{"msg"=>"Errno::ENOENT: No such file or directory @ apply2files - C:/ProgramData/PuppetLabs/puppet/cache/clientbucket", "kind"=>"puppet_agent/cannot-remove-error", "details"=>{}}}

❯ bolt task run puppet_agent::delete_local_filebucket force=true
   {:success=>true}

$ mkdir -p /cygdrive/c/ProgramData/PuppetLabs/puppet/cache/clientbucket

❯ bolt task run puppet_agent::delete_local_filebucket
  {:success=>true}
  
$ ls  /cygdrive/c/ProgramData/PuppetLabs/puppet/cache/clientbucket
ls: cannot access /cygdrive/c/ProgramData/PuppetLabs/puppet/cache/clientbucket: No such file or directory

```