### PR TITLE
(MODULES-10996) Fix SLES 11 PE upgrades

### DIFF
--- a/acceptance/helpers.rb
+++ b/acceptance/helpers.rb
@@ -346,8 +346,10 @@ module Beaker
           return
         end
 
-        step "(Agent) waiting for upgrade pid file to be created..." do
-          retry_on(host, "cat #{upgrade_pidfile}", {:max_retries => 5, :retry_interval => 2})
+        unless host['platform'] =~ /windows/
+          step "(Agent) waiting for upgrade pid file to be created..." do
+            retry_on(host, "cat #{upgrade_pidfile}", {:max_retries => 5, :retry_interval => 2})
+          end
         end
 
         step "(Agent) waiting for upgrade to complete..." do

--- a/acceptance/tests/test_upgrade_puppet5_to_puppet6.rb
+++ b/acceptance/tests/test_upgrade_puppet5_to_puppet6.rb
@@ -18,7 +18,8 @@ node default {
     apt_source      => 'http://nightlies.puppet.com/apt',
     yum_source      => 'http://nightlies.puppet.com/yum',
     windows_source  => 'http://nightlies.puppet.com/downloads',
-    collection      => 'puppet6-nightly'
+    collection      => 'puppet6-nightly',
+    service_names   => []
   }
 }
     PP
@@ -39,9 +40,15 @@ node default {
 
   step "Upgrade the agents from Puppet 5 to Puppet 6..." do
     agents_only.each do |agent|
-      start_puppet_service_and_wait_for_puppet_run(agent)
+      on(agent, puppet("agent -t --debug"), acceptable_exit_codes: 2)
       wait_for_installation_pid(agent)
       assert_agent_version_on(agent, latest_version.scan(/6\.\d*\.\d*\.\d*/).first)
+    end
+  end
+
+  step "Run again for idempotency" do
+    agents_only.each do |agent|
+      on(agent, puppet("agent -t --debug"), acceptable_exit_codes: 0)
     end
   end
 end

--- a/acceptance/tests/test_upgrade_puppet6_to_puppet7.rb
+++ b/acceptance/tests/test_upgrade_puppet6_to_puppet7.rb
@@ -18,7 +18,8 @@ node default {
     apt_source      => 'http://nightlies.puppet.com/apt',
     yum_source      => 'http://nightlies.puppet.com/yum',
     windows_source  => 'http://nightlies.puppet.com/downloads',
-    collection      => 'puppet7-nightly'
+    collection      => 'puppet7-nightly',
+    service_names   => []
   }
 }
     PP
@@ -39,9 +40,15 @@ node default {
 
   step "Upgrade the agents from Puppet 6 to Puppet 7..." do
     agents_only.each do |agent|
-      start_puppet_service_and_wait_for_puppet_run(agent)
+      on(agent, puppet("agent -t --debug"), acceptable_exit_codes: 2)
       wait_for_installation_pid(agent)
       assert_agent_version_on(agent, latest_version.scan(/7\.\d*\.\d*\.\d*/).first)
+    end
+  end
+
+  step "Run again for idempotency" do
+    agents_only.each do |agent|
+      on(agent, puppet("agent -t --debug"), acceptable_exit_codes: 0)
     end
   end
 end

--- a/files/rpm_gpg_import_check.sh
+++ b/files/rpm_gpg_import_check.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# shellcheck disable=SC2086
+
+ACTION=$1
+GPG_HOMEDIR=$2
+GPG_KEY_PATH=$3
+
+GPG_ARGS="--homedir $GPG_HOMEDIR --with-colons"
+GPG_BIN=$(command -v gpg || command -v gpg2)
+
+if [ -z "${GPG_BIN}" ]; then
+  echo Could not find a suitable gpg command, exiting...
+  exit 1
+fi
+
+GPG_PUBKEY=gpg-pubkey-$("${GPG_BIN}" ${GPG_ARGS} "${GPG_KEY_PATH}" 2>&1 | grep ^pub | cut -d':' -f5 | cut --characters=9-16 | tr '[:upper:]' '[:lower:]')
+
+if [ "${ACTION}" = "check" ]; then
+  # This will return 1 if there are differences between the key imported in the
+  # RPM database and the local keyfile. This means we need to purge the key and
+  # reimport it.
+  diff <(rpm -qi "${GPG_PUBKEY}" | "${GPG_BIN}" ${GPG_ARGS}) <("${GPG_BIN}" ${GPG_ARGS} "${GPG_KEY_PATH}")
+elif [ "${ACTION}" = "import" ]; then
+  (rpm -q "${GPG_PUBKEY}" && rpm -e --allmatches "${GPG_PUBKEY}") || true
+  rpm --import "${GPG_KEY_PATH}"
+fi

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -68,7 +68,7 @@ class puppet_agent::install(
       }
     } else { # RPM platforms: EL and SUSE
       $_install_options = $install_options
-      if $::puppet_agent::absolute_source {
+      if ($::puppet_agent::absolute_source) or ($::osfamily == 'suse' and $::operatingsystemmajrelease == '11' and $::puppet_agent::is_pe) {
         # absolute_source means we use rpm on EL/suse based platforms
         $_package_version = $package_version
         $_provider = 'rpm'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -41,6 +41,15 @@ class puppet_agent::install(
       }
       contain '::puppet_agent::install::windows'
     }
+  } elsif $::osfamily == 'suse' {
+    # Prevent re-running the batch install
+    if ($puppet_agent::aio_upgrade_required) or ($puppet_agent::aio_downgrade_required){
+      class { 'puppet_agent::install::suse':
+        package_version => $package_version,
+        install_options => $install_options,
+      }
+      contain '::puppet_agent::install::suse'
+    }
   } else {
     if $::operatingsystem == 'AIX' {
       # AIX installations always use RPM directly since no there isn't any default package manager for rpms
@@ -66,23 +75,19 @@ class puppet_agent::install(
         $_provider = 'apt'
         $_source = undef
       }
-    } else { # RPM platforms: EL and SUSE
+    } else { # RPM platforms: EL
       $_install_options = $install_options
-      if ($::puppet_agent::absolute_source) or ($::osfamily == 'suse' and $::operatingsystemmajrelease == '11' and $::puppet_agent::is_pe) {
-        # absolute_source means we use rpm on EL/suse based platforms
+      if $::puppet_agent::absolute_source {
+        # absolute_source means we use rpm on EL based platforms
         $_package_version = $package_version
         $_provider = 'rpm'
         # The source package should have been downloaded by puppet_agent::prepare::package to the local_packages_dir
         $_source = "${::puppet_agent::params::local_packages_dir}/${::puppet_agent::prepare::package::package_file_name}"
       } else {
-        # any other type of source means we use a package manager (yum or zypper) with no 'source' parameter in the
+        # any other type of source means we use a package manager (yum) with no 'source' parameter in the
         # package resource below
         $_package_version = $package_version
-        if $::osfamily == 'suse' {
-          $_provider = 'zypper'
-        } else {
-          $_provider = 'yum'
-        }
+        $_provider = 'yum'
         $_source = undef
       }
     }

--- a/manifests/install/suse.pp
+++ b/manifests/install/suse.pp
@@ -1,0 +1,38 @@
+# == Class puppet_agent::install::suse
+#
+# Private class called from puppet_agent class
+#
+# Manage the install process for SUSE OSes specifically
+#
+class puppet_agent::install::suse(
+  $package_version,
+  $install_options = [],
+){
+  assert_private()
+
+  if ($::puppet_agent::absolute_source) or ($::operatingsystemmajrelease == '11' and $::puppet_agent::is_pe) {
+    $_provider = 'rpm'
+    $_source = "${::puppet_agent::params::local_packages_dir}/${::puppet_agent::prepare::package::package_file_name}"
+
+    exec { 'GPG check the RPM file':
+      path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+      command   => "rpm -K ${_source}",
+      require   => File[$_source],
+      logoutput => 'on_failure',
+      notify    => Package[$::puppet_agent::package_name],
+    }
+  } else {
+    $_provider = 'zypper'
+    $_source = undef
+  }
+
+  $_aio_package_version = $package_version.match(/^\d+\.\d+\.\d+(\.\d+)?/)[0]
+  package { $::puppet_agent::package_name:
+    ensure          => $package_version,
+    install_options => $install_options,
+    provider        => $_provider,
+    source          => $_source,
+    notify          => Puppet_agent_end_run[$_aio_package_version],
+  }
+  puppet_agent_end_run { $_aio_package_version : }
+}

--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -75,17 +75,11 @@ class puppet_agent::osfamily::redhat{
       $_sslclientkey_path = undef
     }
 
-    # Fedora doesn't ship with a gpg binary, only gpg2
-    if $::operatingsystem == 'Fedora' {
-      $gpg_cmd = 'gpg2'
-    } else {
-      $gpg_cmd = 'gpg'
-    }
-
     $legacy_keyname = 'GPG-KEY-puppet'
     $legacy_gpg_path = "/etc/pki/rpm-gpg/RPM-${legacy_keyname}"
     $keyname = 'GPG-KEY-puppet-20250406'
     $gpg_path = "/etc/pki/rpm-gpg/RPM-${keyname}"
+    $gpg_homedir = '/root/.gnupg'
     $gpg_keys = "file://${legacy_gpg_path}
   file://${gpg_path}"
 
@@ -103,17 +97,6 @@ class puppet_agent::osfamily::redhat{
       source => "puppet:///modules/puppet_agent/${legacy_keyname}",
     }
 
-    # Given the path to a key, see if it is imported, if not, import it
-    $legacy_gpg_pubkey = "gpg-pubkey-$(echo $(${gpg_cmd} --with-colons ${legacy_gpg_path} 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))"
-
-    exec {  "import-${legacy_keyname}":
-      path      => '/bin:/usr/bin:/sbin:/usr/sbin',
-      command   => "rpm --import ${legacy_gpg_path}",
-      unless    => "rpm -q ${legacy_gpg_pubkey}",
-      require   => File[$legacy_gpg_path],
-      logoutput => 'on_failure',
-    }
-
     file { $gpg_path:
       ensure => present,
       owner  => 0,
@@ -122,12 +105,22 @@ class puppet_agent::osfamily::redhat{
       source => "puppet:///modules/puppet_agent/${keyname}",
     }
 
-    # Given the path to a key, see if it is imported, if not, import it
-    $gpg_pubkey = "gpg-pubkey-$(echo $(${gpg_cmd} --with-colons ${gpg_path} 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))"
-    exec {  "import-${keyname}":
+    file { "${::env_temp_variable}/rpm_gpg_import_check.sh":
+      ensure => file,
+      source => 'puppet:///modules/puppet_agent/rpm_gpg_import_check.sh',
+      mode   => '0755',
+    }
+    -> exec { "import-${legacy_keyname}":
       path      => '/bin:/usr/bin:/sbin:/usr/sbin',
-      command   => "rpm --import ${gpg_path}",
-      unless    => "rpm -q ${gpg_pubkey}",
+      command   => "${::env_temp_variable}/rpm_gpg_import_check.sh import ${gpg_homedir} ${legacy_gpg_path}",
+      unless    => "${::env_temp_variable}/rpm_gpg_import_check.sh check ${gpg_homedir} ${legacy_gpg_path}",
+      require   => File[$legacy_gpg_path],
+      logoutput => 'on_failure',
+    }
+    -> exec { "import-${keyname}":
+      path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+      command   => "${::env_temp_variable}/rpm_gpg_import_check.sh import ${gpg_homedir} ${gpg_path}",
+      unless    => "${::env_temp_variable}/rpm_gpg_import_check.sh check ${gpg_homedir} ${gpg_path}",
       require   => File[$gpg_path],
       logoutput => 'on_failure',
     }

--- a/manifests/osfamily/suse.pp
+++ b/manifests/osfamily/suse.pp
@@ -15,14 +15,36 @@ class puppet_agent::osfamily::suse{
     }
     contain puppet_agent::prepare::package
   } else {
-    if  ($::puppet_agent::is_pe and (!$::puppet_agent::use_alternate_sources)) {
+    if ($::puppet_agent::is_pe and (!$::puppet_agent::use_alternate_sources)) {
       $pe_server_version = pe_build_version()
-      if $::puppet_agent::source {
-        $source = "${::puppet_agent::source}/packages/${pe_server_version}/${::platform_tag}"
-      } elsif $::puppet_agent::alternate_pe_source {
-        $source = "${::puppet_agent::alternate_pe_source}/packages/${pe_server_version}/${::platform_tag}"
+
+      # SLES 11 in PE can no longer install agents from pe_repo
+      if $::operatingsystemmajrelease == '11' {
+        if $::puppet_agent::source {
+          $source = "${::puppet_agent::source}/packages/${pe_server_version}/${::platform_tag}"
+        } elsif $::puppet_agent::alternate_pe_source {
+          $source = "${::puppet_agent::alternate_pe_source}/packages/${pe_server_version}/${::platform_tag}"
+        } else {
+          $source = "puppet:///pe_packages/${pe_server_version}/${::platform_tag}/${::puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.sles11.${::puppet_agent::arch}.rpm"
+        }
+
+        # Nuke the repo if it exists to ensure zypper doesn't remain broken
+        file { '/etc/zypp/repos.d/pc_repo.repo':
+          ensure => absent,
+        }
+
+        class { '::puppet_agent::prepare::package':
+          source => $source,
+        }
+        contain puppet_agent::prepare::package
       } else {
-        $source = "https://${::puppet_master_server}:8140/packages/${pe_server_version}/${::platform_tag}"
+        if $::puppet_agent::source {
+          $source = "${::puppet_agent::source}/packages/${pe_server_version}/${::platform_tag}"
+        } elsif $::puppet_agent::alternate_pe_source {
+          $source = "${::puppet_agent::alternate_pe_source}/packages/${pe_server_version}/${::platform_tag}"
+        } else {
+          $source = "https://${::puppet_master_server}:8140/packages/${pe_server_version}/${::platform_tag}"
+        }
       }
     } else {
       if $::puppet_agent::collection == 'PC1' {
@@ -83,41 +105,43 @@ class puppet_agent::osfamily::suse{
           logoutput => 'on_failure',
         }
 
-        if getvar('::puppet_agent::manage_repo') == true {
-          # Set up a zypper repository by creating a .repo file which mimics a ini file
-          $repo_file = '/etc/zypp/repos.d/pc_repo.repo'
-          $repo_name = 'pc_repo'
+        unless $::operatingsystemmajrelease == '11' and $::puppet_agent::is_pe {
+          if getvar('::puppet_agent::manage_repo') == true {
+            # Set up a zypper repository by creating a .repo file which mimics a ini file
+            $repo_file = '/etc/zypp/repos.d/pc_repo.repo'
+            $repo_name = 'pc_repo'
 
-          # 'auto' versus X.Y.Z
-          $_package_version = getvar('puppet_agent::master_or_package_version')
+            # 'auto' versus X.Y.Z
+            $_package_version = getvar('puppet_agent::master_or_package_version')
 
-          # In Puppet Enterprise, agent packages are served by the same server
-          # as the master, which can be using either a self signed CA, or an external CA.
-          # Zypper has issues with validating a self signed CA, so for now disable ssl verification.
-          $repo_settings = {
-            'name'        => $repo_name,
-            'enabled'     => '1',
-            'autorefresh' => '0',
-            'baseurl'     => "${source}?ssl_verify=no",
-            'type'        => 'rpm-md',
-          }
-
-          $repo_settings.each |String $setting, String $value| {
-            ini_setting { "zypper ${repo_name} ${setting}":
-              ensure  => present,
-              path    => $repo_file,
-              section => $repo_name,
-              setting => $setting,
-              value   => $value,
-              before  => Exec["refresh-${repo_name}"],
+            # In Puppet Enterprise, agent packages are served by the same server
+            # as the master, which can be using either a self signed CA, or an external CA.
+            # Zypper has issues with validating a self signed CA, so for now disable ssl verification.
+            $repo_settings = {
+              'name'        => $repo_name,
+              'enabled'     => '1',
+              'autorefresh' => '0',
+              'baseurl'     => "${source}?ssl_verify=no",
+              'type'        => 'rpm-md',
             }
-          }
 
-          exec { "refresh-${repo_name}":
-            path      => '/bin:/usr/bin:/sbin:/usr/sbin',
-            unless    => "zypper search -r ${repo_name} -s | grep puppet-agent | awk '{print \$7}' | grep \"^${_package_version}\"",
-            command   => "zypper refresh ${repo_name}",
-            logoutput => 'on_failure',
+            $repo_settings.each |String $setting, String $value| {
+              ini_setting { "zypper ${repo_name} ${setting}":
+                ensure  => present,
+                path    => $repo_file,
+                section => $repo_name,
+                setting => $setting,
+                value   => $value,
+                before  => Exec["refresh-${repo_name}"],
+              }
+            }
+
+            exec { "refresh-${repo_name}":
+              path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+              unless    => "zypper search -r ${repo_name} -s | grep puppet-agent | awk '{print \$7}' | grep \"^${_package_version}\"",
+              command   => "zypper refresh ${repo_name}",
+              logoutput => 'on_failure',
+            }
           }
         }
       }

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -15,6 +15,7 @@ describe 'puppet_agent' do
       :architecture              => 'x64',
       :puppet_master_server      => 'master.example.vm',
       :clientcert                => 'foo.example.vm',
+      :env_temp_variable         => '/tmp',
     }
   end
 
@@ -24,39 +25,21 @@ describe 'puppet_agent' do
         super().merge(:operatingsystem  => os, :operatingsystemmajrelease => osmajor)
       end
 
-      if os == 'Fedora' then
-        it { is_expected.to contain_exec('import-GPG-KEY-puppet-20250406').with({
-          'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
-          'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406',
-          'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg2 --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
-          'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406]',
-          'logoutput' => 'on_failure',
-        }) }
+      it { is_expected.to contain_exec('import-GPG-KEY-puppet-20250406').with({
+        'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
+        'command'   => '/tmp/rpm_gpg_import_check.sh import /root/.gnupg /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406',
+        'unless'    => '/tmp/rpm_gpg_import_check.sh check /root/.gnupg /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406',
+        'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406]',
+        'logoutput' => 'on_failure',
+      }) }
 
-        it { is_expected.to contain_exec('import-GPG-KEY-puppet').with({
-          'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
-          'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet',
-          'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg2 --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
-          'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet]',
-          'logoutput' => 'on_failure',
-        }) }
-      else
-        it { is_expected.to contain_exec('import-GPG-KEY-puppet-20250406').with({
-          'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
-          'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406',
-          'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
-          'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406]',
-          'logoutput' => 'on_failure',
-        }) }
-
-        it { is_expected.to contain_exec('import-GPG-KEY-puppet').with({
-          'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
-          'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet',
-          'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
-          'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet]',
-          'logoutput' => 'on_failure',
-        }) }
-      end
+      it { is_expected.to contain_exec('import-GPG-KEY-puppet').with({
+        'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
+        'command'   => '/tmp/rpm_gpg_import_check.sh import /root/.gnupg /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet',
+        'unless'    => '/tmp/rpm_gpg_import_check.sh check /root/.gnupg /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet',
+        'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet]',
+        'logoutput' => 'on_failure',
+      }) }
 
       context 'with manage_pki_dir => true' do
         ['/etc/pki', '/etc/pki/rpm-gpg'].each do |path|

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -10,6 +10,7 @@ describe 'puppet_agent' do
     :operatingsystemmajrelease => '12',
     :architecture              => 'x86_64',
     :puppet_master_server      => 'master.example.vm',
+    :env_temp_variable         => '/tmp',
     :clientcert                => 'foo.example.vm',
   }
 
@@ -50,19 +51,24 @@ describe 'puppet_agent' do
               }
             end
 
+            it { is_expected.to contain_file('/tmp/rpm_gpg_import_check.sh').with({
+              'ensure'    => 'file',
+              'source'    => 'puppet:///modules/puppet_agent/rpm_gpg_import_check.sh',
+              'mode'      => '0755',
+            }) }
 
             it { is_expected.to contain_exec('import-GPG-KEY-puppet').with({
               'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
-              'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet',
-              'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
+              'command'   => '/tmp/rpm_gpg_import_check.sh import /root/.gnupg /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet',
+              'unless'    => '/tmp/rpm_gpg_import_check.sh check /root/.gnupg /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet',
               'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet]',
               'logoutput' => 'on_failure',
             }) }
 
             it { is_expected.to contain_exec('import-GPG-KEY-puppet-20250406').with({
               'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
-              'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406',
-              'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
+              'command'   => '/tmp/rpm_gpg_import_check.sh import /root/.gnupg /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406',
+              'unless'    => '/tmp/rpm_gpg_import_check.sh check /root/.gnupg /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406',
               'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406]',
               'logoutput' => 'on_failure',
             }) }
@@ -196,22 +202,6 @@ describe 'puppet_agent' do
               })
             end
 
-            it { is_expected.to contain_exec('import-GPG-KEY-puppet').with({
-              'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
-              'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet',
-              'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
-              'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet]',
-              'logoutput' => 'on_failure',
-            }) }
-
-            it { is_expected.to contain_exec('import-GPG-KEY-puppet-20250406').with({
-              'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
-              'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406',
-              'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
-              'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406]',
-              'logoutput' => 'on_failure',
-            }) }
-
             context 'with manage_pki_dir => true' do
               ['/etc/pki', '/etc/pki/rpm-gpg'].each do |path|
                 it { is_expected.to contain_file(path).with({
@@ -228,6 +218,12 @@ describe 'puppet_agent' do
             end
 
             it { is_expected.to contain_class("puppet_agent::osfamily::suse") }
+
+            it { is_expected.to contain_file('/tmp/rpm_gpg_import_check.sh').with({
+              'ensure'    => 'file',
+              'source'    => 'puppet:///modules/puppet_agent/rpm_gpg_import_check.sh',
+              'mode'      => '0755',
+            }) }
 
             it { is_expected.to contain_file('/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406').with({
               'ensure' => 'present',

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -2,23 +2,13 @@ require 'spec_helper'
 
 describe 'puppet_agent' do
   package_version = '1.10.100'
-  before(:each) do
-    # Need to mock the PE functions
-    Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
-      "2000.0.0"
-    end
-
-    Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
-      package_version
-    end
-  end
 
   facts = {
     :is_pe                     => true,
     :osfamily                  => 'Suse',
     :operatingsystem           => 'SLES',
     :operatingsystemmajrelease => '12',
-    :architecture              => 'x64',
+    :architecture              => 'x86_64',
     :puppet_master_server      => 'master.example.vm',
     :clientcert                => 'foo.example.vm',
   }
@@ -41,127 +31,310 @@ describe 'puppet_agent' do
     end
   end
 
-  describe 'supported environment' do
-    context "when operatingsystemmajrelease 11 or 12 is supported" do
-      ['11', '12'].each do |os_version|
-        context "when SLES #{os_version}" do
-          let(:facts) do
-            facts.merge({
-              :operatingsystemmajrelease => os_version,
-              :platform_tag              => "sles-#{os_version}-x86_64",
-            })
-          end
-
-          it { is_expected.to contain_exec('import-GPG-KEY-puppet').with({
-            'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
-            'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet',
-            'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
-            'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet]',
-            'logoutput' => 'on_failure',
-          }) }
-
-          it { is_expected.to contain_exec('import-GPG-KEY-puppet-20250406').with({
-            'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
-            'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406',
-            'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
-            'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406]',
-            'logoutput' => 'on_failure',
-          }) }
-
-          context 'with manage_pki_dir => true' do
-            ['/etc/pki', '/etc/pki/rpm-gpg'].each do |path|
-              it { is_expected.to contain_file(path).with({
-                'ensure' => 'directory',
-              }) }
+  context 'when FOSS' do
+    describe 'supported environment' do
+      context "when operatingsystemmajrelease is supported" do
+        ['11', '12', '15'].each do |os_version|
+          context "when SLES #{os_version}" do
+            let(:facts) do
+              facts.merge({
+                :operatingsystemmajrelease => os_version,
+                :is_pe => false,
+                :platform_tag              => "sles-#{os_version}-x86_64",
+              })
             end
-          end
 
-          context 'with manage_pki_dir => false' do
-            let(:params) {{ :manage_pki_dir => 'false' }}
-            ['/etc/pki', '/etc/pki/rpm-gpg'].each do |path|
-              it { is_expected.not_to contain_file(path) }
-            end
-          end
-
-          it { is_expected.to contain_class("puppet_agent::osfamily::suse") }
-
-          it { is_expected.to contain_file('/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406').with({
-            'ensure' => 'present',
-            'owner'  => '0',
-            'group'  => '0',
-            'mode'   => '0644',
-            'source' => 'puppet:///modules/puppet_agent/GPG-KEY-puppet-20250406',
-          }) }
-
-          it { is_expected.to contain_file('/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet').with({
-            'ensure' => 'present',
-            'owner'  => '0',
-            'group'  => '0',
-            'mode'   => '0644',
-            'source' => 'puppet:///modules/puppet_agent/GPG-KEY-puppet',
-          }) }
-
-          context "with manage_repo enabled" do
-            let(:params) {
+            let(:params) do
               {
-                :manage_repo => true,
-                :package_version => package_version
-              }
-            }
-
-            {
-              'name'        => 'pc_repo',
-              'enabled'     => '1',
-              'autorefresh' => '0',
-              'baseurl'     => "https://master.example.vm:8140/packages/2000.0.0/sles-#{os_version}-x86_64?ssl_verify=no",
-              'type'        => 'rpm-md',
-            }.each do |setting, value|
-              it { is_expected.to contain_ini_setting("zypper pc_repo #{setting}").with({
-                'path'    => '/etc/zypp/repos.d/pc_repo.repo',
-                'section' => 'pc_repo',
-                'setting' => setting,
-                'value'   => value,
-              }) }
-            end
-          end
-
-          context "with manage_repo disabled" do
-            let(:params) {
-              {
-                :manage_repo => false,
-                :package_version => package_version
-              }
-            }
-
-            [
-              'name',
-              'enabled',
-              'autorefresh',
-              'baseurl',
-              'type',
-            ].each do |setting|
-              it { is_expected.not_to contain_ini_setting("zypper pc_repo #{setting}") }
-            end
-          end
-
-          context "with manage_repo enabled and custom source" do
-            let(:params) {
-              {
-                :manage_repo => true,
                 :package_version => package_version,
-                :source => "https://fake-sles-source.com",
               }
-            }
-            it { is_expected.to contain_ini_setting("zypper pc_repo baseurl").with({
-              'path'    => '/etc/zypp/repos.d/pc_repo.repo',
-              'section' => 'pc_repo',
-              'setting' => 'baseurl',
-              'value'   => "https://fake-sles-source.com/packages/2000.0.0/sles-#{os_version}-x86_64?ssl_verify=no",
-            }) }
-          end
+            end
 
-          it do
-            is_expected.to contain_package('puppet-agent')
+
+            it { is_expected.to contain_exec('import-GPG-KEY-puppet').with({
+              'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
+              'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet',
+              'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
+              'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet]',
+              'logoutput' => 'on_failure',
+            }) }
+
+            it { is_expected.to contain_exec('import-GPG-KEY-puppet-20250406').with({
+              'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
+              'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406',
+              'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
+              'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406]',
+              'logoutput' => 'on_failure',
+            }) }
+
+            context 'with manage_pki_dir => true' do
+              ['/etc/pki', '/etc/pki/rpm-gpg'].each do |path|
+                it { is_expected.to contain_file(path).with({
+                  'ensure' => 'directory',
+                }) }
+              end
+            end
+
+            context 'with manage_pki_dir => false' do
+              let(:params) {{ :manage_pki_dir => 'false' }}
+              ['/etc/pki', '/etc/pki/rpm-gpg'].each do |path|
+                it { is_expected.not_to contain_file(path) }
+              end
+            end
+
+            it { is_expected.to contain_class("puppet_agent::osfamily::suse") }
+
+            it { is_expected.to contain_file('/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406').with({
+              'ensure' => 'present',
+              'owner'  => '0',
+              'group'  => '0',
+              'mode'   => '0644',
+              'source' => 'puppet:///modules/puppet_agent/GPG-KEY-puppet-20250406',
+            }) }
+
+            it { is_expected.to contain_file('/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet').with({
+              'ensure' => 'present',
+              'owner'  => '0',
+              'group'  => '0',
+              'mode'   => '0644',
+              'source' => 'puppet:///modules/puppet_agent/GPG-KEY-puppet',
+            }) }
+
+            describe 'manage_repo' do
+              context "with manage_repo enabled" do
+                let(:params) {
+                  {
+                    :manage_repo => true,
+                    :collection => 'puppet6',
+                    :package_version => package_version
+                  }
+                }
+
+                {
+                  'name'        => 'pc_repo',
+                  'enabled'     => '1',
+                  'autorefresh' => '0',
+                  'baseurl'     => "http://yum.puppet.com/puppet6/sles/#{os_version}/x86_64?ssl_verify=no",
+                  'type'        => 'rpm-md',
+                }.each do |setting, value|
+                  it { is_expected.to contain_ini_setting("zypper pc_repo #{setting}").with({
+                    'path'    => '/etc/zypp/repos.d/pc_repo.repo',
+                    'section' => 'pc_repo',
+                    'setting' => setting,
+                    'value'   => value,
+                  }) }
+                end
+              end
+
+              context "with manage_repo disabled" do
+                let(:params) {
+                  {
+                    :manage_repo => false,
+                    :collection => 'puppet6',
+                    :package_version => package_version
+                  }
+                }
+
+                [
+                  'name',
+                  'enabled',
+                  'autorefresh',
+                  'baseurl',
+                  'type',
+                ].each do |setting|
+                  it { is_expected.not_to contain_ini_setting("zypper pc_repo #{setting}") }
+                end
+              end
+
+              context "with manage_repo enabled and custom repo" do
+                let(:params) {
+                  {
+                    :manage_repo => true,
+                    :package_version => package_version,
+                    :collection => 'puppet6',
+                    :yum_source => "https://nightlies.puppet.com/yum",
+                  }
+                }
+                it { is_expected.to contain_ini_setting("zypper pc_repo baseurl").with({
+                  'path'    => '/etc/zypp/repos.d/pc_repo.repo',
+                  'section' => 'pc_repo',
+                  'setting' => 'baseurl',
+                  'value'   => "https://nightlies.puppet.com/yum/puppet6/sles/#{os_version}/x86_64?ssl_verify=no",
+                }) }
+              end
+
+              it do
+                is_expected.to contain_package('puppet-agent')
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  context 'when PE' do
+    before(:each) do
+      # Need to mock the PE functions
+      Puppet::Parser::Functions.newfunction(:pe_build_version, :type => :rvalue) do |args|
+        "2000.0.0"
+      end
+
+      Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, :type => :rvalue) do |args|
+        package_version
+      end
+    end
+
+    describe 'supported environment' do
+      context "when operatingsystemmajrelease is supported" do
+        ['11', '12', '15'].each do |os_version|
+          context "when SLES #{os_version}" do
+            let(:facts) do
+              facts.merge({
+                :operatingsystemmajrelease => os_version,
+                :platform_tag              => "sles-#{os_version}-x86_64",
+              })
+            end
+
+            it { is_expected.to contain_exec('import-GPG-KEY-puppet').with({
+              'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
+              'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet',
+              'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
+              'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet]',
+              'logoutput' => 'on_failure',
+            }) }
+
+            it { is_expected.to contain_exec('import-GPG-KEY-puppet-20250406').with({
+              'path'      => '/bin:/usr/bin:/sbin:/usr/sbin',
+              'command'   => 'rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406',
+              'unless'    => "rpm -q gpg-pubkey-$(echo $(gpg --homedir /root/.gnupg --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406 2>&1 | grep ^pub | awk -F ':' '{print \$5}' | cut --characters=9-16 | tr '[:upper:]' '[:lower:]'))",
+              'require'   => 'File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406]',
+              'logoutput' => 'on_failure',
+            }) }
+
+            context 'with manage_pki_dir => true' do
+              ['/etc/pki', '/etc/pki/rpm-gpg'].each do |path|
+                it { is_expected.to contain_file(path).with({
+                  'ensure' => 'directory',
+                }) }
+              end
+            end
+
+            context 'with manage_pki_dir => false' do
+              let(:params) {{ :manage_pki_dir => 'false' }}
+              ['/etc/pki', '/etc/pki/rpm-gpg'].each do |path|
+                it { is_expected.not_to contain_file(path) }
+              end
+            end
+
+            it { is_expected.to contain_class("puppet_agent::osfamily::suse") }
+
+            it { is_expected.to contain_file('/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406').with({
+              'ensure' => 'present',
+              'owner'  => '0',
+              'group'  => '0',
+              'mode'   => '0644',
+              'source' => 'puppet:///modules/puppet_agent/GPG-KEY-puppet-20250406',
+            }) }
+
+            it { is_expected.to contain_file('/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet').with({
+              'ensure' => 'present',
+              'owner'  => '0',
+              'group'  => '0',
+              'mode'   => '0644',
+              'source' => 'puppet:///modules/puppet_agent/GPG-KEY-puppet',
+            }) }
+
+            describe 'manage_repo', :if => os_version != '11' do
+              context "with manage_repo enabled" do
+                let(:params) {
+                  {
+                    :manage_repo => true,
+                    :package_version => package_version
+                  }
+                }
+
+                {
+                  'name'        => 'pc_repo',
+                  'enabled'     => '1',
+                  'autorefresh' => '0',
+                  'baseurl'     => "https://master.example.vm:8140/packages/2000.0.0/sles-#{os_version}-x86_64?ssl_verify=no",
+                  'type'        => 'rpm-md',
+                }.each do |setting, value|
+                  it { is_expected.to contain_ini_setting("zypper pc_repo #{setting}").with({
+                    'path'    => '/etc/zypp/repos.d/pc_repo.repo',
+                    'section' => 'pc_repo',
+                    'setting' => setting,
+                    'value'   => value,
+                  }) }
+                end
+              end
+
+              context "with manage_repo disabled" do
+                let(:params) {
+                  {
+                    :manage_repo => false,
+                    :package_version => package_version
+                  }
+                }
+
+                [
+                  'name',
+                  'enabled',
+                  'autorefresh',
+                  'baseurl',
+                  'type',
+                ].each do |setting|
+                  it { is_expected.not_to contain_ini_setting("zypper pc_repo #{setting}") }
+                end
+              end
+
+              context "with manage_repo enabled and custom source" do
+                let(:params) {
+                  {
+                    :manage_repo => true,
+                    :package_version => package_version,
+                    :source => "https://fake-sles-source.com",
+                  }
+                }
+                it { is_expected.to contain_ini_setting("zypper pc_repo baseurl").with({
+                  'path'    => '/etc/zypp/repos.d/pc_repo.repo',
+                  'section' => 'pc_repo',
+                  'setting' => 'baseurl',
+                  'value'   => "https://fake-sles-source.com/packages/2000.0.0/sles-#{os_version}-x86_64?ssl_verify=no",
+                }) }
+              end
+
+              it do
+                is_expected.to contain_package('puppet-agent')
+              end
+            end
+
+            describe 'manage_repo', :if => os_version != '11' do
+              [true, false].each do
+                let(:params) {
+                  {
+                    :manage_repo => false,
+                    :package_version => package_version
+                  }
+                }
+
+                [
+                  'name',
+                  'enabled',
+                  'autorefresh',
+                  'baseurl',
+                  'type',
+                ].each do |setting|
+                  it { is_expected.not_to contain_ini_setting("zypper pc_repo #{setting}") }
+                end
+              end
+            end
+
+            describe 'package source', :if => os_version == '11' do
+              it { is_expected.to contain_file('/etc/zypp/repos.d/pc_repo.repo').with({ 'ensure' => 'absent' }) }
+              it { is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-1.10.100-1.sles11.x86_64.rpm').with_source('puppet:///pe_packages/2000.0.0/sles-11-x86_64/puppet-agent-1.10.100-1.sles11.x86_64.rpm') }
+            end
           end
         end
       end

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -333,7 +333,20 @@ describe 'puppet_agent' do
 
             describe 'package source', :if => os_version == '11' do
               it { is_expected.to contain_file('/etc/zypp/repos.d/pc_repo.repo').with({ 'ensure' => 'absent' }) }
-              it { is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-1.10.100-1.sles11.x86_64.rpm').with_source('puppet:///pe_packages/2000.0.0/sles-11-x86_64/puppet-agent-1.10.100-1.sles11.x86_64.rpm') }
+              it { is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-1.10.100-1.sles11.x86_64.rpm')
+                .with(
+                  :source => 'puppet:///pe_packages/2000.0.0/sles-11-x86_64/puppet-agent-1.10.100-1.sles11.x86_64.rpm',
+                )
+              }
+              it { is_expected.to contain_exec('GPG check the RPM file')
+                .with(
+                  :command   => 'rpm -K /opt/puppetlabs/packages/puppet-agent-1.10.100-1.sles11.x86_64.rpm',
+                  :path      => '/bin:/usr/bin:/sbin:/usr/sbin',
+                  :require   => 'File[/opt/puppetlabs/packages/puppet-agent-1.10.100-1.sles11.x86_64.rpm]',
+                  :logoutput => 'on_failure',
+                  :notify    => 'Package[puppet-agent]',
+                )
+              }
             end
           end
         end

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -29,7 +29,12 @@ describe 'puppet_agent' do
       if os =~ %r{sles}
         {
           is_pe: true,
+          env_temp_variable: '/tmp',
           operatingsystemmajrelease: facts[:operatingsystemrelease].split('.')[0],
+        }
+      elsif os =~ %r{redhat|centos|fedora|scientific|oracle}
+        {
+          env_temp_variable: '/tmp',
         }
       elsif os =~ %r{solaris}
         {


### PR DESCRIPTION
SLES 11 can no longer be upgraded in PE by installing from the repos. To work around this, if we're SLES 11 and PE, download the package and install it directly using rpm, regardless of the value of `manage_repo`. This is the same approach we take for AIX, macOS and Windows. Because zypper is left in a semi-broken state if our pe_repo is installed, make sure we remove it and don't install it again.

The GPG keys will continue to be imported.

For non-PE agents, installing from the FOSS repos should still be possible, so nothing should change on that part. Additional tests were added to assert the behavior of FOSS vs PE.