### PR TITLE
(MODULES-11045) add `exclude` parameter to `facts_diff` task

### DIFF
--- a/tasks/facts_diff.json
+++ b/tasks/facts_diff.json
@@ -1,5 +1,10 @@
 {
   "description": "Run the Puppet agent facts diff action",
-  "parameters": {},
+  "parameters": {
+    "exclude": {
+      "description": "Regex used to exclude specific facts from diff",
+      "type": "Optional[String]"
+    }
+  },
   "files": ["puppet_agent/files/rb_task_helper.rb"]
 }

--- a/tasks/facts_diff.rb
+++ b/tasks/facts_diff.rb
@@ -38,7 +38,8 @@ module PuppetAgent
       }
 
       command = [puppet_bin, 'facts', 'diff']
-      command << "--exclude" << @exclude if @exclude
+      command << "--exclude" << @exclude if @exclude && ! @exclude.empty?
+
       run_result = Puppet::Util::Execution.execute(command, options)
       run_result.start_with?('{}') ? 'No differences found' : run_result
     end

--- a/tasks/facts_diff.rb
+++ b/tasks/facts_diff.rb
@@ -33,7 +33,7 @@ module PuppetAgent
       ) if @exclude && !exclude_parameter_supported?
 
       options = {
-        failonfail: false,
+        failonfail: true,
         override_locale: false
       }
 
@@ -41,7 +41,9 @@ module PuppetAgent
       command << "--exclude" << @exclude if @exclude && ! @exclude.empty?
 
       run_result = Puppet::Util::Execution.execute(command, options)
-      run_result.start_with?('{}') ? 'No differences found' : run_result
+
+      minified_run_result = run_result.gsub("\n", '').gsub(' ', '')
+      minified_run_result == '{}' ? 'No differences found' : run_result
     end
 
     private


### PR DESCRIPTION
Starting with puppet 6.22.0, `puppet facts diff` supports a new parameter
`--exclude` that allows users to remove certain facts from output

This commit exposes `puppet facts diff` `--exclude` parameter to
`facts_diff` task via `exclude` parameter

