### PR TITLE
(maint) lock to ruby 2.5.8 to avoid segmentation fault

### DIFF
--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -16,7 +16,7 @@ jobs:
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
-            ruby: 2.5
+            ruby: 2.5.8
           - puppet_version: 7
             ruby: 2.7
 

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -16,7 +16,7 @@ jobs:
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
-            ruby: 2.5
+            ruby: 2.5.8
           - puppet_version: 7
             ruby: 2.7
 


### PR DESCRIPTION
win32-dir seg faults on ruby 2.5.9
```
C:/hostedtoolcache/windows/Ruby/2.5.9/x64/lib/ruby/gems/2.5.0/gems/win32-dir-0.4.9/lib/win32/dir.rb:89: [BUG] Segmentation fault
ruby 2.5.9p229 (2021-04-05 revision 67939) [x64-mingw32]

-- Control frame information -----------------------------------------------
c:0042 p:---- s:0186 e:000185 CFUNC  :SHGetFileInfo
```