### PR TITLE
(MODULES-11066) Add support for running puppet_agent::install in noop mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [4.7.0] - 2021-05-12
+
+### Summary
+Support running `puppet_agent::install` task in no-operation mode.
+
+### Features
+
+- ([MODULES-11066](https://tickets.puppetlabs.com/browse/MODULES-11066)) Support running `puppet_agent::install` task in no-operation mode ([#559](https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/559))
+
 ## [4.6.1] - 2021-04-27
 
 ### Summary

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-puppet_agent",
-  "version": "4.6.1",
+  "version": "4.7.0",
   "author": "puppetlabs",
   "summary": "Upgrades All-In-One Puppet Agents",
   "license": "Apache-2.0",

--- a/tasks/install.json
+++ b/tasks/install.json
@@ -40,7 +40,16 @@
     }
   },
   "implementations": [
-    {"name": "install_shell.sh", "requirements": ["shell"], "files": ["facts/tasks/bash.sh"], "input_method": "environment"},
-    {"name": "install_powershell.ps1", "requirements": ["powershell"]}
-  ]
+    {
+      "name": "install_shell.sh",
+      "requirements": ["shell"],
+      "files": ["facts/tasks/bash.sh"],
+      "input_method": "environment"
+      },
+    {
+      "name": "install_powershell.ps1",
+      "requirements": ["powershell"]
+    }
+  ],
+  "supports_noop": true
 }

--- a/tasks/install_powershell.json
+++ b/tasks/install_powershell.json
@@ -39,5 +39,6 @@
       "type": "Optional[Integer]",
       "default": 5
     }
-  }
+  },
+  "supports_noop": true
 }

--- a/tasks/install_powershell.ps1
+++ b/tasks/install_powershell.ps1
@@ -5,7 +5,8 @@ Param(
   [String]$windows_source = 'https://downloads.puppet.com',
   [String]$install_options = 'REINSTALLMODE="amus"',
   [Bool]$stop_service = $False,
-  [Int]$retry = 5
+  [Int]$retry = 5,
+  [Bool]$_noop = $False
 )
 # If an error is encountered, the script will stop instead of the default of "Continue"
 $ErrorActionPreference = "Stop"
@@ -153,8 +154,11 @@ function Cleanup {
     Remove-Item -Force $install_log
 }
 
-DownloadPuppet
-InstallPuppet
-Cleanup
-
-Write-Output "Puppet Agent installed on $env:COMPUTERNAME"
+if($_noop -eq 'true') {
+  Exit
+} else {
+  DownloadPuppet
+  InstallPuppet
+  Cleanup
+  Write-Output "Puppet Agent installed on $env:COMPUTERNAME" 
+}

--- a/tasks/install_shell.json
+++ b/tasks/install_shell.json
@@ -41,5 +41,6 @@
       "default": 5
     }
   },
-  "files": ["facts/tasks/bash.sh"]
+  "files": ["facts/tasks/bash.sh"],
+  "supports_noop": true
 }


### PR DESCRIPTION
This enables running the `puppet_agent::install` task in noop mode. When
the task is run in noop mode, it executes up until the puppet-agent
package is downloaded and installed.

This work enables adding support for running plans in noop mode in Bolt,
which uses the `puppet_agent::install` task as the default
puppet_library plugin when running an `apply_prep`.