### PR TITLE
(PE-31118) add MacOS 11 support

### DIFF
--- a/manifests/osfamily/darwin.pp
+++ b/manifests/osfamily/darwin.pp
@@ -1,10 +1,11 @@
 class puppet_agent::osfamily::darwin{
   assert_private()
 
-  if $::macosx_productversion_major =~ /^11\./ {
-    $productversion_major = '11'
-  } else {
+  if $::macosx_productversion_major =~ /^10\./ {
     $productversion_major = $::macosx_productversion_major
+  } else {
+    $productversion_array = split($::macosx_productversion_major, '[.]')
+    $productversion_major = $productversion_array[0]
   }
 
   if $::puppet_agent::absolute_source {

--- a/manifests/osfamily/darwin.pp
+++ b/manifests/osfamily/darwin.pp
@@ -1,19 +1,25 @@
 class puppet_agent::osfamily::darwin{
   assert_private()
 
+  if $::macosx_productversion_major =~ /^11\./ {
+    $productversion_major = '11'
+  } else {
+    $productversion_major = $::macosx_productversion_major
+  }
+
   if $::puppet_agent::absolute_source {
     $source = $::puppet_agent::absolute_source
   } elsif ($::puppet_agent::is_pe and (!$::puppet_agent::use_alternate_sources)) {
     $pe_server_version = pe_build_version()
     if $::puppet_agent::alternate_pe_source {
-      $source = "${::puppet_agent::alternate_pe_source}/packages/${pe_server_version}/${::platform_tag}/${puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.osx${$::macosx_productversion_major}.dmg"
+      $source = "${::puppet_agent::alternate_pe_source}/packages/${pe_server_version}/${::platform_tag}/${puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.osx${$productversion_major}.dmg"
     } elsif $::puppet_agent::source {
-      $source = "${::puppet_agent::source}/packages/${pe_server_version}/${::platform_tag}/${puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.osx${$::macosx_productversion_major}.dmg"
+      $source = "${::puppet_agent::source}/packages/${pe_server_version}/${::platform_tag}/${puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.osx${$productversion_major}.dmg"
     } else {
-      $source = "puppet:///pe_packages/${pe_server_version}/${::platform_tag}/${puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.osx${$::macosx_productversion_major}.dmg"
+      $source = "puppet:///pe_packages/${pe_server_version}/${::platform_tag}/${puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.osx${$productversion_major}.dmg"
     }
   } else {
-    $source = "${::puppet_agent::mac_source}/mac/${::puppet_agent::collection}/${::macosx_productversion_major}/${::puppet_agent::arch}/${puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.osx${$::macosx_productversion_major}.dmg"
+    $source = "${::puppet_agent::mac_source}/mac/${::puppet_agent::collection}/${::macosx_productversion_major}/${::puppet_agent::arch}/${puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.osx${$productversion_major}.dmg"
   }
 
   class { '::puppet_agent::prepare::package':

--- a/metadata.json
+++ b/metadata.json
@@ -110,7 +110,8 @@
       "operatingsystem": "OSX",
       "operatingsystemrelease": [
         "10.14",
-        "10.15"
+        "10.15",
+        "11"
        ]
     }
   ],

--- a/spec/classes/puppet_agent_osfamily_darwin_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_darwin_spec.rb
@@ -104,7 +104,7 @@ describe 'puppet_agent' do
     it { is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-5.10.200-1.osx10.13.dmg").with_source('puppet:///pe_packages/2000.0.0/osx-10.13-x86_64/puppet-agent-5.10.200-1.osx10.13.dmg') }
   end
 
-  describe 'when using package_version auto with MacOS 11' do
+  describe 'when using package_version auto with MacOS 11(two numbers version productversion)' do
     let(:params) {
       {
         package_version: 'auto',
@@ -116,6 +116,24 @@ describe 'puppet_agent' do
         :aio_agent_version           => '1.10.99',
         :platform_tag                => 'osx-11-x86_64',
         :macosx_productversion_major => '11.2',
+        :serverversion               => '5.10.200'
+      })
+    end
+    it { is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-5.10.200-1.osx11.dmg").with_source('puppet:///pe_packages/2000.0.0/osx-11-x86_64/puppet-agent-5.10.200-1.osx11.dmg') }
+  end
+
+  describe 'when using package_version auto with MacOS 11(one number version productversion)' do
+    let(:params) {
+      {
+        package_version: 'auto',
+      }
+    }
+    let(:facts) do
+      facts.merge({
+        :is_pe                       => true,
+        :aio_agent_version           => '1.10.99',
+        :platform_tag                => 'osx-11-x86_64',
+        :macosx_productversion_major => '11',
         :serverversion               => '5.10.200'
       })
     end

--- a/spec/classes/puppet_agent_osfamily_darwin_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_darwin_spec.rb
@@ -30,7 +30,7 @@ describe 'puppet_agent' do
   describe 'supported environment' do
     let(:params) {{ package_version: package_version }}
     context "when running a supported OSX" do
-      ["osx-10.12-x86_64", "osx-10.13-x86_64", "osx-10.14-x86_64", "osx-10.15-x86_64"].each do |tag|
+      ["osx-10.12-x86_64", "osx-10.13-x86_64", "osx-10.14-x86_64", "osx-10.15-x86_64", "osx-11-x86_64"].each do |tag|
         context "on #{tag} with no aio_version" do
           let(:osmajor) { tag.split('-')[1] }
 
@@ -104,4 +104,21 @@ describe 'puppet_agent' do
     it { is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-5.10.200-1.osx10.13.dmg").with_source('puppet:///pe_packages/2000.0.0/osx-10.13-x86_64/puppet-agent-5.10.200-1.osx10.13.dmg') }
   end
 
+  describe 'when using package_version auto with MacOS 11' do
+    let(:params) {
+      {
+        package_version: 'auto',
+      }
+    }
+    let(:facts) do
+      facts.merge({
+        :is_pe                       => true,
+        :aio_agent_version           => '1.10.99',
+        :platform_tag                => 'osx-11-x86_64',
+        :macosx_productversion_major => '11.2',
+        :serverversion               => '5.10.200'
+      })
+    end
+    it { is_expected.to contain_file("/opt/puppetlabs/packages/puppet-agent-5.10.200-1.osx11.dmg").with_source('puppet:///pe_packages/2000.0.0/osx-11-x86_64/puppet-agent-5.10.200-1.osx11.dmg') }
+  end
 end

--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -37,6 +37,8 @@ describe 'install task' do
                          '6.18.0'
                        when %r{osx-10.15}
                          '6.15.0'
+                       when %r{osx-11}
+                         '6.23.0'
                        else
                          '6.17.0'
                        end

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -210,12 +210,17 @@ if [ -f "$PT__installdir/facts/tasks/bash.sh" ]; then
     platform_version=`sw_vers | awk '/^ProductVersion:/ { print $2 }'`
 
     major_version=`echo $platform_version | cut -d. -f1,2`
+
+    # Starting with MacOS 11, the major version is the first number only
+    if echo "${major_version}" | grep -q '^11\.'; then major_version=11; fi
+
     case $major_version in
       "10.11") platform_version="10.11";;
       "10.12") platform_version="10.12";;
       "10.13") platform_version="10.13";;
       "10.14") platform_version="10.14";;
       "10.15") platform_version="10.15";;
+      "11")    platform_version="11";;
       *) echo "No builds for platform: $major_version"
          exit 1
          ;;

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -211,8 +211,10 @@ if [ -f "$PT__installdir/facts/tasks/bash.sh" ]; then
 
     major_version=`echo $platform_version | cut -d. -f1,2`
 
-    # Starting with MacOS 11, the major version is the first number only
-    if echo "${major_version}" | grep -q '^11\.'; then major_version=11; fi
+    # Excepting MacOS 10.x, the major version is the first number only
+    if ! echo "${major_version}" | grep -q '^10\.'; then
+        major_version=$(echo "${major_version}" | cut -d '.' -f 1);
+    fi
 
     case $major_version in
       "10.11") platform_version="10.11";;


### PR DESCRIPTION
Most of the changes are caused by the change in major product version.
Until now, the major product version was 10.15, 10.14, etc.

Starting with MacOS 11, the major version was incremented and we
started to use only the first number (eg. 11) as major version