### PR TITLE
(MODULES-11074) Fix `facts_diff` task argument parsing on Windows

### DIFF
--- a/tasks/facts_diff.rb
+++ b/tasks/facts_diff.rb
@@ -38,7 +38,7 @@ module PuppetAgent
       }
 
       command = [puppet_bin, 'facts', 'diff']
-      command << "--exclude" << @exclude if @exclude && ! @exclude.empty?
+      command << "--exclude" << "\"#{Regexp.new(@exclude).to_s}\"" if @exclude && ! @exclude.empty?
 
       run_result = Puppet::Util::Execution.execute(command, options)
 


### PR DESCRIPTION
Previously, running the `facts_diff` task with its `exclude` argument set to a regular expression with characters considered special in `cmd`/`powershell`/`bash` could end up discarded or injected as part of the underlying `puppet facts diff` CLI command.

This commit ensures that all `cmd`/`powershell`/`bash` special characters are escaped by wrapping the `exclude` regular expression argument content between double quotes and validates it before passing it to the `Puppet::Util::Execution.execute` method. Invalid regular expressions will raise `RegexpError`.

Used ``^!@%\$&(a)d+\w*\.\/|facter|\|d?[a-z]-=<>;:|a{3}|0`~|\(\[\<$|custom`` as a base for testing the exclude argument against special characters. Manual tests passed using CLI, PE console and bolt on both Linux and Windows machines.

Tests included adding custom facts that contained such special characters to ensure excluding mechanism still works as expected. Some examples:
```ruby
Facter.add('|custom') do
  setcode do
    Facter.value(:facterversion)
  end
end

Facter.add('c|ustom') do
  setcode do
    Facter.value(:facterversion)
  end
end

Facter.add('!custom') do
  setcode do
    Facter.value(:facterversion)
  end
end
```

### Known issues
Ideally, we should be able to give the same input to all 3 methods mentioned (PE console, bolt and CLI), as seen below:
![Untitled Diagram (8)](https://user-images.githubusercontent.com/39198766/118502013-f5336a00-b731-11eb-9ad4-90555d0594ea.png)

But there are some limitations:
1. All regular expressions need to be accordingly escaped when running `puppet facts diff` or `bolt task run puppet_agent::facts_diff` depending on the shell limitations.

2. Regular expressions starting with double quote (`"`) need to be escaped using backslash (`\`) in PE console due to puppetserver nature of dealing with strings.

With above limitations in mind, the initial regular expression was also combined with user query given in ticket, resulting in ``^!@%\$&(a)d+\w*\.\/|facter|\|d?[a-z]-=<>;:|a{3}|0`~|\(\[\<$|custom|puppet_agent_pid|puppet_inventory_metadata|processors\.|disks.*type|os\.distro|lsb.*release|dhcp_servers\.system|hypervisors\.|ec2_userdata|networking.*\.scope6|pe_postgresql_info|docker\.SystemTime|docker\.Swarm\.RemoteManagers|docker\.NGoroutines`` and everything worked as expected.