### PR TITLE
(maint) increase winrm connection timeout

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -17,7 +17,12 @@ describe 'install task' do
   end
 
   def bolt_inventory
-    hosts_to_inventory
+    host_data = hosts_to_inventory
+    host_data['nodes'].each do |node_data|
+      node_data['config']['winrm']['connect-timeout'] = 120 if target_platform =~ %r{win}
+    end
+
+    host_data
   end
 
   def target_platform
@@ -42,6 +47,10 @@ describe 'install task' do
                        else
                          '6.17.0'
                        end
+
+    # extra request is needed on windows hosts
+    # this will fail with "execution expired"
+    run_task('puppet_agent::version', 'target', {}) if target_platform =~ %r{win}
 
     # Test the agent isn't already installed and that the version task works
     results = run_task('puppet_agent::version', 'target', {})


### PR DESCRIPTION
task acceptance tests are failing on windows
with a connection timeout. Because of unknow reasons,
running the first remote command takes longer than
the default timeout of 10 seconds.

This commit increases the timeout of winrm hosts
to 120 seconds