### PR TITLE
(MODULES-11113) Allow present and latest as package version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,7 @@ group :development do
   gem "rake", '~> 12',                                       require: false
   gem "parallel_tests", '>= 2.14.1', '< 2.14.3',             require: false
   gem "metadata-json-lint", '>= 2.0.2', '< 3.0.0',           require: false
-  gem "rspec-puppet-facts", '~> 1.10.0',                     require: false
+  gem "rspec-puppet-facts", '~> 2.0.1',                      require: false
   gem "rspec_junit_formatter", '~> 0.2',                     require: false
   gem "rubocop", '~> 0.49.0',                                require: false
   gem "rubocop-rspec", '~> 1.16.0',                          require: false
@@ -48,7 +48,7 @@ group :development do
   gem "puppetlabs_spec_helper", '>= 2.9.0', '< 3.0.0',       require: false
   gem "puppet-module-posix-default-r#{minor_version}",       require: false, platforms: "ruby"
   gem "puppet-module-win-default-r#{minor_version}",         require: false, platforms: ["mswin", "mingw", "x64_mingw"]
-  gem "rspec-puppet",                                        require: true, git: "https://github.com/rodjek/rspec-puppet", tag: "v2.7.9"
+  gem "rspec-puppet",                                        require: true
   gem 'rspec-expectations', '~> 3.9.0',                      require: false
   gem "json_pure", '<= 2.0.1',                               require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
   gem "fast_gettext", '1.1.0',                               require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')

--- a/README.markdown
+++ b/README.markdown
@@ -72,7 +72,7 @@ Previous releases of this module, now unsupported, upgraded agents from later ve
 
 The puppet_agent module installs the appropriate official Puppet package repository (on systems that support repositories); migrates configuration required by Puppet to new locations used by puppet-agent; and installs the puppet-agent package, removing the previous Puppet installation.
 
-If a package_version parameter is provided, it will ensure that puppet-agent version is installed. The package_version parameter is required to perform upgrades starting from a puppet-agent package, also this parameter can be set to "auto", ensuring that agent version matches the version on the master without having to manually update package_version after upgrading the master(s).
+If a package_version parameter is provided, it will ensure that puppet-agent version is installed. The package_version parameter is required to perform upgrades starting from a puppet-agent package, also this parameter can be set to "auto", ensuring that agent version matches the version on the master without having to manually update package_version after upgrading the master(s). On platforms that install packages through repos (EL, Fedora, Debian, Ubuntu, SLES), the parameter can be set to "latest" in order to install the latest available package. To only ensure the presence of the package, the parameter can be set to "present".
 
 If a config parameter is provided, it will manage the defined agent configuration settings.
 
@@ -190,6 +190,14 @@ The package version to upgrade to. This must be explicitly specified.
 or
 ``` puppet
   package_version => 'auto'
+```
+or
+``` puppet
+  package_version => 'latest'
+```
+or
+``` puppet
+  package_version => 'present'
 ```
 
 ##### `service_names`

--- a/acceptance/tests/test_upgrade_puppet5_to_puppet6.rb
+++ b/acceptance/tests/test_upgrade_puppet5_to_puppet6.rb
@@ -13,8 +13,14 @@ test_name 'puppet_agent class: Upgrade agents from puppet5 to puppet6' do
   step "Create new site.pp with upgrade manifest" do
     manifest = <<-PP
 node default {
+  if $::osfamily =~ /^(?i:windows|solaris|aix|darwin)$/ {
+    $_package_version = '#{latest_version}'
+  } else {
+    $_package_version = 'latest'
+  }
+
   class { puppet_agent:
-    package_version => '#{latest_version}',
+    package_version => $_package_version,
     apt_source      => 'http://nightlies.puppet.com/apt',
     yum_source      => 'http://nightlies.puppet.com/yum',
     windows_source  => 'http://nightlies.puppet.com/downloads',

--- a/acceptance/tests/test_upgrade_puppet6_to_puppet7.rb
+++ b/acceptance/tests/test_upgrade_puppet6_to_puppet7.rb
@@ -13,8 +13,14 @@ test_name 'puppet_agent class: Upgrade agents from puppet6 to puppet7' do
   step "Create new site.pp with upgrade manifest" do
     manifest = <<-PP
 node default {
+  if $::osfamily =~ /^(?i:windows|solaris|aix|darwin)$/ {
+    $_package_version = '#{latest_version}'
+  } else {
+    $_package_version = 'latest'
+  }
+
   class { puppet_agent:
-    package_version => '#{latest_version}',
+    package_version => $_package_version,
     apt_source      => 'http://nightlies.puppet.com/apt',
     yum_source      => 'http://nightlies.puppet.com/yum',
     windows_source  => 'http://nightlies.puppet.com/downloads',

--- a/lib/puppet/provider/puppet_agent_end_run/puppet_agent_end_run.rb
+++ b/lib/puppet/provider/puppet_agent_end_run/puppet_agent_end_run.rb
@@ -27,6 +27,13 @@ Puppet::Type.type(:puppet_agent_end_run).provide :puppet_agent_end_run do
     current_version = Facter.value('aio_agent_version')
     desired_version = @resource.name
 
+    return false if desired_version == 'present'
+
+    if desired_version == 'latest'
+      latest_version = @resource.catalog.resource('package', 'puppet-agent').parameters[:ensure].latest
+      desired_version = latest_version.match(%r{^(?:[0-9]:)?(\d+\.\d+(\.\d+)?(?:\.\d+))?}).captures.first
+    end
+
     Puppet::Util::Package.versioncmp(desired_version, current_version) != 0
   end
 end

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -43,7 +43,7 @@ class puppet_agent::install(
     }
   } elsif $::osfamily == 'suse' {
     # Prevent re-running the batch install
-    if ($puppet_agent::aio_upgrade_required) or ($puppet_agent::aio_downgrade_required){
+    if ($package_version =~ /^latest$|^present$/) or ($puppet_agent::aio_upgrade_required) or ($puppet_agent::aio_downgrade_required){
       class { 'puppet_agent::install::suse':
         package_version => $package_version,
         install_options => $install_options,
@@ -67,7 +67,7 @@ class puppet_agent::install(
         $_source = "${::puppet_agent::params::local_packages_dir}/${::puppet_agent::prepare::package::package_file_name}"
       } else {
         # any other type of source means we use apt with no 'source' defined in the package resource below
-        if $package_version == 'present' {
+        if $package_version =~ /^latest$|^present$/ {
           $_package_version = $package_version
         } else {
           $_package_version = "${package_version}-1${::lsbdistcodename}"
@@ -91,7 +91,7 @@ class puppet_agent::install(
         $_source = undef
       }
     }
-    $_aio_package_version = $package_version.match(/^\d+\.\d+\.\d+(\.\d+)?/)[0]
+    $_aio_package_version = $package_version.match(/^\d+\.\d+\.\d+(\.\d+)?|^latest$|^present$/)[0]
     package { $::puppet_agent::package_name:
       ensure          => $_package_version,
       install_options => $_install_options,

--- a/manifests/install/suse.pp
+++ b/manifests/install/suse.pp
@@ -26,7 +26,7 @@ class puppet_agent::install::suse(
     $_source = undef
   }
 
-  $_aio_package_version = $package_version.match(/^\d+\.\d+\.\d+(\.\d+)?/)[0]
+  $_aio_package_version = $package_version.match(/^\d+\.\d+\.\d+(\.\d+)?|^latest$|^present$/)[0]
   package { $::puppet_agent::package_name:
     ensure          => $package_version,
     install_options => $install_options,

--- a/spec/classes/puppet_agent_osfamily_solaris_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_solaris_spec.rb
@@ -111,7 +111,7 @@ EOF
 
       # Ensure we get a versionable package provider
       pkg = Puppet::Type.type(:package)
-      pkg.stubs(:defaultprovider).returns(pkg.provider(:pkg))
+      allow(pkg).to receive(:defaultprovider).and_return(pkg.provider(:pkg))
     end
 
     context "when Solaris 11 i386 and a custom source" do

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -62,7 +62,7 @@ describe 'puppet_agent' do
 
   context 'package version' do
     context 'valid' do
-      ['5.5.15-1.el7', '5.5.15.el7', '6.0.9.3.g886c5ab'].each do |version|
+      ['5.5.15-1.el7', '5.5.15.el7', '6.0.9.3.g886c5ab', 'present', 'latest'].each do |version|
 
         redhat_familly_supported_os.each do |os, facts|
           let(:facts) { global_facts(facts, os) }
@@ -88,6 +88,32 @@ describe 'puppet_agent' do
 
           context "on #{os}" do
             it { expect { catalogue }.to raise_error(%r{invalid version}) }
+          end
+        end
+      end
+    end
+
+    context 'latest' do
+      context 'on unsupported platform' do
+        on_supported_os.select { |platform, _| platform =~ /solaris|aix|windows|osx/ }.each do |os, facts|
+          let(:facts) { global_facts(facts, os) }
+          let(:params) { { package_version: 'latest' } }
+
+          context os do
+            it { is_expected.not_to compile }
+            it { expect { catalogue }.to raise_error(Puppet::Error, /Setting package_version to 'latest' is not supported/) }
+          end
+        end
+      end
+
+      context 'on supported platform' do
+        on_supported_os.reject { |platform, _| platform =~ /solaris|aix|windows|osx/ }.each do |os, facts|
+          let(:facts) { global_facts(facts, os) }
+          let(:params) { { package_version: 'latest' } }
+
+          context os do
+            it { is_expected.to compile.with_all_deps }
+            it { expect { catalogue }.not_to raise_error }
           end
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ if Puppet::Util::Package.versioncmp(Puppet.version, '4.5.0') >= 0
 end
 
 RSpec.configure do |c|
+  c.mock_with :rspec
   c.before :each do
     Puppet::Parser::Functions.newfunction(:pe_build_version, type: :rvalue, doc: '') do |args|
       '2018.1.0'

--- a/spec/unit/puppet/provider/puppet_agent_end_run_spec.rb
+++ b/spec/unit/puppet/provider/puppet_agent_end_run_spec.rb
@@ -1,0 +1,112 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:puppet_agent_end_run).provider(:puppet_agent_end_run) do
+  let(:catalog) { Puppet::Resource::Catalog.new }
+
+  before do
+    allow(Facter).to receive(:value)
+  end
+
+  context 'when package_version is latest' do
+    let(:resource) do
+      Puppet::Type.type(:puppet_agent_end_run).new(:name => 'latest', :provider => :puppet_agent_end_run)
+    end
+
+    let(:agent_latest_package) do
+      Puppet::Type.type(:package).new(:name => 'puppet-agent', :ensure => 'latest', :provider => :yum)
+    end
+
+    before do
+      catalog.add_resource(agent_latest_package)
+      resource.catalog = catalog
+    end
+
+    context 'with dev versions' do
+      it 'does not stop the run if package is already latest' do
+        catalog.resource('package', 'puppet-agent').parameters[:ensure].latest = '0:7.8.0.64.g6670bf40b-1.el8'
+        allow(Facter).to receive(:value).with('aio_agent_version').and_return('7.8.0.64')
+        expect(Puppet::Application).not_to receive(:stop!)
+
+        resource.provider.stop
+      end
+
+      it 'stops the run if the current and desired versions differ' do
+        catalog.resource('package', 'puppet-agent').parameters[:ensure].latest = '0:7.8.0.64.g6670bf40b-1.el8'
+        allow(Facter).to receive(:value).with('aio_agent_version').and_return('7.8.0.32')
+        expect(Puppet::Application).to receive(:stop!)
+
+        resource.provider.stop
+      end
+    end
+
+    context 'with released versions' do
+      it 'does not stop the run if package is already latest' do
+        catalog.resource('package', 'puppet-agent').parameters[:ensure].latest = '7.8.0-1.el8'
+        allow(Facter).to receive(:value).with('aio_agent_version').and_return('7.8.0')
+        expect(Puppet::Application).not_to receive(:stop!)
+
+        resource.provider.stop
+      end
+
+
+      it 'stops the run if the current and desired versions differ' do
+        catalog.resource('package', 'puppet-agent').parameters[:ensure].latest = '7.9.0-1.el8'
+        allow(Facter).to receive(:value).with('aio_agent_version').and_return('7.8.0')
+        expect(Puppet::Application).to receive(:stop!)
+
+        resource.provider.stop
+      end
+    end
+  end
+
+  context 'when package_version is present' do
+    let(:resource) do
+      Puppet::Type.type(:puppet_agent_end_run).new(:name => 'present', :provider => :puppet_agent_end_run)
+    end
+
+    it 'never stops the run' do
+      expect(Puppet::Application).not_to receive(:stop!)
+      resource.provider.stop
+    end
+  end
+
+  context 'when package_version is a released version' do
+    let(:resource) do
+      Puppet::Type.type(:puppet_agent_end_run).new(:name => '7.8.0', :provider => :puppet_agent_end_run)
+    end
+
+    it 'does not stop the run if current and desired versions match' do
+      allow(Facter).to receive(:value).with('aio_agent_version').and_return('7.8.0')
+      expect(Puppet::Application).not_to receive(:stop!)
+
+      resource.provider.stop
+    end
+
+    it 'stops the run if current and desired versions do not match' do
+      allow(Facter).to receive(:value).with('aio_agent_version').and_return('7.7.0')
+      expect(Puppet::Application).to receive(:stop!)
+
+      resource.provider.stop
+    end
+  end
+
+  context 'when package_version is a nightly version' do
+    let(:resource) do
+      Puppet::Type.type(:puppet_agent_end_run).new(:name => '7.8.0.32', :provider => :puppet_agent_end_run)
+    end
+
+    it 'does not stop the run if current and desired versions match' do
+      allow(Facter).to receive(:value).with('aio_agent_version').and_return('7.8.0.32')
+      expect(Puppet::Application).not_to receive(:stop!)
+
+      resource.provider.stop
+    end
+
+    it 'stops the run if current and desired versions do not match' do
+      allow(Facter).to receive(:value).with('aio_agent_version').and_return('7.8.0')
+      expect(Puppet::Application).to receive(:stop!)
+
+      resource.provider.stop
+    end
+  end
+end


### PR DESCRIPTION
This pull requests intends to implement the package versions `present` and `latest` as valid package versions. According to #333, this was the case prior to commit c2206a7. The issue with #333 is that it is an outdated pull request that does not apply to the current state of  `main`. This, along with the fact that the author of #333 did not agree to the CLA in over 2 years now, is why I am raising this as a separate pull request.

Since there is no issues section in this project, I would also like to use this pull request as a discussion for this feature. The issue with the implementation as it is proposed in this pull request is that every puppet run will end with:
```
Notice: Stopping run after puppet-agent upgrade. Run puppet agent -t or apply your manifest again to finish the transaction.
```
when the version is set to `present` or `latest`. This is because the `needs_upgrade?` function in the `puppet_agent_end_run` type uses the `Puppet::Util::Package.versioncmp` function to compare the literal string `present` and `latest` with the actual version of the Puppet agent installed, e.g. `6.22.1`, which will never be equal.

I am not sure of a suitable fix for this and was hoping someone else could help.

I stumbled upon this issue when I realized the `pc_repo.repo` file was no longer being managed by this module after removing setting `puppet_agent::package_version` to `auto` which in itself led to an issue where the Puppet agent would also be downgraded (despite the server being the same version as the client) anytime the Puppet agent upgraded through the package manager. This is with `puppet_agent::collection` set to `puppet6` for both the main server and the agent, the `puppetserver` version being `6.15.3` and the `puppet-agent` version, prior to a catalogue pull, being `6.22.1` on both the main server and the agent.
