### PR TITLE
(MODULES-11112) Add parameter puppet_agent::proxy

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -43,6 +43,8 @@
         - [`use_alternate_sources`](#use_alternate_sources)
         - [`alternate_pe_source`](#alternate_pe_source)
         - [`install_dir`](#install_dir)
+        - [`disable_proxy`](#disable_proxy)
+        - [`proxy`](#proxy)
         - [`install_options`](#install_options)
         - [`msi_move_locked_files`](#msi_move_locked_files)
         - [`wait_for_pxp_agent_exit`](#wait_for_pxp_agent_exit)
@@ -285,6 +287,20 @@ Base URL of a location where packages are located in the same structure that's s
 The directory the puppet agent should be installed to. This is only applicable for Windows operating systems and when upgrading the agent to a new version; it will not cause re-installation of the same version to a new location. This must use backslashes for the path separator, and be an absolute path, for example:
 ``` puppet
   install_dir => 'D:\Program Files\Puppet Labs'
+```
+
+##### `disable_proxy`
+
+This setting controls whether or not the Puppet repositories are configured with proxies. Currently this is only supported on RedHat-based OSes.
+``` puppet
+  disable_proxy => true
+```
+
+##### `proxy`
+
+This setting specifies the proxy with which to configure the Puppet repos. Currently this is only supported on RedHat-based OSes.
+``` puppet
+  proxy => 'http://myrepo-proxy.example.com'
 ```
 
 ##### `install_options`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,6 +119,7 @@ class puppet_agent (
   $alternate_pe_source     = undef,
   $install_dir             = undef,
   $disable_proxy           = false,
+  $proxy                   = undef,
   $install_options         = [],
   $skip_if_unavailable     = 'absent',
   $msi_move_locked_files   = false,

--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -145,7 +145,7 @@ fi
     if $::puppet_agent::manage_repo == true {
       $_proxy = $::puppet_agent::disable_proxy ? {
         true    => '_none_',
-        default => undef,
+        default => $::puppet_agent::proxy,
       }
       yumrepo { 'pc_repo':
         baseurl             => $source,

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -201,6 +201,18 @@ SCRIPT
             is_expected.to contain_yumrepo('pc_repo').with_proxy('_none_')
           }
         end
+        describe 'proxy' do
+          let(:params) {
+            {
+              :manage_repo     => true,
+              :package_version => package_version,
+              :proxy           => 'http://myrepo-proxy.example.com',
+            }
+          }
+          it {
+            is_expected.to contain_yumrepo('pc_repo').with_proxy('http://myrepo-proxy.example.com')
+          }
+        end
         describe 'skip repo if unavailable' do
           let(:params) {
             {


### PR DESCRIPTION
Original description:
> This is to be able to configure yum-repo with proxy, needed for
example for clients in dmz:s that need to use proxy to reach the repo
provided by puppetserver.

This replaces https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/504, I rebased on the latest main, added documentation and a test.