### PR TITLE
(MODULES-11135) puppet_agent : Add task support for Rocky Linux 8.4 Green Obsidian

### DIFF
--- a/.github/workflows/task_acceptance_tests.yaml
+++ b/.github/workflows/task_acceptance_tests.yaml
@@ -12,10 +12,10 @@ jobs:
     name: On ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ 'centos-7', 'ubuntu-18.04' ]
+        os: [ 'centos-7', 'ubuntu-18.04', 'rocky-8' ]
 
     env:
-      ruby_version: 2.5
+      ruby_version: 2.5.9
       GEM_BOLT: true
       BEAKER_debug: true
       BEAKER_set: docker/${{ matrix.os }}

--- a/docker/bin/upgrade.sh
+++ b/docker/bin/upgrade.sh
@@ -9,6 +9,7 @@
 #             supports comma-separated lists. Available:
 #             - `ubuntu`
 #             - `centos`
+#             - `rocky`
 #             Default: `ubuntu`
 # - BEFORE: The puppet-agent package version that is installed prior to upgrade.
 #           Default: 1.10.14

--- a/docker/bin/versions.sh
+++ b/docker/bin/versions.sh
@@ -8,13 +8,14 @@
 # - PLATFORM: The platform on which the upgrade should occur. Available:
 #             - `ubuntu`
 #             - `centos`
+#             - `rocky`
 #             Default: `ubuntu`
 set -e
 
 platform=${1:-ubuntu}
 
 case "${platform}" in
-    ubuntu|centos)
+    ubuntu|centos|rocky)
         ;;
     *) echo "Invalid platform: '${platform}'. Must be 'ubuntu' or 'centos'"
         exit 1

--- a/docker/rocky/Dockerfile
+++ b/docker/rocky/Dockerfile
@@ -1,0 +1,103 @@
+# This Dockerfile enables an iterative development workflow where you can make
+# a change and test it out quickly. The majority of commands in this file will
+# be cached, making the feedback loop typically quite short. The workflow is
+# as follows:
+#   1. Set up pre-conditions for the system in puppet code using `deploy.pp`.
+#   2. Make a change to the module.
+#   3. Run `docker build -f docker/Dockerfile .` or
+#      `./docker/bin/upgrade.sh rocky` from the project directory. If you would
+#      like to test specific version upgrades, you can add run this like so:
+#        `docker build -f docker/rocky/Dockerfile . \
+#           -t pa-dev:rocky --build-arg before=1.10.14`
+#   4. Upgrade the container by running the image:
+#        `docker run -it pa-dev:rocky`
+#      Specify your upgrade TO version as an argument to the `docker run`
+#      command.
+#   5. Review the output. Repeat steps 2-5 as needed.
+#
+# At the end of execution, you will see a line like:
+#
+# Notice: /Stage[main]/Puppet_agent::Install/Package[puppet-agent]/ensure: ensure changed '1.10.14-1.el8' to '6.2.0'
+#
+# This specifies the versions that were used for upgrade.
+#
+# Arguments:
+# - before: The version to do upgrade FROM. Default: "1.10.14"
+
+FROM rockylinux/rockylinux:8
+
+# Use this to force a cache reset (e.g. for output purposes)
+#COPY $0 /tmp/Dockerfile
+
+# Install some other dependencies for ease of life.
+RUN  dnf update -y \
+  && dnf install -y wget git \
+  && dnf clean all
+
+ARG before=1.10.14
+LABEL before=${before}
+
+# Install proper FROM repo: puppet 6 or puppet 7.
+RUN if [[ ${before} == 6.* ]]; then \
+        echo Installing puppet6 repo; \
+        wget -O puppet6.rpm http://yum.puppet.com/puppet6-release-el-8.noarch.rpm && \
+        rpm -i puppet6.rpm; \
+    elif [[ ${before} == 7.* ]]; then \
+        echo Installing puppet7 repo; \
+        wget -O puppet7.rpm http://yum.puppet.com/puppet7-release-el-8.noarch.rpm && \
+        rpm -i puppet7.rpm; \
+    else echo no; \
+    fi
+
+# Print out which versions of the puppet-agent package are available (for reference).
+#RUN dnf list puppet-agent --showduplicates
+
+# Install FROM version of puppet-agent.
+RUN dnf -y update && \
+    dnf install -y puppet-agent-${before}-1.el8
+
+# This is also duplicated in the docker/bin/helpers/run-upgrade.sh.
+ENV module_path=/tmp/modules
+WORKDIR "${module_path}/puppet_agent"
+COPY metadata.json ./
+
+# Dependency installation: Forge or source? The former is what the user will
+# have downloaded, but the latter allows testing of version bumps.
+# Install module dependencies from the Forge using Puppet Module Tool (PMT).
+RUN /opt/puppetlabs/puppet/bin/puppet module install --modulepath $module_path --target-dir .. puppetlabs-stdlib
+RUN /opt/puppetlabs/puppet/bin/puppet module install --modulepath $module_path --target-dir .. puppetlabs-inifile
+RUN /opt/puppetlabs/puppet/bin/puppet module install --modulepath $module_path --target-dir .. puppetlabs-apt
+
+# Installing dependencies from source. These versions should be within the range
+# of `dependencies` in metadata.json. `translate` is a dependency for inifile.
+#RUN git clone https://github.com/puppetlabs/puppetlabs-stdlib ../stdlib --branch 5.2.0
+#RUN git clone https://github.com/puppetlabs/puppetlabs-inifile ../inifile --branch 2.5.0
+#RUN git clone https://github.com/puppetlabs/puppetlabs-translate ../translate --branch 1.2.0
+#RUN git clone https://github.com/puppetlabs/puppetlabs-apt ../apt --branch 6.3.0
+
+# Check that all dependencies are installed.
+RUN /opt/puppetlabs/puppet/bin/puppet module --modulepath $module_path list --tree
+COPY docker/deploy.pp /tmp/deploy.pp
+RUN ["sh", "-c", "/opt/puppetlabs/puppet/bin/puppet apply --modulepath $module_path /tmp/deploy.pp"]
+
+# Now move the project directory's files into the image. That way, if these
+# files change, caching will skip everything before this.
+COPY docker/bin/helpers/run-upgrade.sh /tmp/bin/run-upgrade.sh
+COPY files/ ./files/
+COPY locales/ ./locales/
+COPY spec/ ./spec/
+COPY task_spec/  ./task_spec/
+COPY tasks/ ./tasks/
+COPY templates/ ./templates
+COPY types/ ./types/
+COPY Gemfile Gemfile.lock Rakefile ./
+COPY lib/ ./lib/
+COPY manifests/ ./manifests/
+
+COPY docker/upgrade.pp /tmp/upgrade.pp
+
+# Print out which versions of the puppet-agent package are available (for reference).
+#RUN yum list puppet-agent --showduplicates
+
+# Perform the upgrade.
+ENTRYPOINT ["/tmp/bin/run-upgrade.sh"]

--- a/docker/rocky/Dockerfile.versions
+++ b/docker/rocky/Dockerfile.versions
@@ -1,0 +1,16 @@
+FROM rockylinux/rockylinux:8
+
+# Install some other dependencies for ease of life.
+RUN  dnf update -y \
+  && dnf install -y wget git \
+  && dnf clean all
+
+# Install several repos: puppet 6, and puppet7.
+RUN wget -O puppet6.rpm http://yum.puppet.com/puppet6-release-el-8.noarch.rpm && \
+    rpm -i puppet6.rpm --force --replacefiles --nodeps && \
+    wget -O puppet7.rpm http://yum.puppet.com/puppet7-release-el-8.noarch.rpm && \
+    rpm -i puppet7.rpm --force --replacefiles --nodeps
+
+# Print out available package versions for puppet-agent. If a specific version
+# is desired, pass that in with e.g. `--build-arg before=1.1.1`
+ENTRYPOINT ["dnf", "list", "puppet-agent", "--showduplicates"]

--- a/spec/acceptance/nodesets/docker/rocky-8.yml
+++ b/spec/acceptance/nodesets/docker/rocky-8.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  rocky-8-x64:
+    platform: el-8-x86_64
+    hypervisor: docker
+    image: rockylinux/rockylinux:8
+    docker_preserve_image: true
+    docker_cmd: '["/usr/sbin/init"]'
+    # install various tools required to get the image up to usable levels
+    docker_image_commands:
+      - 'dnf install -y crontabs tar wget openssl iproute which initscripts'
+CONFIG:
+  trace_limit: 200

--- a/spec/acceptance/nodesets/rocky-8.yml
+++ b/spec/acceptance/nodesets/rocky-8.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  rocky-8-x64:
+    roles:
+      - agent
+      - default
+    platform: el-8-x86_64
+    hypervisor: vagrant
+    box: rockylinux/8
+CONFIG:
+  type: foss

--- a/task_spec/spec/acceptance/nodesets/docker/rocky-8.yml
+++ b/task_spec/spec/acceptance/nodesets/docker/rocky-8.yml
@@ -1,0 +1,14 @@
+HOSTS:
+  rocky-8-x64:
+    roles:
+      - target
+    platform: el-8-x86_64
+    hypervisor: docker
+    image: rockylinux/rockylinux:8
+    docker_preserve_image: true
+    docker_cmd: '["/usr/sbin/init"]'
+    # install various tools required to get the image up to usable levels
+    docker_image_commands:
+      - 'dnf install -y crontabs tar wget openssl iproute which initscripts'
+CONFIG:
+  trace_limit: 200

--- a/task_spec/spec/acceptance/nodesets/rocky-8-x64.yml
+++ b/task_spec/spec/acceptance/nodesets/rocky-8-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  rocky-8-x64:
+    roles:
+      - target
+      - default
+    platform: el-8-x86_64
+    hypervisor: vagrant
+    box: rockylinux/8
+CONFIG:
+  type: foss

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -174,6 +174,10 @@ if [ -f "$PT__installdir/facts/tasks/bash.sh" ]; then
   if test "x$platform" = "xCentOS"; then
     platform="el"
 
+  # Handle Rocky
+  elif test "x$platform" = "xRocky"; then
+    platform="el"
+
   # Handle Oracle
   elif test "x$platform" = "xOracle Linux Server"; then
     platform="el"


### PR DESCRIPTION
When running the puppet_agent::install task on a Rocky Linux target, the following message appears :

20:24:31 +0000 INFO: Version parameter not defined and no agent detected. Assuming latest.
20:24:31 +0000 INFO: Downloading Puppet latest for Rocky...
20:24:31 +0000 CRIT: Sorry Rocky is not supported yet!