### PR TITLE
(MODULES-11123) Avoid loading puppet facts in `install/windows.pp`

### DIFF
--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -109,7 +109,7 @@ class puppet_agent::install::windows(
                   -NoProfile \
                   -NoLogo \
                   -NonInteractive \
-                  -Command {\$CurrentVersion = [string](facter.bat -p aio_agent_version); \
+                  -Command {\$CurrentVersion = [string](facter.bat aio_agent_version); \
                             if (\$CurrentVersion -eq '${::puppet_agent::_expected_package_version}') { \
                               exit 0; \
                             } \

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'puppet_agent', tag: 'win' do
             {:package_version => '5.6.7'})
           }
           it {
-            is_expected.to contain_exec('install_puppet.ps1').with_unless(/\-Command {\$CurrentVersion = \[string\]\(facter.bat \-p aio_agent_version\);/)
+            is_expected.to contain_exec('install_puppet.ps1').with_unless(/\-Command {\$CurrentVersion = \[string\]\(facter.bat aio_agent_version\);/)
             is_expected.to contain_exec('install_puppet.ps1').with_unless(/\-Command.*if \(\$CurrentVersion \-eq '5\.6\.7'\) { +exit 0; *} *exit 1; }\.Invoke\(\)/)
           }
         end


### PR DESCRIPTION
The install puppet command in `manifests/install/windows.pp` is executed if the desired version is not already installed. This is done by asking facter the value of the `aio_agent_version` fact on the target node and is compared to expected package version.

Before this commit, facter was asked to also load puppet facts (using the `-p` parameter) which was causing high load times due to unnecessary facts getting loaded and resolved when currently installed puppet agent version was the only information needed.

This fix removes the puppet facts loading for this command requirement and lowers catalog application time by as much as half in some scenarios. In our minimal and default environment we got the following output on a Windows node:
:x: Before fix:
```sh-session
➜ puppet agent -t --debug
...
Debug: Exec[prerequisites_check.ps1](provider=windows): Executing 'C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe                   -ExecutionPolicy Bypass                   -NoProfile                   -NoLogo                   -NonInteractive                   C:\Users\ADMINI~1\AppData\Local\Temp\1\prerequisites_check.ps1 6.24.0 C:\ProgramData\Puppetlabs\packages\puppet-agent-x64.msi C:\Users\ADMINI~1\AppData\Local\Temp\1\puppet-2021_08_26-15_02-installer.log'
Debug: Executing: 'C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe                   -ExecutionPolicy Bypass                   -NoProfile                   -NoLogo                   -NonInteractive                   C:\Users\ADMINI~1\AppData\Local\Temp\1\prerequisites_check.ps1 6.24.0 C:\ProgramData\Puppetlabs\packages\puppet-agent-x64.msi C:\Users\ADMINI~1\AppData\Local\Temp\1\puppet-2021_08_26-15_02-installer.log'
Notice: /Stage[main]/Puppet_agent::Install::Windows/Exec[prerequisites_check.ps1]/returns: executed successfully (corrective)
Debug: /Stage[main]/Puppet_agent::Install::Windows/Exec[prerequisites_check.ps1]: The container Class[Puppet_agent::Install::Windows] will propagate my refresh event
Debug: Exec[install_puppet.ps1](provider=windows): Executing check 'C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe                   -ExecutionPolicy Bypass                   -NoProfile                   -NoLogo                   -NonInteractive                   -Command {$CurrentVersion = [string](facter.bat -p aio_agent_version);                             if ($CurrentVersion -eq '6.24.0') {                               exit 0;                             }                             exit 1; }.Invoke()'
Debug: Executing: 'C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe                   -ExecutionPolicy Bypass                   -NoProfile                   -NoLogo                   -NonInteractive                   -Command {$CurrentVersion = [string](facter.bat -p aio_agent_version);                             if ($CurrentVersion -eq '6.24.0') {                               exit 0;                             }                             exit 1; }.Invoke()'
Debug: Exec[install_puppet.ps1](provider=windows): Executing 'C:\Windows\system32\cmd.exe /S /c start /b C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe                   -ExecutionPolicy Bypass                   -NoProfile                   -NoLogo                   -NonInteractive                   -Command C:\Users\ADMINI~1\AppData\Local\Temp\1\install_puppet.ps1                           -PuppetPID 3512                           -Source 'C:\ProgramData\Puppetlabs\packages\puppet-agent-x64.msi'                           -Logfile 'C:\Users\ADMINI~1\AppData\Local\Temp\1\puppet-2021_08_26-15_02-installer.log'                           -InstallDir ''                           -PuppetMaster 'voltaic-mileage.delivery.puppetlabs.net'                           -PuppetStartType 'Automatic'                           -InstallArgs 'REINSTALLMODE="""amus"""'                                                                                 '
Debug: Executing: 'C:\Windows\system32\cmd.exe /S /c start /b C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe                   -ExecutionPolicy Bypass                   -NoProfile                   -NoLogo                   -NonInteractive                   -Command C:\Users\ADMINI~1\AppData\Local\Temp\1\install_puppet.ps1                           -PuppetPID 3512                           -Source 'C:\ProgramData\Puppetlabs\packages\puppet-agent-x64.msi'                           -Logfile 'C:\Users\ADMINI~1\AppData\Local\Temp\1\puppet-2021_08_26-15_02-installer.log'                           -InstallDir ''                           -PuppetMaster 'voltaic-mileage.delivery.puppetlabs.net'                           -PuppetStartType 'Automatic'                           -InstallArgs 'REINSTALLMODE="""amus"""'                                                                                 '
Notice: /Stage[main]/Puppet_agent::Install::Windows/Exec[install_puppet.ps1]/returns: executed successfully
...
Notice: Applied catalog in 10.82 seconds
```
✅ After fix:
```sh-session
➜ puppet agent -t --debug
...
Debug: Exec[prerequisites_check.ps1](provider=windows): Executing 'C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe                   -ExecutionPolicy Bypass                   -NoProfile                   -NoLogo                   -NonInteractive                   C:\Users\ADMINI~1\AppData\Local\Temp\1\prerequisites_check.ps1 6.24.0 C:\ProgramData\Puppetlabs\packages\puppet-agent-x64.msi C:\Users\ADMINI~1\AppData\Local\Temp\1\puppet-2021_08_26-15_07-installer.log'
Debug: Executing: 'C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe                   -ExecutionPolicy Bypass                   -NoProfile                   -NoLogo                   -NonInteractive                   C:\Users\ADMINI~1\AppData\Local\Temp\1\prerequisites_check.ps1 6.24.0 C:\ProgramData\Puppetlabs\packages\puppet-agent-x64.msi C:\Users\ADMINI~1\AppData\Local\Temp\1\puppet-2021_08_26-15_07-installer.log'
Notice: /Stage[main]/Puppet_agent::Install::Windows/Exec[prerequisites_check.ps1]/returns: executed successfully (corrective)
Debug: /Stage[main]/Puppet_agent::Install::Windows/Exec[prerequisites_check.ps1]: The container Class[Puppet_agent::Install::Windows] will propagate my refresh event
Debug: Exec[install_puppet.ps1](provider=windows): Executing check 'C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe                   -ExecutionPolicy Bypass                   -NoProfile                   -NoLogo                   -NonInteractive                   -Command {$CurrentVersion = [string](facter.bat aio_agent_version);                             if ($CurrentVersion -eq '6.24.0') {                               exit 0;                             }                             exit 1; }.Invoke()'
Debug: Executing: 'C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe                   -ExecutionPolicy Bypass                   -NoProfile                   -NoLogo                   -NonInteractive                   -Command {$CurrentVersion = [string](facter.bat aio_agent_version);                             if ($CurrentVersion -eq '6.24.0') {                               exit 0;                             }                             exit 1; }.Invoke()'
Debug: Exec[install_puppet.ps1](provider=windows): Executing 'C:\Windows\system32\cmd.exe /S /c start /b C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe                   -ExecutionPolicy Bypass                   -NoProfile                   -NoLogo                   -NonInteractive                   -Command C:\Users\ADMINI~1\AppData\Local\Temp\1\install_puppet.ps1                           -PuppetPID 7136                           -Source 'C:\ProgramData\Puppetlabs\packages\puppet-agent-x64.msi'                           -Logfile 'C:\Users\ADMINI~1\AppData\Local\Temp\1\puppet-2021_08_26-15_07-installer.log'                           -InstallDir ''                           -PuppetMaster 'voltaic-mileage.delivery.puppetlabs.net'                           -PuppetStartType 'Automatic'                           -InstallArgs 'REINSTALLMODE="""amus"""'                                                                                 '
Debug: Executing: 'C:\Windows\system32\cmd.exe /S /c start /b C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe                   -ExecutionPolicy Bypass                   -NoProfile                   -NoLogo                   -NonInteractive                   -Command C:\Users\ADMINI~1\AppData\Local\Temp\1\install_puppet.ps1                           -PuppetPID 7136                           -Source 'C:\ProgramData\Puppetlabs\packages\puppet-agent-x64.msi'                           -Logfile 'C:\Users\ADMINI~1\AppData\Local\Temp\1\puppet-2021_08_26-15_07-installer.log'                           -InstallDir ''                           -PuppetMaster 'voltaic-mileage.delivery.puppetlabs.net'                           -PuppetStartType 'Automatic'                           -InstallArgs 'REINSTALLMODE="""amus"""'                                                                                 '
Notice: /Stage[main]/Puppet_agent::Install::Windows/Exec[install_puppet.ps1]/returns: executed successfully
...
Notice: Applied catalog in 5.64 seconds
```