### PR TITLE
(maint) set `aio_agent_version` for consistency

### DIFF
--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -137,7 +137,7 @@ describe 'puppet_agent' do
 
             context 'with mismatching digest algorithms' do
               let(:facts) do
-                global_facts(facts, os).merge(puppet_digest_algorithm: 'md5')
+                global_facts(facts, os).merge(puppet_digest_algorithm: 'md5', aio_agent_version: '6.17.0')
               end
 
               it { is_expected.not_to compile }


### PR DESCRIPTION
Because `aio_agent_version` fact comes from facterdb
it can have different values for different platforms,
which can cause CI failures.