### PR TITLE
Allow detection of non-AIO Puppet

### DIFF
--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -133,6 +133,8 @@ fi
 # Track to handle puppet5 to puppet6
 if [ -f /opt/puppetlabs/puppet/VERSION ]; then
   installed_version=`cat /opt/puppetlabs/puppet/VERSION`
+elif which puppet >/dev/null 2>&1; then
+  installed_version=`puppet --version`
 else
   installed_version=uninstalled
 fi


### PR DESCRIPTION
This PR add full support for FreeBSD.

If depends on this external PR:
* https://github.com/puppetlabs/puppetlabs-facts/pull/54

It is successfuly used for managing my configuration files on multiple operating systems:
https://github.com/smortex/dotfiles
