### PR TITLE
Use Test-PuppetInstalledVersion instead of Test-PuppetInstalled

### DIFF
--- a/tasks/install_powershell.ps1
+++ b/tasks/install_powershell.ps1
@@ -26,16 +26,6 @@ catch [System.Management.Automation.CommandNotFoundException] {
   }
 }
 
-function Test-PuppetInstalled {
-  $rootPath = 'HKLM:\SOFTWARE\Puppet Labs\Puppet'
-  try { 
-    if (Get-ItemProperty -Path $rootPath) { RETURN $true }
-  }
-  catch {
-    RETURN $false
-  }
-}
-
 function Test-PuppetInstalledVersion {
   $rootPath = 'HKLM:\SOFTWARE\Puppet Labs\Puppet'
 
@@ -82,7 +72,7 @@ if ($version) {
     }
 }
 else {
-    if (Test-PuppetInstalled) {
+    if (Test-PuppetInstalledVersion) {
       Write-Output "Version parameter not defined and agent detected. Nothing to do."
       Exit
     }
@@ -160,5 +150,5 @@ if($_noop -eq 'true') {
   DownloadPuppet
   InstallPuppet
   Cleanup
-  Write-Output "Puppet Agent installed on $env:COMPUTERNAME" 
+  Write-Output "Puppet Agent installed on $env:COMPUTERNAME"
 }


### PR DESCRIPTION
I ran into an issue with Bolt running "puppet_agent::install" where we had uninstalled the Puppet Agent on a Win10 machine and Bolt would not install the agent again. The message was `Version parameter not defined and agent detected. Nothing to do.`

When the Puppet Agent is uninstalled, the registry keys (at least on the two Windows machines I've tested) are left in place. I believe the `Test-PuppetInstalled` method is a little lacking and should do further testing to check whether Puppet is installed or not. Similar to what the existing `Test-PuppetInstalledVersion` already does, which only has a boolean result.

I'm looking for suggestions related to this topic, because I can see a couple different options to tackle this problem.

I've also noticed there are a couple different places doing similar logic, reading the registry keys and the `VERSION` file. Another refactor might be to pull those pieces up to a "helper".