### PR TITLE
(MODULES-11214) Wrong url generated for darwin 11

### DIFF
--- a/acceptance/tests/test_upgrade_puppet6_to_puppet7.rb
+++ b/acceptance/tests/test_upgrade_puppet6_to_puppet7.rb
@@ -23,6 +23,7 @@ node default {
     package_version => $_package_version,
     apt_source      => 'http://nightlies.puppet.com/apt',
     yum_source      => 'http://nightlies.puppet.com/yum',
+    mac_source      => 'http://nightlies.puppet.com/downloads',
     windows_source  => 'http://nightlies.puppet.com/downloads',
     collection      => 'puppet7-nightly',
     service_names   => []

--- a/manifests/osfamily/darwin.pp
+++ b/manifests/osfamily/darwin.pp
@@ -20,7 +20,7 @@ class puppet_agent::osfamily::darwin{
       $source = "puppet:///pe_packages/${pe_server_version}/${::platform_tag}/${puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.osx${$productversion_major}.dmg"
     }
   } else {
-    $source = "${::puppet_agent::mac_source}/mac/${::puppet_agent::collection}/${::macosx_productversion_major}/${::puppet_agent::arch}/${puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.osx${$productversion_major}.dmg"
+    $source = "${::puppet_agent::mac_source}/mac/${::puppet_agent::collection}/${productversion_major}/${::puppet_agent::arch}/${puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.osx${$productversion_major}.dmg"
   }
 
   class { '::puppet_agent::prepare::package':


### PR DESCRIPTION
Previously, any Darwin 11 machine that used a facter version older than
4.1.1, and tried to update the puppet-agent version using the
puppetlabs-puppet_agent module, would recieve a badly generated URL.

This happened because the `productversion_major` fact also included the
minor version.