### PR TITLE
(MODULES-11238) Bump centos base docker image

### DIFF
--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -24,7 +24,7 @@
 # Arguments:
 # - before: The version to do upgrade FROM. Default: "1.10.14"
 
-FROM centos:7
+FROM centos:8
 
 # Use this to force a cache reset (e.g. for output purposes)
 #COPY $0 /tmp/Dockerfile

--- a/docker/centos/Dockerfile.versions
+++ b/docker/centos/Dockerfile.versions
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM centos:8
 
 # Install some other dependencies for ease of life.
 RUN  yum update -y \


### PR DESCRIPTION
The dockerfiles are only used for iterative development to test upgrades.

```
$ bundle update
...
$ docker/bin/upgrade.sh centos 6.25.1 7.13.1
Sending build context to Docker daemon  2.609MB
Step 1/28 : FROM centos:8
 ---> 5d0da3dc9764
Step 2/28 : RUN  yum update -y   && yum install -y wget git   && yum clean all
...
Notice: /Stage[main]/Puppet_agent::Install/Package[puppet-agent]/ensure: ensure changed '6.25.1-1.el7' to '7.13.1'
Debug: /Package[puppet-agent]: The container Class[Puppet_agent::Install] will propagate my refresh event
Notice: Stopping run after puppet-agent upgrade. Run puppet agent -t or apply your manifest again to finish the transaction.
Debug: Class[Puppet_agent::Install]: Transaction canceled, skipping
Debug: Class[Puppet_agent::Configure]: Transaction canceled, skipping
Debug: Class[Puppet_agent::Configure]: Transaction canceled, skipping
Debug: Class[Puppet_agent::Service]: Transaction canceled, skipping
Debug: Class[Puppet_agent::Service]: Transaction canceled, skipping
Debug: Class[Puppet_agent]: Transaction canceled, skipping
Debug: Stage[main]: Transaction canceled, skipping
Debug: /Schedule[puppet]: Transaction canceled, skipping
Debug: /Schedule[hourly]: Transaction canceled, skipping
Debug: /Schedule[daily]: Transaction canceled, skipping
Debug: /Schedule[weekly]: Transaction canceled, skipping
Debug: /Schedule[monthly]: Transaction canceled, skipping
Debug: /Schedule[never]: Transaction canceled, skipping
Debug: /Filebucket[puppet]: Transaction canceled, skipping
Debug: Finishing transaction 35613180
Debug: Storing state
Debug: Pruned old state cache entries in 0.00 seconds
Debug: Stored state in 0.01 seconds
Notice: Applied catalog in 8.59 seconds
Debug: Applying settings catalog for sections reporting, metrics
Debug: Finishing transaction 37290600
Debug: Received report to process from 75e7cb56e971
Debug: Processing report from 75e7cb56e971 with processor Puppet::Reports::Store
Explore the upgraded container? [y/N]: n
Moving on...
Complete
```