### PR TITLE
Update install.pp

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -61,7 +61,7 @@ class puppet_agent::install(
       $_install_options = $install_options
       if $::puppet_agent::absolute_source {
         # absolute_source means we use dpkg on debian based platforms
-        $_package_version = 'present'
+        $_package_version = 'latest'
         $_provider = 'dpkg'
         # The source package should have been downloaded by puppet_agent::prepare::package to the local_packages_dir
         $_source = "${::puppet_agent::params::local_packages_dir}/${::puppet_agent::prepare::package::package_file_name}"


### PR DESCRIPTION
When using dpkg provider along with a source attribute, a package update will only work when the ensure attribute has the value 'latest'.