### PR TITLE
(MODULES-11276) Replace lsbdistcodename with os.disto.codename

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -70,7 +70,7 @@ class puppet_agent::install(
         if $package_version =~ /^latest$|^present$/ {
           $_package_version = $package_version
         } else {
-          $_package_version = "${package_version}-1${::lsbdistcodename}"
+          $_package_version = "${package_version}-1${facts['os']['distro']['codename']}"
         }
         $_provider = 'apt'
         $_source = undef

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -7,6 +7,10 @@ describe 'puppet_agent' do
     lsbdistcodename: 'stretch',
     os: {
       'name'    => 'Debian',
+      'distro'  => {
+        'codename' => 'stretch',
+        'id'       => 'Debian'
+      },
       'release' => {
         'full'  => '9.0',
         'major' => '9',
@@ -102,6 +106,9 @@ describe 'puppet_agent' do
                       lsbdistcodename: 'xenial',
                       os: {
                         'name'    => 'Ubuntu',
+                        'distro'  => {
+                          'codename' => 'xenial',
+                        },
                         'release' => {
                           'full'  => '16.04',
                         },

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -333,7 +333,7 @@ describe 'puppet_agent' do
             it { is_expected.to contain_class('puppet_agent::install').that_requires('Class[puppet_agent::prepare]') }
 
             if facts[:osfamily] == 'Debian'
-              deb_package_version = package_version + '-1' + facts[:lsbdistcodename]
+              deb_package_version = package_version + '-1' + facts.dig(:os, 'distro', 'codename')
               it { is_expected.to contain_package('puppet-agent').with_ensure(deb_package_version) }
             elsif facts[:osfamily] == 'Solaris'
               if facts[:operatingsystemmajrelease] == '11'


### PR DESCRIPTION
Prior to this PR, the debian package name used the lsbdistcodename
legacy fact to determine the package name. That legacy fact requires the
lsb-release package to determine, however in Puppet 7+, the
os.distro.codename fact can be determined without the lsb-release
package installed. This PR replaces the lsbdistcodename with
os.distro.codename for the Debian package name.