### PR TITLE
(MODULES-11262) Update the version check for acceptance check

### DIFF
--- a/acceptance/tests/test_upgrade_puppet5_to_puppet6.rb
+++ b/acceptance/tests/test_upgrade_puppet5_to_puppet6.rb
@@ -48,7 +48,7 @@ node default {
     agents_only.each do |agent|
       on(agent, puppet('agent -t --debug'), acceptable_exit_codes: 2)
       wait_for_installation_pid(agent)
-      assert_agent_version_on(agent, latest_version.scan(%r{6\.\d*\.\d*\.\d*}).first)
+      assert(puppet_agent_version_on(agent) =~ %r{^6\.\d+\.\d+.*})
     end
   end
 

--- a/acceptance/tests/test_upgrade_puppet6_to_puppet7.rb
+++ b/acceptance/tests/test_upgrade_puppet6_to_puppet7.rb
@@ -49,7 +49,7 @@ node default {
     agents_only.each do |agent|
       on(agent, puppet('agent -t --debug'), acceptable_exit_codes: 2)
       wait_for_installation_pid(agent)
-      assert_agent_version_on(agent, latest_version.scan(%r{7\.\d*\.\d*\.\d*}).first)
+      assert(puppet_agent_version_on(agent) =~ %r{^7\.\d+\.\d+.*})
     end
   end
 


### PR DESCRIPTION
When we test upgrades we should only check to look for the major version.
We use to test the latest known puppet-agent package was upgraded. Due
to a bug in our puppet-agent packaging there are times this test would
produce a failure, even though the agent was upgraded to the major version.