### PR TITLE
(maint) Use windows-2022 runners

### DIFF
--- a/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
@@ -10,7 +10,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
+        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2022' ]
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
@@ -26,7 +26,7 @@ jobs:
             os_type: 'macOS'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest-universal-darwin.gem'
-          - os: 'windows-2016'
+          - os: 'windows-2022'
             os_type: 'Windows'
             env_set_cmd: '$env:'
             gem_file: 'puppet-latest-x64-mingw32.gem'

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
+        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2022' ]
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
@@ -28,7 +28,7 @@ jobs:
             os_type: 'macOS'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest-universal-darwin.gem'
-          - os: 'windows-2016'
+          - os: 'windows-2022'
             os_type: 'Windows'
             env_set_cmd: '$env:'
             gem_file: 'puppet-latest-x64-mingw32.gem'

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2016' ]
+        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2022' ]
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
@@ -24,7 +24,7 @@ jobs:
             os_type: 'Linux'
           - os: 'macos-10.15'
             os_type: 'macOS'
-          - os: 'windows-2016'
+          - os: 'windows-2022'
             os_type: 'Windows'
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The Windows 2016 runner image went EOL on March 15, 2022

https://github.blog/changelog/2021-10-19-github-actions-the-windows-2016-runner-image-will-be-removed-from-github-hosted-runners-on-march-15-2022/