### PR TITLE
(MODULES-11315) Updates AIO auto version logic

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -163,8 +163,10 @@ class puppet_agent (
       fail('Unable to install x64 on a x86 system')
     }
 
+    # The AIO package version and Puppet version can, on rare occasion, diverge.
+    # This logic checks for the AIO version of the server, since that's what the package manager cares about.
     if $package_version == 'auto' {
-      $master_or_package_version = $::serverversion
+      $master_or_package_version = chomp(file('/opt/puppetlabs/puppet/VERSION'))
     } else {
       $master_or_package_version = $package_version
     }

--- a/spec/classes/puppet_agent_osfamily_aix_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_aix_spec.rb
@@ -13,6 +13,13 @@ describe 'puppet_agent' do
     }
   end
 
+  before(:each) do
+    allow(Puppet::FileSystem).to receive(:exist?).and_call_original
+    allow(Puppet::FileSystem).to receive(:read_preserve_line_endings).and_call_original
+    allow(Puppet::FileSystem).to receive(:exist?).with('/opt/puppetlabs/puppet/VERSION').and_return true
+    allow(Puppet::FileSystem).to receive(:read_preserve_line_endings).with('/opt/puppetlabs/puppet/VERSION').and_return "5.10.200\n"
+  end
+
   shared_examples 'aix' do |aixver, pkg_aixver, powerver|
     let(:rpmname) { "puppet-agent-#{params[:package_version]}-1.aix#{pkg_aixver}.ppc.rpm" }
     let(:tag) { "aix-#{pkg_aixver}-power" }

--- a/spec/classes/puppet_agent_osfamily_darwin_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_darwin_spec.rb
@@ -11,6 +11,11 @@ describe 'puppet_agent' do
     Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, type: :rvalue) do |_args|
       master_package_version
     end
+
+    allow(Puppet::FileSystem).to receive(:exist?).and_call_original
+    allow(Puppet::FileSystem).to receive(:read_preserve_line_endings).and_call_original
+    allow(Puppet::FileSystem).to receive(:exist?).with('/opt/puppetlabs/puppet/VERSION').and_return true
+    allow(Puppet::FileSystem).to receive(:read_preserve_line_endings).with('/opt/puppetlabs/puppet/VERSION').and_return "5.10.200\n"
   end
 
   package_version = '1.10.100'

--- a/spec/classes/puppet_agent_osfamily_windows_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_windows_spec.rb
@@ -5,6 +5,7 @@ describe 'puppet_agent' do
   pe_version = '2000.0.0'
 
   let(:params) { { package_version: package_version } }
+  let(:version_file) { '/opt/puppetlabs/puppet/VERSION' }
 
   before(:each) do
     # Need to mock the PE functions
@@ -15,6 +16,13 @@ describe 'puppet_agent' do
     Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, type: :rvalue) do |_args|
       package_version
     end
+
+    allow(Puppet::Util).to receive(:absolute_path?).and_call_original
+    allow(Puppet::Util).to receive(:absolute_path?).with(version_file).and_return true
+    allow(Puppet::FileSystem).to receive(:exist?).and_call_original
+    allow(Puppet::FileSystem).to receive(:read_preserve_line_endings).and_call_original
+    allow(Puppet::FileSystem).to receive(:exist?).with(version_file).and_return true
+    allow(Puppet::FileSystem).to receive(:read_preserve_line_endings).with(version_file).and_return "1.10.100\n"
   end
 
   [['x64', 'x86_64'], ['x86', 'i386']].each do |arch, tag|

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -213,6 +213,13 @@ describe 'puppet_agent' do
           let(:params) { { package_version: 'auto' } }
           let(:node_params) { { serverversion: '7.6.5' } }
 
+          before :each do
+            allow(Puppet::FileSystem).to receive(:exist?).and_call_original
+            allow(Puppet::FileSystem).to receive(:read_preserve_line_endings).and_call_original
+            allow(Puppet::FileSystem).to receive(:exist?).with('/opt/puppetlabs/puppet/VERSION').and_return true
+            allow(Puppet::FileSystem).to receive(:read_preserve_line_endings).with('/opt/puppetlabs/puppet/VERSION').and_return "7.6.5\n"
+          end
+
           it { is_expected.to contain_class('puppet_agent::prepare').with_package_version('7.6.5') }
           it { is_expected.to contain_class('puppet_agent::install').with_package_version('7.6.5') }
         end


### PR DESCRIPTION
puppet-agent 6.27.1 was release last month and contained Puppet version 6.27.0, a rare divergence between the puppet-agent version and the Puppet version. This discrepancy can cause issues using the puppet_agent _module_ when using the "auto" value for the `package_version` attribute.