### PR TITLE
(maint) Minor auto_release workflow fixes

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -52,7 +52,7 @@ jobs:
         git config --local user.email "${{ github.repository_owner }}@users.noreply.github.com"
         git config --local user.name "GitHub Action"
         git add .
-        git commit -m "Release prep v${{ steps.gv.outputs.ver }}"
+        git commit -m "(packaging) Release prep v${{ steps.gv.outputs.ver }}"
 
     - name: Create Pull Request
       id: cpr
@@ -60,14 +60,14 @@ jobs:
       if: ${{ github.repository_owner == 'puppetlabs' }}
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: "Release prep v${{ steps.gv.outputs.ver }}"
+        commit-message: "(packaging) Release prep v${{ steps.gv.outputs.ver }}"
         branch: "release-prep"
         delete-branch: true
         title: "Release prep v${{ steps.gv.outputs.ver }}"
         body: |
           Automated release-prep through [pdk-templates](https://github.com/puppetlabs/pdk-templates/blob/main/moduleroot/.github/workflows/auto_release.yml.erb) from commit ${{ github.sha }}. 
           Please verify before merging:
-          - [ ] last [nightly](https://github.com/${{ github.repository }}/actions/workflows/nightly.yml) run is green
+          - [ ] last [nightly](https://github.com/${{ github.repository }}/actions/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml) run is green
           - [ ] [Changelog](https://github.com/${{ github.repository }}/blob/release-prep/CHANGELOG.md) is readable and has no unlabeled pull requests
           - [ ] Ensure the [changelog](https://github.com/${{ github.repository }}/blob/release-prep/CHANGELOG.md) version and [metadata](https://github.com/${{ github.repository }}/blob/release-prep/metadata.json) version match
         labels: "maintenance"


### PR DESCRIPTION
Updates commit summaries to include the `(packaging)` prefix
to appease the static code analysis PR check.

Updates link to to nightly tests.