### PR TITLE
(maint) Adds cases for newly-supported OSes

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -34,10 +34,16 @@ describe 'install task' do
 
   it 'works with version and install tasks' do
     puppet_6_version = case target_platform
+                       when %r{debian-11}
+                         '6.24.0'
+                       when %r{el-9}
+                         '6.26.0'
                        when %r{fedora-30}
                          '6.19.1'
                        when %r{fedora-31}
                          '6.20.0'
+                       when %r{fedora-34}
+                         '6.23.0'
                        when %r{osx-10.14}
                          '6.18.0'
                        when %r{osx-10.15}


### PR DESCRIPTION
Fedora 34, Debian 11, and Red Hat 9 were all added after the 6
series had been released. As a result, we need special cases
for them in our install task test.