### PR TITLE
(FM-8969) Add support for macOS 12 ARM

### DIFF
--- a/acceptance/README.md
+++ b/acceptance/README.md
@@ -97,10 +97,10 @@ bundle exec beaker-hostgenerator -t docker centos7-64mcda-debian9-64a > ./hosts.
 
 Decide on a collection or version of puppet-agent to use on your master, and
 run the `prepare` rake task to set it up. This example installs the latest
-puppet-agent and puppetserver in the puppet 5 series on the master:
+puppet-agent and puppetserver in the puppet 7 series on the master:
 
 ```sh
-MASTER_COLLECTION=puppet5 bundle exec rake prepare
+MASTER_COLLECTION=puppet7 bundle exec rake prepare
 ````
 
 ### Run and re-run the tests

--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -32,6 +32,12 @@ describe 'install task' do
     hosts.first[:platform]
   end
 
+  def log_output_errors(result)
+    return if result['status'] == 'success'
+    out = result.dig('value', '_output') || 'Unknown result output'
+    puts logger.info(out)
+  end
+
   it 'works with version and install tasks' do
     puppet_6_version = case target_platform
                        when %r{debian-11}
@@ -94,6 +100,11 @@ describe 'install task' do
                                                             'version' => puppet_6_version,
                                                             'stop_service' => true })
 
+    results.each do |result|
+      logger.info("Installed puppet-agent on #{result['target']}: #{result['status']}")
+      log_output_errors(result)
+    end
+
     expect(results).to all(include('status' => 'success'))
 
     # It installed a version older than latest puppet6
@@ -121,6 +132,11 @@ describe 'install task' do
     # Expect nothing to happen and receive a message regarding this
     results = run_task('puppet_agent::install', 'target', { 'collection' => puppet_6_collection })
 
+    results.each do |result|
+      logger.info("Ensuring installed puppet-agent on #{result['target']}: #{result['status']}")
+      log_output_errors(result)
+    end
+
     results.each do |res|
       expect(res).to include('status' => 'success')
       expect(res['value']['_output']).to match(%r{Version parameter not defined and agent detected. Nothing to do.})
@@ -144,6 +160,12 @@ describe 'install task' do
 
       # Upgrade to latest puppet6 version
       results = run_task('puppet_agent::install', 'target', { 'collection' => 'puppet6', 'version' => 'latest' })
+
+      results.each do |result|
+        logger.info("Upgraded puppet-agent to latest puppet6 on #{result['target']}: #{result['status']}")
+        log_output_errors(result)
+      end
+
       expect(results).to all(include('status' => 'success'))
 
       # Verify that it upgraded
@@ -173,6 +195,12 @@ describe 'install task' do
 
     # Succesfully upgrade from puppet6 to puppet7
     results = run_task('puppet_agent::install', 'target', { 'collection' => puppet_7_collection, 'version' => 'latest' })
+
+    results.each do |result|
+      logger.info("Upgraded puppet-agent to puppet7 on #{result['target']}: #{result['status']}")
+      log_output_errors(result)
+    end
+
     expect(results).to all(include('status' => 'success'))
 
     # Verify that it upgraded

--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -39,6 +39,10 @@ describe 'install task' do
   end
 
   it 'works with version and install tasks' do
+    # Specify the first released version for each target platform. When adding a new
+    # OS, you'll typically want to specify 'latest' to install from nightlies, since
+    # official packages won't be released until later. During the N+1 release, you'll
+    # want to change `target_platform` to be the first version (N) that added the OS.
     puppet_6_version = case target_platform
                        when %r{debian-11}
                          '6.24.0'
@@ -56,7 +60,7 @@ describe 'install task' do
                          '6.15.0'
                        when %r{osx-11}
                          '6.23.0'
-                       when %r{osx-12}
+                       when %r{osx-12-x86_64}
                          '6.27.1'
                        when %r{ubuntu-22.04}
                          'latest'
@@ -64,7 +68,8 @@ describe 'install task' do
                          '6.17.0'
                        end
 
-    # platforms that only have nightly builds available
+    # platforms that only have nightly builds available. Once a platform
+    # is released, it should be removed from this list.
     case target_platform
     when %r{ubuntu-22.04}
       puppet_6_collection = 'puppet6-nightly'
@@ -75,8 +80,10 @@ describe 'install task' do
     end
 
     # we can only tests puppet 6.x -> 6.y upgrades if there multiple versions
+    # Once there a platform has been released more than once, it can be removed
+    # from this list.
     multiple_puppet6_versions = case target_platform
-                                when %r{osx-12}
+                                when %r{osx-12-x86_64}
                                   false
                                 when %r{ubuntu-22.04}
                                   false

--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -62,6 +62,8 @@ describe 'install task' do
                          '6.23.0'
                        when %r{osx-12-x86_64}
                          '6.27.1'
+                       when %r{osx-12-arm}
+                         'latest'
                        when %r{ubuntu-22.04}
                          'latest'
                        else
@@ -71,7 +73,7 @@ describe 'install task' do
     # platforms that only have nightly builds available. Once a platform
     # is released, it should be removed from this list.
     case target_platform
-    when %r{ubuntu-22.04}
+    when %r{ubuntu-22.04}, %r{osx-12-arm}
       puppet_6_collection = 'puppet6-nightly'
       puppet_7_collection = 'puppet7-nightly'
     else
@@ -83,7 +85,7 @@ describe 'install task' do
     # Once there a platform has been released more than once, it can be removed
     # from this list.
     multiple_puppet6_versions = case target_platform
-                                when %r{osx-12-x86_64}
+                                when %r{osx-12-x86_64}, %r{osx-12-arm}
                                   false
                                 when %r{ubuntu-22.04}
                                   false

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -675,7 +675,12 @@ case $platform in
     else
       filename="puppet-agent-${version}-1.osx${platform_version}.dmg"
     fi
-    download_url="${mac_source}/mac/${collection}/${platform_version}/x86_64/${filename}"
+
+    arch="x86_64"
+    if [[ $(uname -p) == "arm" ]]; then
+        arch="arm64"
+    fi
+    download_url="${mac_source}/mac/${collection}/${platform_version}/${arch}/${filename}"
     ;;
   *)
     critical "Sorry $platform is not supported yet!"


### PR DESCRIPTION
Emit task output when something goes wrong to ease debugging,

Distinguish between macOS 12 x86_64 and ARM in tests and install task.