### PR TITLE
(FM-8983) Add Fedora 36

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -62,10 +62,8 @@ describe 'install task' do
                          '6.23.0'
                        when %r{osx-12-x86_64}
                          '6.27.1'
-                       when %r{osx-12-arm}
-                         'latest'
-                       when %r{ubuntu-22.04}
-                         'latest'
+                       when %r{osx-12-arm}, %r{ubuntu-22.04}
+                         '6.28.0'
                        else
                          '6.17.0'
                        end
@@ -73,7 +71,7 @@ describe 'install task' do
     # platforms that only have nightly builds available. Once a platform
     # is released, it should be removed from this list.
     case target_platform
-    when %r{ubuntu-22.04}, %r{osx-12-arm}
+    when false
       puppet_6_collection = 'puppet6-nightly'
       puppet_7_collection = 'puppet7-nightly'
     else
@@ -85,7 +83,7 @@ describe 'install task' do
     # Once there a platform has been released more than once, it can be removed
     # from this list.
     multiple_puppet6_versions = case target_platform
-                                when %r{osx-12-x86_64}, %r{osx-12-arm}
+                                when %r{osx-12-arm}
                                   false
                                 when %r{ubuntu-22.04}
                                   false

--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -64,6 +64,8 @@ describe 'install task' do
                          '6.27.1'
                        when %r{osx-12-arm}, %r{ubuntu-22.04}
                          '6.28.0'
+                       when %r{fedora-36}
+                         'latest'
                        else
                          '6.17.0'
                        end
@@ -71,7 +73,7 @@ describe 'install task' do
     # platforms that only have nightly builds available. Once a platform
     # is released, it should be removed from this list.
     case target_platform
-    when false
+    when %r{fedora-36}
       puppet_6_collection = 'puppet6-nightly'
       puppet_7_collection = 'puppet7-nightly'
     else
@@ -86,6 +88,8 @@ describe 'install task' do
                                 when %r{osx-12-arm}
                                   false
                                 when %r{ubuntu-22.04}
+                                  false
+                                when %r{fedora-36}
                                   false
                                 else
                                   true


### PR DESCRIPTION
This updates the bolt task used to install puppet-agent for Fedora 36 and recently released OS'es.

On Fedora 36:
* Install 6.x nightly and upgrade to 7.x nightly.
* Skip 6.x -> 6.y updates since there's only one "latest" version

On macOS 12 x86_64:
* Enable 6.x -> 6.y upgrades since it's been supported for multiple 6.x releases.

On Ubuntu 22.04 and macOS 12 M1:
* Install 6.28.0 instead of nightly
* Continue to skip 6.x -> 6.y upgrades since we don't have immediate plans for 6.29.
