### PR TITLE
(MODULES-11328) Removes Ubuntu 16.04

### DIFF
--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -93,23 +93,23 @@ describe 'puppet_agent' do
       it { is_expected.not_to contain_apt__setting('list-puppet-enterprise-installer') }
     end
 
-    context 'xenial' do
+    context 'focal' do
       let(:facts) do
         facts.merge({
                       is_pe: true,
-                      platform_tag: 'ubuntu-1604-x86_64',
+                      platform_tag: 'ubuntu-2004-x86_64',
                       operatingsystem: 'Ubuntu',
-                      lsbdistcodename: 'xenial',
+                      lsbdistcodename: 'focal',
                       os: {
                         'name'    => 'Ubuntu',
                         'release' => {
-                          'full'  => '16.04',
+                          'full'  => '20.04',
                         },
                       },
                     })
       end
 
-      context 'when managing debian xenial apt repo' do
+      context 'when managing debian focal apt repo' do
         let(:params) do
           {
             manage_repo: true,
@@ -133,7 +133,7 @@ describe 'puppet_agent' do
         }
       end
 
-      context 'when not managing debian xenial apt repo' do
+      context 'when not managing debian focal apt repo' do
         let(:params) do
           {
             manage_repo: false,

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -648,15 +648,6 @@ case $platform in
   "Ubuntu")
     info "Ubuntu platform! Lets get you a DEB..."
     case $platform_version in
-      "12.04") deb_codename="precise";;
-      "12.10") deb_codename="quantal";;
-      "13.04") deb_codename="raring";;
-      "13.10") deb_codename="saucy";;
-      "14.04") deb_codename="trusty";;
-      "14.10") deb_codename="trusty";;
-      "15.04") deb_codename="vivid";;
-      "15.10") deb_codename="wily";;
-      "16.04") deb_codename="xenial";;
       "16.10") deb_codename="yakkety";;
       "17.04") deb_codename="zesty";;
       "18.04") deb_codename="bionic";;


### PR DESCRIPTION
Ubuntu 16.04 hit end-of-life in April 2021. This commit removes this version of Ubuntu from the installation task and tests.