### PR TITLE
(MODULES-11268) Remove support for Fedora 34

### DIFF
--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -19,7 +19,7 @@ describe 'puppet_agent' do
     }
   end
 
-  [['Rocky', 'el/8', 8], ['AlmaLinux', 'el/8', 8], ['Fedora', 'fedora/f34', 34], ['CentOS', 'el/7', 7], ['Amazon', 'el/6', 2017], ['Amazon', 'el/7', 2]].each do |os, urlbit, osmajor|
+  [['Rocky', 'el/8', 8], ['AlmaLinux', 'el/8', 8], ['Fedora', 'fedora/f36', 36], ['CentOS', 'el/7', 7], ['Amazon', 'el/6', 2017], ['Amazon', 'el/7', 2]].each do |os, urlbit, osmajor|
     context "with #{os} and #{urlbit}" do
       let(:facts) do
         super().merge(operatingsystem: os, operatingsystemmajrelease: osmajor)

--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -52,8 +52,6 @@ describe 'install task' do
                          '6.19.1'
                        when %r{fedora-31}
                          '6.20.0'
-                       when %r{fedora-34}
-                         '6.23.0'
                        when %r{osx-10.14}
                          '6.18.0'
                        when %r{osx-10.15}


### PR DESCRIPTION
Fedora 34 reached end-of-life in June 2022. This commit removes Fedora 34 from puppetlabs-puppet_agent.