### PR TITLE
(MODULES-11339) Removes Debian 9 from install task

### DIFF
--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -619,11 +619,6 @@ case $platform in
   "Debian")
     info "Debian platform! Lets get you a DEB..."
     case $major_version in
-      "5") deb_codename="lenny";;
-      "6") deb_codename="squeeze";;
-      "7") deb_codename="wheezy";;
-      "8") deb_codename="jessie";;
-      "9") deb_codename="stretch";;
       "10") deb_codename="buster";;
       "11") deb_codename="bullseye";;
     esac


### PR DESCRIPTION
Debian 9 ("stretch") hit the end of its LTS support in June 2022 This commit removes Debian 9 (and older) from the installation task.