### PR TITLE
(maint) Standardizes Rubies in GitHub Actions

### DIFF
--- a/.github/workflows/task_acceptance_tests.yaml
+++ b/.github/workflows/task_acceptance_tests.yaml
@@ -15,7 +15,7 @@ jobs:
         os: [ 'centos-7', 'ubuntu-18.04', 'rocky-8' ]
 
     env:
-      ruby_version: 2.5.9
+      ruby_version: 2.5
       GEM_BOLT: true
       BEAKER_debug: true
       BEAKER_set: docker/${{ matrix.os }}

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -16,7 +16,7 @@ jobs:
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
-            ruby: 2.5.8
+            ruby: 2.5
           - puppet_version: 7
             ruby: 2.7
 

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -16,7 +16,7 @@ jobs:
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
-            ruby: 2.5.8
+            ruby: 2.5
           - puppet_version: 7
             ruby: 2.7
 


### PR DESCRIPTION
The Ruby versions used in our GitHub Actions were inconsistent. This commit sets all Ruby versions to use the short version (e.g. 2.5 instead of 2.5.9) for all Rubies to automatically match the latest release of that version.