### PR TITLE
(MODULES-11346) Update dependency for APT module

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,13 +2,13 @@ fixtures:
   forge_modules:
     stdlib:
       repo: "puppetlabs/stdlib"
-      ref: "6.0.0"
+      ref: "8.4.0"
     inifile:
       repo: "puppetlabs/inifile"
-      ref: "2.4.0"
+      ref: "5.3.0"
     apt:
       repo: "puppetlabs/apt"
-      ref: "7.7.1"
+      ref: "9.0.0"
     translate:
       repo: "puppetlabs/translate"
       ref: "1.2.0"
@@ -16,6 +16,6 @@ fixtures:
       repo: "puppetlabs/yumrepo_core"
     facts:
       repo: "puppetlabs/facts"
-      ref: "0.5.1"
+      ref: "1.4.0"
   symlinks:
     puppet_agent: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">= 7.7.1 < 9.0.0"
+      "version_requirement": ">= 7.7.1 < 10.0.0"
     },
     {
       "name": "puppetlabs-facts",

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -1,0 +1,14 @@
+
+# Use default_module_facts.yml for module specific facts.
+#
+# Facts specified here will override the values provided by rspec-puppet-facts.
+---
+ipaddress: "172.16.254.254"
+ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
+is_pe: false
+osfamily: 'Debian'
+macaddress: "AA:AA:AA:AA:AA:AA"
+pe_build: 2021.5.0
+identity:
+  user: root
+


### PR DESCRIPTION
(MODULES-11346) Update dependency for APT module
Prior to this commit, the puppet_agent module requirements would put it at odds with other supported modules based on thee APT requirement of less than version 9.0

I also update the fixtures to that tests where carried out on the versions stated as supported in the metadata.yaml