### PR TITLE
(MODULES-11345) Updates macOS GitHub Actions runners 

### DIFF
--- a/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
@@ -10,7 +10,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2022' ]
+        os: [ 'ubuntu-18.04', 'macos-latest', 'windows-2022' ]
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
@@ -22,7 +22,7 @@ jobs:
             os_type: 'Linux'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest.gem'
-          - os: 'macos-10.15'
+          - os: 'macos-latest'
             os_type: 'macOS'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest-universal-darwin.gem'

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2022' ]
+        os: [ 'ubuntu-18.04', 'macos-latest', 'windows-2022' ]
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
@@ -24,7 +24,7 @@ jobs:
             os_type: 'Linux'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest.gem'
-          - os: 'macos-10.15'
+          - os: 'macos-latest'
             os_type: 'macOS'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest-universal-darwin.gem'

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-10.15', 'windows-2022' ]
+        os: [ 'ubuntu-18.04', 'macos-latest', 'windows-2022' ]
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
@@ -22,7 +22,7 @@ jobs:
 
           - os: 'ubuntu-18.04'
             os_type: 'Linux'
-          - os: 'macos-10.15'
+          - os: 'macos-latest'
             os_type: 'macOS'
           - os: 'windows-2022'
             os_type: 'Windows'

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 .envrc
 /inventory.yaml
 /spec/fixtures/litmus_inventory.yaml
+.vscode/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,0 @@
-{
-  "recommendations": [
-    "puppet.puppet-vscode",
-    "rebornix.Ruby"
-  ]
-}


### PR DESCRIPTION
GitHub Actions' macOS 10.15 runners are going end-of-life on December 1, 2022:
https://github.com/actions/runner-images/issues/5583

This commit updates the macOS runners in use to macos-latest, which is currently macOS 11 Big Sur.