### PR TITLE
(MODULES-11361) Remove legacy facts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,3 @@
 .envrc
 /inventory.yaml
 /spec/fixtures/litmus_inventory.yaml
-.vscode/

--- a/.sync.yml
+++ b/.sync.yml
@@ -40,6 +40,8 @@ Gemfile:
         version: '4.21.0' # due to https://github.com/octokit/octokit.rb/issues/1391
       - gem: async
         version: '~> 1.30' # otherwise async 2.0.0(needs ruby >=3.1.0) is wrongly selected by bundler on jenkins while running with ruby 2.7.1
+      - gem: puppet-lint-legacy_facts-check
+        version: '~> 1.0'
 appveyor.yml:
   delete: true
 .travis.yml:
@@ -56,3 +58,4 @@ spec/spec_helper.rb:
   unmanaged: true
 Rakefile:
   changelog_since_tag: 4.9.0
+

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :development do
   gem "beaker-task_helper", '~> 1.9',                                            require: false if ENV["GEM_BOLT"]
   gem "octokit", '4.21.0',                                                       require: false
   gem "async", '~> 1.30',                                                        require: false
+  gem "puppet-lint-legacy_facts-check", '~> 1.0',                                require: false
 end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -113,8 +113,10 @@ class puppet_agent (
   $apt_source              = 'https://apt.puppet.com',
   $mac_source              = 'https://downloads.puppet.com',
   $windows_source          = 'https://downloads.puppet.com',
+  #lint:ignore:puppet_url_without_modules
   $solaris_source          = 'puppet:///pe_packages',
   $aix_source              = 'puppet:///pe_packages',
+  #lint:endignore
   $use_alternate_sources   = false,
   $alternate_pe_source     = undef,
   $install_dir             = undef,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,13 +17,13 @@ class puppet_agent::install(
   # Solaris, MacOS, Windows platforms will require more than just a package
   # resource to install correctly. These will call to other classes that
   # define how the installations work.
-  if $::operatingsystem == 'Solaris' {
+  if $facts['os']['name'] == 'Solaris' {
     class { 'puppet_agent::install::solaris':
       package_version => $package_version,
       install_options => $install_options,
     }
     contain '::puppet_agent::install::solaris'
-  } elsif $::operatingsystem == 'Darwin' {
+  } elsif $facts['os']['name'] == 'Darwin' {
     # Prevent re-running the script install
     if $puppet_agent::aio_upgrade_required {
       class { 'puppet_agent::install::darwin':
@@ -32,7 +32,7 @@ class puppet_agent::install(
       }
       contain '::puppet_agent::install::darwin'
     }
-  } elsif $::osfamily == 'windows' {
+  } elsif $facts['os']['family'] == 'windows' {
     # Prevent re-running the batch install
     if ($puppet_agent::aio_upgrade_required) or ($puppet_agent::aio_downgrade_required){
       class { 'puppet_agent::install::windows':
@@ -41,7 +41,7 @@ class puppet_agent::install(
       }
       contain '::puppet_agent::install::windows'
     }
-  } elsif $::osfamily == 'suse' {
+  } elsif $facts['os']['family'] == 'suse' {
     # Prevent re-running the batch install
     if ($package_version =~ /^latest$|^present$/) or ($puppet_agent::aio_upgrade_required) or ($puppet_agent::aio_downgrade_required){
       class { 'puppet_agent::install::suse':
@@ -51,13 +51,13 @@ class puppet_agent::install(
       contain '::puppet_agent::install::suse'
     }
   } else {
-    if $::operatingsystem == 'AIX' {
+    if $facts['os']['name'] == 'AIX' {
       # AIX installations always use RPM directly since no there isn't any default package manager for rpms
       $_package_version = $package_version
       $_install_options = concat(['--ignoreos'],$install_options)
       $_provider = 'rpm'
       $_source = "${::puppet_agent::params::local_packages_dir}/${::puppet_agent::prepare::package::package_file_name}"
-    } elsif $::osfamily == 'Debian' {
+    } elsif $facts['os']['family'] == 'Debian' {
       $_install_options = $install_options
       if $::puppet_agent::absolute_source {
         # absolute_source means we use dpkg on debian based platforms
@@ -70,7 +70,7 @@ class puppet_agent::install(
         if $package_version =~ /^latest$|^present$/ {
           $_package_version = $package_version
         } else {
-          $_package_version = "${package_version}-1${::lsbdistcodename}"
+          $_package_version = "${package_version}-1${facts['os']['distro']['codename']}"
         }
         $_provider = 'apt'
         $_source = undef

--- a/manifests/install/solaris.pp
+++ b/manifests/install/solaris.pp
@@ -9,7 +9,7 @@ class puppet_agent::install::solaris(
   $install_options = [],
 ){
   assert_private()
-  if $::operatingsystemmajrelease == '10' {
+  if $facts['os']['release']['major'] == '10' {
     $_unzipped_package_name = regsubst($::puppet_agent::prepare::package::package_file_name, '\.gz$', '')
     $install_script = 'solaris_install.sh.erb'
 

--- a/manifests/install/suse.pp
+++ b/manifests/install/suse.pp
@@ -10,7 +10,7 @@ class puppet_agent::install::suse(
 ){
   assert_private()
 
-  if ($::puppet_agent::absolute_source) or ($::operatingsystemmajrelease == '11' and $::puppet_agent::is_pe) {
+  if ($::puppet_agent::absolute_source) or ($facts['os']['release']['major'] == '11' and $::puppet_agent::is_pe) {
     $_provider = 'rpm'
     $_source = "${::puppet_agent::params::local_packages_dir}/${::puppet_agent::prepare::package::package_file_name}"
 

--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -75,7 +75,7 @@ class puppet_agent::install::windows(
   }
 
   exec { 'prerequisites_check.ps1':
-    command => "${::system32}\\WindowsPowerShell\\v1.0\\powershell.exe \
+    command => "${facts['os']['windows']['system32']}\\WindowsPowerShell\\v1.0\\powershell.exe \
                   -ExecutionPolicy Bypass \
                   -NoProfile \
                   -NoLogo \
@@ -88,7 +88,7 @@ class puppet_agent::install::windows(
     # The powershell execution uses -Command and not -File because -File will interpolate the quotes
     # in a context like cmd.exe: https://docs.microsoft.com/en-us/powershell/scripting/components/console/powershell.exe-command-line-help?view=powershell-6#-file--
     # Because of this it's much cleaner to use -Command and use single quotes for each powershell param
-    command => "${::system32}\\cmd.exe /S /c start /b ${::system32}\\WindowsPowerShell\\v1.0\\powershell.exe \
+    command => "${facts['os']['windows']['system32']}\\cmd.exe /S /c start /b ${facts['os']['windows']['system32']}\\WindowsPowerShell\\v1.0\\powershell.exe \
                   -ExecutionPolicy Bypass \
                   -NoProfile \
                   -NoLogo \
@@ -104,7 +104,7 @@ class puppet_agent::install::windows(
                           ${_move_dll_workaround} \
                           ${_pxp_agent_wait} \
                           ${_puppet_run_wait}",
-    unless  => "${::system32}\\WindowsPowerShell\\v1.0\\powershell.exe \
+    unless  => "${facts['os']['windows']['system32']}\\WindowsPowerShell\\v1.0\\powershell.exe \
                   -ExecutionPolicy Bypass \
                   -NoProfile \
                   -NoLogo \
@@ -124,8 +124,8 @@ class puppet_agent::install::windows(
 
   # PUP-5480/PE-15037 Cache dir loses inheritable SYSTEM perms
   exec { 'fix inheritable SYSTEM perms':
-    command => "${::system32}\\icacls.exe \"${::puppet_client_datadir}\" /grant \"SYSTEM:(OI)(CI)(F)\"",
-    unless  => "${::system32}\\cmd.exe /c ${::system32}\\icacls.exe \"${::puppet_client_datadir}\" | findstr \"SYSTEM:(OI)(CI)(F)\"",
+    command => "${facts['os']['windows']['system32']}\\icacls.exe \"${::puppet_client_datadir}\" /grant \"SYSTEM:(OI)(CI)(F)\"",
+    unless  => "${facts['os']['windows']['system32']}\\cmd.exe /c ${facts['os']['windows']['system32']}\\icacls.exe \"${::puppet_client_datadir}\" | findstr \"SYSTEM:(OI)(CI)(F)\"",
     require => Exec['install_puppet.ps1'],
   }
 }

--- a/manifests/osfamily/aix.pp
+++ b/manifests/osfamily/aix.pp
@@ -1,8 +1,8 @@
 class puppet_agent::osfamily::aix{
   assert_private()
 
-  if $::operatingsystem != 'AIX' {
-    fail("${::operatingsystem} not supported")
+  if $facts['os']['name'] != 'AIX' {
+    fail("${facts['os']['name']} not supported")
   }
 
   if $::puppet_agent::is_pe != true {

--- a/manifests/osfamily/darwin.pp
+++ b/manifests/osfamily/darwin.pp
@@ -1,10 +1,10 @@
 class puppet_agent::osfamily::darwin{
   assert_private()
 
-  if $::macosx_productversion_major =~ /^10\./ {
-    $productversion_major = $::macosx_productversion_major
+  if $facts['os']['version']['major'] =~ /^10\./ {
+    $productversion_major = $facts['os']['version']['major']
   } else {
-    $productversion_array = split($::macosx_productversion_major, '[.]')
+    $productversion_array = split($facts['os']['version']['major'], '[.]')
     $productversion_major = $productversion_array[0]
   }
 

--- a/manifests/osfamily/darwin.pp
+++ b/manifests/osfamily/darwin.pp
@@ -17,7 +17,9 @@ class puppet_agent::osfamily::darwin{
     } elsif $::puppet_agent::source {
       $source = "${::puppet_agent::source}/packages/${pe_server_version}/${::platform_tag}/${puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.osx${$productversion_major}.dmg"
     } else {
+      #lint:ignore:puppet_url_without_modules
       $source = "puppet:///pe_packages/${pe_server_version}/${::platform_tag}/${puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.osx${$productversion_major}.dmg"
+      #lint:endignore
     }
   } else {
     $source = "${::puppet_agent::mac_source}/mac/${::puppet_agent::collection}/${productversion_major}/${::puppet_agent::arch}/${puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.osx${$productversion_major}.dmg"

--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -16,7 +16,7 @@ class puppet_agent::osfamily::redhat{
         $platform_and_version = "fedora/${facts['os']['release']['major']}"
       }
       'Amazon': {
-        if ("${facts['os']['release']['major']}" == '2') {
+        if ($facts['os']['release']['major'] == '2') {
           $amz_el_version = '7'
         } else {
           $amz_el_version = '6'

--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -11,12 +11,12 @@ class puppet_agent::osfamily::redhat{
     }
     contain puppet_agent::prepare::package
   } else {
-    case $::operatingsystem {
+    case $facts['os']['name'] {
       'Fedora': {
-        $platform_and_version = "fedora/${::operatingsystemmajrelease}"
+        $platform_and_version = "fedora/${facts['os']['release']['major']}"
       }
       'Amazon': {
-        if ("${::operatingsystemmajrelease}" == '2') {
+        if ("${facts['os']['release']['major']}" == '2') {
           $amz_el_version = '7'
         } else {
           $amz_el_version = '6'
@@ -24,14 +24,14 @@ class puppet_agent::osfamily::redhat{
         $platform_and_version = "el/${amz_el_version}"
       }
       default: {
-        $platform_and_version = "el/${::operatingsystemmajrelease}"
+        $platform_and_version = "el/${facts['os']['release']['major']}"
       }
     }
     if ($::puppet_agent::is_pe and (!$::puppet_agent::use_alternate_sources)) {
       $pe_server_version = pe_build_version()
       # Treat Amazon Linux just like Enterprise Linux
-      $pe_repo_dir = ($::operatingsystem == 'Amazon') ? {
-        true    => "el-${amz_el_version}-${::architecture}",
+      $pe_repo_dir = ($facts['os']['name'] == 'Amazon') ? {
+        true    => "el-${amz_el_version}-${facts['os']['architecture']}",
         default =>  $::platform_tag,
       }
       if $::puppet_agent::source {

--- a/manifests/osfamily/solaris.pp
+++ b/manifests/osfamily/solaris.pp
@@ -1,8 +1,8 @@
 class puppet_agent::osfamily::solaris{
   assert_private()
 
-  if $::operatingsystem != 'Solaris' {
-    fail("${::operatingsystem} not supported")
+  if $facts['os']['name'] != 'Solaris' {
+    fail("${facts['os']['name']} not supported")
   }
 
   if $::puppet_agent::is_pe != true {
@@ -25,7 +25,7 @@ class puppet_agent::osfamily::solaris{
     default      => 'i386',
   }
 
-  case $::operatingsystemmajrelease {
+  case $facts['os']['release']['major'] {
     '10': {
       $package_file_name = "${::puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.${pkg_arch}.pkg.gz"
       if $::puppet_agent::absolute_source {
@@ -70,7 +70,7 @@ class puppet_agent::osfamily::solaris{
 
         $pkgrepo_dir = '/etc/puppetlabs/installer/solaris.repo'
         $publisher = 'puppetlabs.com'
-        $arch = $::architecture ? {
+        $arch = $facts['os']['architecture'] ? {
           /^sun4[uv]$/ => 'sparc',
           default      => 'i386',
         }
@@ -121,7 +121,7 @@ class puppet_agent::osfamily::solaris{
       }
     }
     default: {
-      fail("${::operatingsystem} ${::operatingsystemmajrelease} not supported")
+      fail("${facts['os']['name']} ${facts['os']['release']['major']} not supported")
     }
   }
 }

--- a/manifests/osfamily/solaris.pp
+++ b/manifests/osfamily/solaris.pp
@@ -52,7 +52,9 @@ class puppet_agent::osfamily::solaris{
         owner  => 0,
         group  => 0,
         mode   => '0644',
+        #lint:ignore:puppet_url_without_modules
         source => "puppet:///pe_packages/${pe_server_version}/${::platform_tag}/solaris-noask",
+        #lint:endignore
       }
     }
     '11': {

--- a/manifests/osfamily/suse.pp
+++ b/manifests/osfamily/suse.pp
@@ -1,8 +1,8 @@
 class puppet_agent::osfamily::suse{
   assert_private()
 
-  if $::operatingsystem != 'SLES' {
-    fail("${::operatingsystem} not supported")
+  if $facts['os']['name'] != 'SLES' {
+    fail("${facts['os']['name']} not supported")
   }
 
   if $::puppet_agent::absolute_source {
@@ -19,7 +19,7 @@ class puppet_agent::osfamily::suse{
       $pe_server_version = pe_build_version()
 
       # SLES 11 in PE can no longer install agents from pe_repo
-      if $::operatingsystemmajrelease == '11' {
+      if $facts['os']['release']['major'] == '11' {
         if $::puppet_agent::source {
           $source = "${::puppet_agent::source}/packages/${pe_server_version}/${::platform_tag}"
         } elsif $::puppet_agent::alternate_pe_source {
@@ -48,13 +48,13 @@ class puppet_agent::osfamily::suse{
       }
     } else {
       if $::puppet_agent::collection == 'PC1' {
-        $source = "${::puppet_agent::yum_source}/sles/${::operatingsystemmajrelease}/${::puppet_agent::collection}/${::puppet_agent::arch}"
+        $source = "${::puppet_agent::yum_source}/sles/${facts['os']['release']['major']}/${::puppet_agent::collection}/${::puppet_agent::arch}"
       } else {
-        $source = "${::puppet_agent::yum_source}/${::puppet_agent::collection}/sles/${::operatingsystemmajrelease}/${::puppet_agent::arch}"
+        $source = "${::puppet_agent::yum_source}/${::puppet_agent::collection}/sles/${facts['os']['release']['major']}/${::puppet_agent::arch}"
       }
     }
 
-    case $::operatingsystemmajrelease {
+    case $facts['os']['release']['major'] {
       '11', '12', '15': {
         # Import the GPG key
         $legacy_keyname  = 'GPG-KEY-puppet'
@@ -122,7 +122,7 @@ fi
           logoutput => 'on_failure',
         }
 
-        unless $::operatingsystemmajrelease == '11' and $::puppet_agent::is_pe {
+        unless $facts['os']['release']['major'] == '11' and $::puppet_agent::is_pe {
           if getvar('::puppet_agent::manage_repo') == true {
             # Set up a zypper repository by creating a .repo file which mimics a ini file
             $repo_file = '/etc/zypp/repos.d/pc_repo.repo'
@@ -178,7 +178,7 @@ fi
         }
       }
       default: {
-        fail("${::operatingsystem} ${::operatingsystemmajrelease} not supported")
+        fail("${facts['os']['name']} ${facts['os']['release']['major']} not supported")
       }
     }
   }

--- a/manifests/osfamily/suse.pp
+++ b/manifests/osfamily/suse.pp
@@ -25,7 +25,9 @@ class puppet_agent::osfamily::suse{
         } elsif $::puppet_agent::alternate_pe_source {
           $source = "${::puppet_agent::alternate_pe_source}/packages/${pe_server_version}/${::platform_tag}"
         } else {
+          #lint:ignore:puppet_url_without_modules
           $source = "puppet:///pe_packages/${pe_server_version}/${::platform_tag}/${::puppet_agent::package_name}-${::puppet_agent::prepare::package_version}-1.sles11.${::puppet_agent::arch}.rpm"
+          #lint:endignore
         }
 
         # Nuke the repo if it exists to ensure zypper doesn't remain broken

--- a/manifests/osfamily/windows.pp
+++ b/manifests/osfamily/windows.pp
@@ -17,7 +17,9 @@ class puppet_agent::osfamily::windows{
     if $::puppet_agent::alternate_pe_source {
       $source = "${::puppet_agent::alternate_pe_source}/packages/${pe_server_version}/${tag}/${::puppet_agent::package_name}-${::puppet_agent::arch}.msi"
     } else {
+      #lint:ignore:puppet_url_without_modules
       $source = "puppet:///pe_packages/${pe_server_version}/${tag}/${::puppet_agent::package_name}-${::puppet_agent::arch}.msi"
+      #lint:endignore
     }
   } else {
     if $::puppet_agent::collection == 'PC1'{

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,7 @@
 #
 class puppet_agent::params{
   # Which services should be started after the upgrade process?
-  if ($::osfamily == 'Solaris' and $::operatingsystemmajrelease == '11') {
+  if ($facts['os']['family'] == 'Solaris' and $facts['os']['release']['major'] == '11') {
     # Solaris 11 is a special case; it uses a custom script.
     $service_names = []
   } else {
@@ -13,7 +13,7 @@ class puppet_agent::params{
     # the puppet version is >= 6.0.0
     $service_names = ['puppet', 'mcollective']
   }
-  if $::osfamily == 'windows' {
+  if $facts['os']['family'] == 'windows' {
     $local_puppet_dir = windows_native_path("${::puppet_agent_appdata}/Puppetlabs")
     $local_packages_dir = windows_native_path("${local_puppet_dir}/packages")
 

--- a/manifests/prepare.pp
+++ b/manifests/prepare.pp
@@ -11,7 +11,7 @@ class puppet_agent::prepare(
   $package_version = undef
 ){
   include puppet_agent::params
-  $_windows_client = downcase($::osfamily) == 'windows'
+  $_windows_client = downcase($facts['os']['family']) == 'windows'
 
   # Manage /opt/puppetlabs for platforms. This is done before both config and prepare because,
   # on Windows, both can be in C:/ProgramData/Puppet Labs; doing it later creates a dependency
@@ -22,7 +22,7 @@ class puppet_agent::prepare(
     }
   }
 
-  $_osfamily_class = downcase("::puppet_agent::osfamily::${::osfamily}")
+  $_osfamily_class = downcase("::puppet_agent::osfamily::${facts['os']['family']}")
 
   # Manage deprecating configuration settings.
   class { 'puppet_agent::prepare::puppet_config':
@@ -35,12 +35,12 @@ class puppet_agent::prepare(
   # Break out the platform-specific configuration into subclasses, dependent on
   # the osfamily of the client being configured.
 
-  case $::osfamily {
+  case $facts['os']['family'] {
     'redhat', 'debian', 'windows', 'solaris', 'aix', 'suse', 'darwin': {
       contain $_osfamily_class
     }
     default: {
-      fail("puppet_agent not supported on ${::osfamily}")
+      fail("puppet_agent not supported on ${facts['os']['family']}")
     }
   }
 }

--- a/manifests/prepare/package.pp
+++ b/manifests/prepare/package.pp
@@ -22,7 +22,7 @@ class puppet_agent::prepare::package(
   # any part of the path this should be safe, since the source will simply remain
   # what it was before and we can still pull off the filename.
   $package_file_name = basename(regsubst($source, "\\\\", '/', 'G'))
-  if $::osfamily =~ /windows/ {
+  if $facts['os']['family'] =~ /windows/ {
     $local_package_file_path = windows_native_path("${::puppet_agent::params::local_packages_dir}/${package_file_name}")
     $mode = undef
   } else {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -7,13 +7,13 @@ class puppet_agent::service{
   assert_private()
 
   # Starting with puppet6 and up collections we no longer carry the mcollective service
-  if versioncmp("${::clientversion}", '6.0.0') >= 0 {
+  if versioncmp($clientversion, '6.0.0') >= 0 {
     $_service_names = delete($::puppet_agent::service_names, 'mcollective')
   } else {
     $_service_names = $::puppet_agent::service_names
   }
 
-  if $facts['os']['name'] == 'Solaris' and $facts['os']['release']['major'] == '10' and versioncmp("${::clientversion}", '5.0.0') < 0 {
+  if $facts['os']['name'] == 'Solaris' and $facts['os']['release']['major'] == '10' and versioncmp($clientversion, '5.0.0') < 0 {
     # Skip managing service, upgrade script will handle it.
   } elsif $facts['os']['name'] == 'Solaris' and $facts['os']['release']['major'] == '11' and $puppet_agent::aio_upgrade_required {
     # Only use script if we just performed an upgrade.

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -13,9 +13,9 @@ class puppet_agent::service{
     $_service_names = $::puppet_agent::service_names
   }
 
-  if $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '10' and versioncmp("${::clientversion}", '5.0.0') < 0 {
+  if $facts['os']['name'] == 'Solaris' and $facts['os']['release']['major'] == '10' and versioncmp("${::clientversion}", '5.0.0') < 0 {
     # Skip managing service, upgrade script will handle it.
-  } elsif $::operatingsystem == 'Solaris' and $::operatingsystemmajrelease == '11' and $puppet_agent::aio_upgrade_required {
+  } elsif $facts['os']['name'] == 'Solaris' and $facts['os']['release']['major'] == '11' and $puppet_agent::aio_upgrade_required {
     # Only use script if we just performed an upgrade.
     $_logfile = "${::env_temp_variable}/solaris_start_puppet.log"
     # We'll need to pass the names of the services to start to the script

--- a/metadata.json
+++ b/metadata.json
@@ -75,7 +75,7 @@
       "version_requirement": ">= 5.0.0 < 8.0.0"
     }
   ],
-  "pdk-version": "2.2.0",
+  "pdk-version": "2.5.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates#2.2.0",
   "template-ref": "tags/2.2.0-0-g2381db6"
 }


### PR DESCRIPTION
This isn't quite ready because we need to use legacy facts when older agents upgrade. Also Facter 3 doesn't support os.distro.codename if lsb_release is not installed (see MODULES-11348)