### PR TITLE
(maint) replace legacy validate function with datatype

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -117,7 +117,7 @@ class puppet_agent (
   $aix_source              = 'puppet:///pe_packages',
   $use_alternate_sources   = false,
   $alternate_pe_source     = undef,
-  $install_dir             = undef,
+  Optional[Stdlib::Absolutepath] $install_dir = undef,
   $disable_proxy           = false,
   $proxy                   = undef,
   $install_options         = [],
@@ -144,10 +144,6 @@ class puppet_agent (
 
   if $source != undef and $absolute_source != undef {
     fail('Only one of $source and $absolute_source can be set')
-  }
-
-  if $facts['os']['family'] == 'windows' and $install_dir != undef {
-    validate_absolute_path($install_dir)
   }
 
   if $package_version == undef {


### PR DESCRIPTION
This replaces the validate_absolute_path() function call with a datatype from puppetlabs/stdlib. The type is available since the 4.13.1 release of stdlib (and this module already depends on 5.1 and newer).

Some background: I'm currently debugging a slow pe-puppetserver metrics API. The puppet-profiler is enabled and provides metrics for all called functions. In our environment the puppet_agent module is the only one still using this legacy function. By replacing it with a datatype, it follows current best practice guides and also speeds up the API because it has to care about less metrics (in my specific case at least).