### PR TITLE
(MODULES-11368) Update Ubuntu GitHub Action runner

### DIFF
--- a/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/daily_unit_tests_with_nightly_puppet_gem.yaml
@@ -10,7 +10,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-latest', 'windows-2022' ]
+        os: [ 'ubuntu-20.04', 'macos-latest', 'windows-2022' ]
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
@@ -18,7 +18,7 @@ jobs:
           - puppet_version: 7
             ruby: 2.7
 
-          - os: 'ubuntu-18.04'
+          - os: 'ubuntu-20.04'
             os_type: 'Linux'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest.gem'

--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -14,7 +14,7 @@ jobs:
     env:
       ruby_version: 2.6
 
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-20.04'
     steps:
       - name: Checkout current PR code
         uses: actions/checkout@v2

--- a/.github/workflows/task_acceptance_tests.yaml
+++ b/.github/workflows/task_acceptance_tests.yaml
@@ -12,7 +12,7 @@ jobs:
     name: On ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ 'centos-7', 'ubuntu-18.04', 'rocky-8' ]
+        os: [ 'centos-7', 'ubuntu-20.04', 'rocky-8' ]
 
     env:
       ruby_version: 2.5
@@ -20,7 +20,7 @@ jobs:
       BEAKER_debug: true
       BEAKER_set: docker/${{ matrix.os }}
 
-    runs-on: 'ubuntu-18.04'
+    runs-on: 'ubuntu-20.04'
     steps:
       - name: Checkout current PR code
         uses: actions/checkout@v2

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-latest', 'windows-2022' ]
+        os: [ 'ubuntu-20.04', 'macos-latest', 'windows-2022' ]
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
@@ -20,7 +20,7 @@ jobs:
           - puppet_version: 7
             ruby: 2.7
 
-          - os: 'ubuntu-18.04'
+          - os: 'ubuntu-20.04'
             os_type: 'Linux'
             env_set_cmd: 'export '
             gem_file: 'puppet-latest.gem'

--- a/.github/workflows/unit_tests_with_released_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_released_puppet_gem.yaml
@@ -12,7 +12,7 @@ jobs:
     name: ${{ matrix.os_type }} / Puppet${{ matrix.puppet_version }} gem / Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        os: [ 'ubuntu-18.04', 'macos-latest', 'windows-2022' ]
+        os: [ 'ubuntu-20.04', 'macos-latest', 'windows-2022' ]
         puppet_version: [ 6, 7 ]
         include:
           - puppet_version: 6
@@ -20,7 +20,7 @@ jobs:
           - puppet_version: 7
             ruby: 2.7
 
-          - os: 'ubuntu-18.04'
+          - os: 'ubuntu-20.04'
             os_type: 'Linux'
           - os: 'macos-latest'
             os_type: 'macOS'

--- a/task_spec/spec/acceptance/nodesets/docker/ubuntu-20.04.yml
+++ b/task_spec/spec/acceptance/nodesets/docker/ubuntu-20.04.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  ubuntu-2004-x64:
+    roles:
+      - target
+    platform: ubuntu-20.04-amd64
+    hypervisor: docker
+    image: ubuntu:20.04
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+CONFIG:
+  trace_limit: 200


### PR DESCRIPTION
GitHub is deprecating Ubuntu 18.04 runners on April 1, 2023. This commit switches all Ubuntu 18.04 runners used in GitHub Actions to Ubuntu 20.04.