### PR TITLE
(maint) Update 6->7 to pull latest version from 7.x and not main branch

### DIFF
--- a/acceptance/tests/test_upgrade_puppet6_to_puppet7.rb
+++ b/acceptance/tests/test_upgrade_puppet6_to_puppet7.rb
@@ -6,7 +6,7 @@ require_relative '../helpers'
 test_name 'puppet_agent class: Upgrade agents from puppet6 to puppet7' do
   require_master_collection 'puppet7-nightly'
   exclude_pe_upgrade_platforms
-  latest_version = `curl http://builds.delivery.puppetlabs.net/passing-agent-SHAs/puppet-agent-main-version`
+  latest_version = `curl http://builds.delivery.puppetlabs.net/passing-agent-SHAs/puppet-agent-7.x-version`
 
   puppet_testing_environment = new_puppet_testing_environment
 


### PR DESCRIPTION
With the creation of the 7.x branch of puppet-agent we need to update the job to pull from that now.