### PR TITLE
(MODULES-11348) Replace lsbdistcodename with os.distro.codename

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -70,7 +70,7 @@ class puppet_agent::install(
         if $package_version =~ /^latest$|^present$/ {
           $_package_version = $package_version
         } else {
-          $_package_version = "${package_version}-1${::lsbdistcodename}"
+          $_package_version = "${package_version}-1${facts['os']['distro']['codename']}"
         }
         $_provider = 'apt'
         $_source = undef

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -7,6 +7,10 @@ describe 'puppet_agent' do
     lsbdistcodename: 'stretch',
     os: {
       'name'    => 'Debian',
+      'distro'  => {
+        'codename' => 'stretch',
+        'id'       => 'Debian',
+      },
       'release' => {
         'full'  => '9.0',
         'major' => '9',
@@ -102,6 +106,9 @@ describe 'puppet_agent' do
                       lsbdistcodename: 'focal',
                       os: {
                         'name'    => 'Ubuntu',
+                        'distro'  => {
+                          'codename' => 'focal',
+                        },
                         'release' => {
                           'full'  => '20.04',
                         },

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -340,7 +340,7 @@ describe 'puppet_agent' do
             it { is_expected.to contain_class('puppet_agent::install').that_requires('Class[puppet_agent::prepare]') }
 
             if facts[:osfamily] == 'Debian'
-              deb_package_version = package_version + '-1' + facts[:lsbdistcodename]
+              deb_package_version = package_version + '-1' + facts.dig(:os, 'distro', 'codename')
               it { is_expected.to contain_package('puppet-agent').with_ensure(deb_package_version) }
             elsif facts[:osfamily] == 'Solaris'
               if facts[:operatingsystemmajrelease] == '11'


### PR DESCRIPTION
This commit replaces references to `lsbdistcodename` with `os.distro.codename`.
`lsbdistcodename` is a legacy fact that is used to determine the package name but
it requires the lsb-release package. Additionally, for Puppet 8, we are moving
towards dropping legacy facts. Also, since Facter 3+ provides the structured
fact, `os.distro.codename`, users can safely upgrade from Puppet 6/7 to 8 or from
Puppet 8.x to 8.y when using `os.distro.codename`. Due to these reasons, 
`os.distro.codename`, will be used instead of `lsbdistcodename`.