### PR TITLE
(MODULES-11392) Add Puppet 7 to 8 upgrade test

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -54,10 +54,10 @@ task :ci do
   begin
     Rake.application['prepare'].invoke
     case ENV['MASTER_COLLECTION']
-    when /puppet6/
-      beaker('exec ./tests/test_upgrade_puppet5_to_puppet6.rb')
     when /puppet7/
       beaker('exec ./tests/test_upgrade_puppet6_to_puppet7.rb')
+    when /puppet8/
+      beaker('exec ./tests/test_upgrade_puppet7_to_puppet8.rb')
     end
   ensure
     beaker('destroy')

--- a/acceptance/helpers.rb
+++ b/acceptance/helpers.rb
@@ -252,8 +252,6 @@ module Beaker::DSL
           on(host, puppet('resource', 'service', 'puppet', 'ensure=stopped'))
         end
 
-        server_version = puppetserver_version_on(master)
-
         step '(Agent) configure server setting on agent' do
           on(host, puppet("config set server #{master}"))
         end
@@ -264,11 +262,7 @@ module Beaker::DSL
 
         agent_certname = fact_on(host, 'fqdn')
         step '(Master) Sign certs' do
-          if version_is_less('5.99.99', server_version)
-            on(master, "puppetserver ca sign --certname #{agent_certname}")
-          else
-            on(master, puppet("cert sign #{agent_certname}"))
-          end
+          on(master, "puppetserver ca sign --certname #{agent_certname}")
         end
 
         teardowns << -> do
@@ -401,11 +395,7 @@ module Beaker::DSL
     # @param [String] agent_certname The name of the cert to remove from the master
     def clean_agent_certificate(agent_certname)
       step "Teardown: (Master) Clean agent #{agent_certname} cert" do
-        if version_is_less('5.99.99', puppetserver_version_on(master))
-          on(master, "puppetserver ca clean --certname #{agent_certname}")
-        else
-          on(master, puppet("cert clean #{agent_certname}"))
-        end
+        on(master, "puppetserver ca clean --certname #{agent_certname}")
       end
     end
   end

--- a/acceptance/helpers.rb
+++ b/acceptance/helpers.rb
@@ -87,8 +87,9 @@ module Beaker::DSL
       if args.is_a?(Symbol)
         collection = args.to_s
 
-        # puppet_collection_for doesn't know about nightly collections
-        unless collection.include?(server_collection)
+        # Dirty, temporary workaround for when we have puppet8 agent nightlies but not server nightlies
+        # Once we have puppet8 server releases, remove the second conditional
+        unless collection.include?(server_collection) || collection == 'puppet8-nightly'
           skip_test(msg_prefix + "\nThis test requires a puppetserver from the #{collection} collection. Skipping the test ...")
         end
 

--- a/acceptance/helpers.rb
+++ b/acceptance/helpers.rb
@@ -179,9 +179,9 @@ module Beaker::DSL
     # @param [String] environment The puppet environment to install the modules to, this must
     #   be a valid environment in the puppet install on the host.
     def install_puppet_agent_module_on(host, environment)
-      on(host, puppet('module', 'install', 'puppetlabs-stdlib',     '--version', '5.1.0', '--environment', environment), { acceptable_exit_codes: [0] })
-      on(host, puppet('module', 'install', 'puppetlabs-inifile',    '--version', '2.4.0', '--environment', environment), { acceptable_exit_codes: [0] })
-      on(host, puppet('module', 'install', 'puppetlabs-apt',        '--version', '7.7.1', '--environment', environment), { acceptable_exit_codes: [0] })
+      on(host, puppet('module', 'install', 'puppetlabs-stdlib',     '--version', '8.4.0', '--environment', environment), { acceptable_exit_codes: [0] })
+      on(host, puppet('module', 'install', 'puppetlabs-inifile',    '--version', '5.3.0', '--environment', environment), { acceptable_exit_codes: [0] })
+      on(host, puppet('module', 'install', 'puppetlabs-apt',        '--version', '9.0.0', '--environment', environment), { acceptable_exit_codes: [0] })
 
       install_dev_puppet_module_on(host,
                                    source: File.join(File.dirname(__FILE__), '..'),

--- a/acceptance/pre_suite/00_master_setup.rb
+++ b/acceptance/pre_suite/00_master_setup.rb
@@ -30,12 +30,12 @@ test_name 'Pre-Suite: Install, configure, and start a compatible puppetserver on
 
   step 'Install puppetserver' do
     # puppetserver is distributed in "release streams" instead of collections.
-    opts = if %r{^pc1$}i.match?(install_options[:puppet_collection])
-             # There is no release stream that's equivalent to the PC1 (puppet-agent
-             # 1.y.z/puppet 4) collection; This version is fine.
-             { version: '2.8.1' }
+
+    # Dirty, temporary workaround for when we have puppet8 agent nightlies but not server nightlies
+    # Once we have puppet8 server releases, pare down to just what's in the else statement
+    opts = if install_options[:puppet_collection].include?('nightly')
+             { release_stream: 'puppet7' }
            else
-             # puppet collections _do_ match with server release streams from puppet 5 onward.
              { release_stream: install_options[:puppet_collection] }
            end
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -199,7 +199,7 @@ def teardown_puppet_on(host)
   # the machine after each run.
   case host['platform']
   when %r{debian|ubuntu}
-    on host, '/opt/puppetlabs/bin/puppet module install puppetlabs-apt --version 7.7.1', { acceptable_exit_codes: [0, 1] }
+    on host, '/opt/puppetlabs/bin/puppet module install puppetlabs-apt --version 9.0.0', { acceptable_exit_codes: [0, 1] }
     clean_repo = "include apt\napt::source { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"
   when %r{fedora|el|centos}
     clean_repo = "yumrepo { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"


### PR DESCRIPTION
This commit adds a Beaker test for upgrading from Puppet 7 to Puppet 8.