### PR TITLE
(maint) Updates macOS structured facts

### DIFF
--- a/manifests/osfamily/darwin.pp
+++ b/manifests/osfamily/darwin.pp
@@ -1,10 +1,10 @@
 class puppet_agent::osfamily::darwin {
   assert_private()
 
-  if $facts['os']['version']['major'] =~ /^10\./ {
-    $productversion_major = $facts['os']['version']['major']
+  if $facts['os']['macosx']['version']['major'] =~ /^10\./ {
+    $productversion_major = $facts['os']['macosx']['version']['major']
   } else {
-    $productversion_array = split($facts['os']['version']['major'], '[.]')
+    $productversion_array = split($facts['os']['macosx']['version']['major'], '[.]')
     $productversion_major = $productversion_array[0]
   }
 

--- a/spec/classes/puppet_agent_osfamily_darwin_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_darwin_spec.rb
@@ -26,8 +26,10 @@ describe 'puppet_agent' do
       architecture: 'x86_64',
       name: 'Darwin',
       family: 'Darwin',
-      version: {
-        major: '10.13',
+      macosx: {
+        version: {
+          major: '10.13',
+        },
       },
     },
     servername: 'master.example.vm',
@@ -50,8 +52,10 @@ describe 'puppet_agent' do
                               aio_agent_version: '1.10.99',
                               is_pe: true,
                               os: {
-                                version: {
-                                  major: osmajor,
+                                macosx: {
+                                  version: {
+                                    major: osmajor,
+                                  },
                                 },
                               },
                               platform_tag: tag,
@@ -95,8 +99,10 @@ describe 'puppet_agent' do
                        aio_agent_version: '1.10.99',
         is_pe: true,
         os: {
-          version: {
-            major: '10.13',
+          macosx: {
+            version: {
+              major: '10.13',
+            },
           },
         },
         platform_tag: 'osx-10.13-x86_64',
@@ -117,8 +123,10 @@ describe 'puppet_agent' do
                        aio_agent_version: '1.10.99',
         is_pe: true,
         os: {
-          version: {
-            major: '10.13',
+          macosx: {
+            version: {
+              major: '10.13',
+            },
           },
         },
         platform_tag: 'osx-10.13-x86_64',
@@ -140,8 +148,10 @@ describe 'puppet_agent' do
                        aio_agent_version: '1.10.99',
         is_pe: true,
         os: {
-          version: {
-            major: '11.2',
+          macosx: {
+            version: {
+              major: '11.2',
+            },
           },
         },
         platform_tag: 'osx-11-x86_64',
@@ -163,8 +173,10 @@ describe 'puppet_agent' do
                        aio_agent_version: '1.10.99',
         is_pe: true,
         os: {
-          version: {
-            major: '11',
+          macosx: {
+            version: {
+              major: '11',
+            },
           },
         },
         platform_tag: 'osx-11-x86_64',


### PR DESCRIPTION
This commit updates the structured facts used for macOS, which previously omitted the 'macosx' level of the hash.