### PR TITLE
(MODULES-11365) Enable rspec tests on Ruby 3.2

### DIFF
--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ 'ubuntu-20.04', 'macos-latest', 'windows-2022' ]
-        puppet_version: [ 6, 7 ]
+        puppet_version: [ '7', '8' ]
         include:
-          - puppet_version: 6
-            ruby: 2.5
-          - puppet_version: 7
-            ruby: 2.7
+          - puppet_version: '7'
+            ruby: '2.7'
+          - puppet_version: '8'
+            ruby: '3.2'
 
           - os: 'ubuntu-20.04'
             os_type: 'Linux'

--- a/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
+++ b/.github/workflows/unit_tests_with_nightly_puppet_gem.yaml
@@ -31,7 +31,11 @@ jobs:
           - os: 'windows-2022'
             os_type: 'Windows'
             env_set_cmd: '$env:'
-            gem_file: 'puppet-latest-x64-mingw32.gem'
+            # setup-ruby uses ucrt for newer Rubies, but we only support mingw
+            # in our Windows Puppet nightly gems. For now, we'll just install
+            # the universal gem and manually install the ffi dependency
+            gem_file: 'puppet-latest.gem'
+            extra_steps: 'gem install ffi --version 1.15.5'
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -45,6 +49,7 @@ jobs:
 
       - name: Install the latest nightly build of puppet${{ matrix.puppet_version }} gem
         run: |
+          ${{ matrix.extra_steps }}
           curl https://nightlies.puppet.com/downloads/gems/puppet${{ matrix.puppet_version }}-nightly/${{ matrix.gem_file }} --output puppet.gem --location
           gem install puppet.gem -N
 

--- a/.sync.yml
+++ b/.sync.yml
@@ -43,6 +43,8 @@ Gemfile:
         version: '4.21.0' # due to https://github.com/octokit/octokit.rb/issues/1391
       - gem: async
         version: '~> 1.30' # otherwise async 2.0.0(needs ruby >=3.1.0) is wrongly selected by bundler on jenkins while running with ruby 2.7.1
+      - gem: puppet_litmus
+        version: '0.34.5'
 appveyor.yml:
   delete: true
 .travis.yml:

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,9 @@ group :development do
   gem "async", '~> 1.30',                                                       require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '< 1.0.0', require: false, platforms: [:ruby, :x64_mingw]
+  # Pin Litmus to the last version that doens't pin r10k
+  # We need later versions of r10k for Ruby 3.2 compatibility
+  gem "puppet_litmus", '= 0.34.5', require: false, platforms: [:ruby, :x64_mingw]
   gem "serverspec", '~> 2.41',    require: false
   gem "voxpupuli-acceptance"
 end

--- a/spec/classes/puppet_agent_osfamily_aix_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_aix_spec.rb
@@ -4,14 +4,14 @@ describe 'puppet_agent' do
   let(:common_facts) do
     {
       clientcert: 'foo.example.vm',
-      is_pe:                      true,
+      is_pe: true,
       os: {
         architecture: 'PowerPC_POWER7',
         family: 'AIX',
         name: 'AIX',
       },
-      platform_tag:               'aix-7.2-power',
-      servername:                 'master.example.vm',
+      platform_tag: 'aix-7.2-power',
+      servername: 'master.example.vm',
     }
   end
 
@@ -212,7 +212,7 @@ describe 'puppet_agent' do
 
     context 'not AIX' do
       let(:facts) do
-        override_facts(common_facts, { os: { name: 'not-AIX', }, })
+        override_facts(common_facts, os: { name: 'not-AIX' })
       end
 
       it { expect { catalogue }.to raise_error(%r{not supported}) }

--- a/spec/classes/puppet_agent_osfamily_darwin_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_darwin_spec.rb
@@ -41,25 +41,13 @@ describe 'puppet_agent' do
   describe 'supported environment' do
     let(:params) { { package_version: package_version } }
 
-    context 'when running a supported OSX' do
+    context 'when running a supported macOS' do
       ['osx-10.15-x86_64', 'osx-11-x86_64', 'osx-12-x86_64'].each do |tag|
         context "on #{tag} with no aio_version" do
           let(:osmajor) { tag.split('-')[1] }
 
           let(:facts) do
-            override_facts(facts,
-                            {
-                              aio_agent_version: '1.10.99',
-                              is_pe: true,
-                              os: {
-                                macosx: {
-                                  version: {
-                                    major: osmajor,
-                                  },
-                                },
-                              },
-                              platform_tag: tag,
-                            })
+            override_facts(facts, aio_agent_version: '1.10.99', is_pe: true, os: { macosx: { version: { major: osmajor, }, }, }, platform_tag: tag)
           end
 
           it { is_expected.to compile.with_all_deps }
@@ -95,18 +83,7 @@ describe 'puppet_agent' do
       }
     end
     let(:facts) do
-      override_facts(facts, {
-                       aio_agent_version: '1.10.99',
-        is_pe: true,
-        os: {
-          macosx: {
-            version: {
-              major: '10.13',
-            },
-          },
-        },
-        platform_tag: 'osx-10.13-x86_64',
-                     })
+      override_facts(facts, aio_agent_version: '1.10.99', is_pe: true, os: { macosx: { version: { major: '10.13', }, }, }, platform_tag: 'osx-10.13-x86_64')
     end
 
     it { is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-5.10.100.1-1.osx10.13.dmg').with_source('https://fake-pe-master.com/packages/2000.0.0/osx-10.13-x86_64/puppet-agent-5.10.100.1-1.osx10.13.dmg') }
@@ -119,69 +96,33 @@ describe 'puppet_agent' do
       }
     end
     let(:facts) do
-      override_facts(facts, {
-                       aio_agent_version: '1.10.99',
-        is_pe: true,
-        os: {
-          macosx: {
-            version: {
-              major: '10.13',
-            },
-          },
-        },
-        platform_tag: 'osx-10.13-x86_64',
-        serverversion: '5.10.200',
-                     })
+      override_facts(facts, aio_agent_version: '1.10.99', is_pe: true, os: { macosx: { version: { major: '10.13', }, }, }, platform_tag: 'osx-10.13-x86_64', serverversion: '5.10.200')
     end
 
     it { is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-5.10.200-1.osx10.13.dmg').with_source('puppet:///pe_packages/2000.0.0/osx-10.13-x86_64/puppet-agent-5.10.200-1.osx10.13.dmg') }
   end
 
-  describe 'when using package_version auto with MacOS 11(two numbers version productversion)' do
+  describe 'when using package_version auto with macOS 11 (two numbers version productversion)' do
     let(:params) do
       {
         package_version: 'auto',
       }
     end
     let(:facts) do
-      override_facts(facts, {
-                       aio_agent_version: '1.10.99',
-        is_pe: true,
-        os: {
-          macosx: {
-            version: {
-              major: '11.2',
-            },
-          },
-        },
-        platform_tag: 'osx-11-x86_64',
-        serverversion: '5.10.200'
-                     })
+      override_facts(facts, aio_agent_version: '1.10.99', is_pe: true, os: { macosx: { version: { major: '11.2', }, }, }, platform_tag: 'osx-11-x86_64', serverversion: '5.10.200')
     end
 
     it { is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-5.10.200-1.osx11.dmg').with_source('puppet:///pe_packages/2000.0.0/osx-11-x86_64/puppet-agent-5.10.200-1.osx11.dmg') }
   end
 
-  describe 'when using package_version auto with MacOS 11(one number version productversion)' do
+  describe 'when using package_version auto with macOS 11 (one number version productversion)' do
     let(:params) do
       {
         package_version: 'auto',
       }
     end
     let(:facts) do
-      override_facts(facts, {
-                       aio_agent_version: '1.10.99',
-        is_pe: true,
-        os: {
-          macosx: {
-            version: {
-              major: '11',
-            },
-          },
-        },
-        platform_tag: 'osx-11-x86_64',
-        serverversion: '5.10.200',
-                     })
+      override_facts(facts, aio_agent_version: '1.10.99', is_pe: true, os: { macosx: { version: { major: '11', }, }, }, platform_tag: 'osx-11-x86_64', serverversion: '5.10.200')
     end
 
     it { is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-5.10.200-1.osx11.dmg').with_source('puppet:///pe_packages/2000.0.0/osx-11-x86_64/puppet-agent-5.10.200-1.osx11.dmg') }

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -45,10 +45,7 @@ describe 'puppet_agent' do
     end
 
     let(:facts) do
-      override_facts(facts, {
-                       is_pe: true,
-        platform_tag: 'debian-7-x86_64',
-                     })
+      override_facts(facts, is_pe: true, platform_tag: 'debian-7-x86_64')
     end
 
     context 'when managing PE debian apt repo' do
@@ -96,19 +93,7 @@ describe 'puppet_agent' do
 
     context 'focal' do
       let(:facts) do
-        override_facts(facts, {
-                         is_pe: true,
-          os: {
-            distro: {
-              codename: 'focal',
-            },
-            name: 'Ubuntu',
-            release: {
-              full: '20.04',
-            },
-          },
-          platform_tag: 'ubuntu-2004-x86_64',
-                       })
+        override_facts(facts, is_pe: true, os: { distro: { codename: 'focal', }, name: 'Ubuntu', release: { full: '20.04', }, }, platform_tag: 'ubuntu-2004-x86_64')
       end
 
       context 'when managing debian focal apt repo' do

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -24,14 +24,7 @@ describe 'puppet_agent' do
   [['Rocky', 'el/8', 8], ['AlmaLinux', 'el/8', 8], ['Fedora', 'fedora/f36', 36], ['CentOS', 'el/7', 7], ['Amazon', 'el/6', 2017], ['Amazon', 'el/7', 2]].each do |os, urlbit, osmajor|
     context "with #{os} and #{urlbit}" do
       let(:facts) do
-        override_facts(super(), {
-                         os: {
-                           name: os,
-                           release: {
-                             major: osmajor,
-                           },
-                         },
-                       })
+        override_facts(super(), os: { name: os, release: { major: osmajor, }, })
       end
 
       script = <<-SCRIPT
@@ -182,16 +175,7 @@ SCRIPT
       end
 
       let(:facts) do
-        override_facts(super(), {
-                         is_pe: true,
-          os: {
-            name: os,
-            release: {
-              major: osmajor,
-            },
-          },
-          platform_tag: tag,
-                       })
+        override_facts(super(), is_pe: true, os: { name: os, release: { major: osmajor, }, }, platform_tag: tag)
       end
 
       context 'when using a custom source' do

--- a/spec/classes/puppet_agent_osfamily_solaris_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_solaris_spec.rb
@@ -118,15 +118,7 @@ EOF
 
     context 'when Solaris 11 i386 and a custom source' do
       let(:facts) do
-        override_facts(facts, {
-                         is_pe: true,
-                                os: {
-                                  release: {
-                                    major: '11',
-                                  },
-                                },
-                                platform_tag: 'solaris-11-i386',
-                       })
+        override_facts(facts, is_pe: true, os: { release: { major: '11', }, }, platform_tag: 'solaris-11-i386')
       end
       let(:params) do
         {
@@ -146,15 +138,7 @@ EOF
 
     context 'when Solaris 11 i386' do
       let(:facts) do
-        override_facts(facts, {
-                         is_pe: true,
-          os: {
-            release: {
-              major: '11',
-            },
-          },
-          platform_tag: 'solaris-11-i386',
-                       })
+        override_facts(facts, is_pe: true, os: { release: { major: '11', }, }, platform_tag: 'solaris-11-i386')
       end
 
       it { is_expected.to compile.with_all_deps }
@@ -211,16 +195,7 @@ EOF
 
     context 'when Solaris 11 sparc sun4u' do
       let(:facts) do
-        override_facts(facts, {
-                         is_pe: true,
-          os: {
-            architecture: 'sun4u',
-            release: {
-              major: '11',
-            },
-          },
-          platform_tag: 'solaris-11-sparc',
-                       })
+        override_facts(facts, is_pe: true, os: { architecture: 'sun4u', release: { major: '11', }, }, platform_tag: 'solaris-11-sparc')
       end
 
       it { is_expected.to compile.with_all_deps }
@@ -276,15 +251,7 @@ EOF
 
     context 'when Solaris 10 i386 and a custom source' do
       let(:facts) do
-        override_facts(facts, {
-                         is_pe: true,
-          os: {
-            release: {
-              major: '10',
-            },
-          },
-          platform_tag: 'solaris-10-i386',
-                       })
+        override_facts(facts, is_pe: true, os: { release: { major: '10', }, }, platform_tag: 'solaris-10-i386')
       end
       let(:params) do
         {
@@ -304,15 +271,7 @@ EOF
 
     context 'when Solaris 10 i386' do
       let(:facts) do
-        override_facts(facts, {
-                         is_pe: true,
-          os: {
-            release: {
-              major: '10',
-            },
-          },
-          platform_tag: 'solaris-10-i386',
-                       })
+        override_facts(facts, is_pe: true, os: { release: { major: '10', }, }, platform_tag: 'solaris-10-i386')
       end
 
       it { is_expected.to compile.with_all_deps }
@@ -337,16 +296,7 @@ EOF
 
       context 'with older aio_agent_version' do
         let(:facts) do
-          override_facts(facts, {
-                           aio_agent_version: '1.0.0',
-            is_pe: true,
-            os: {
-              release: {
-                major: '10',
-              },
-            },
-            platform_tag: 'solaris-10-i386',
-                         })
+          override_facts(facts, aio_agent_version: '1.0.0', is_pe: true, os: { release: { major: '10', }, }, platform_tag: 'solaris-10-i386')
         end
 
         it do
@@ -374,16 +324,7 @@ EOF
       end
 
       let(:facts) do
-        override_facts(facts, {
-                         is_pe: true,
-          os: {
-            architecture: 'sun4u',
-            release: {
-              major: '10',
-            },
-          },
-          platform_tag: 'solaris-10-sparc',
-                       })
+        override_facts(facts, is_pe: true, os: { architecture: 'sun4u', release: { major: '10', }, }, platform_tag: 'solaris-10-sparc')
       end
 
       it { is_expected.to compile.with_all_deps }
@@ -407,17 +348,7 @@ EOF
 
       context 'with older aio_agent_version' do
         let(:facts) do
-          override_facts(facts, {
-                           aio_agent_version: '1.0.0',
-            is_pe: true,
-            os: {
-              architecture: 'sun4u',
-              release: {
-                major: '10',
-              },
-            },
-            platform_tag: 'solaris-10-sparc',
-                         })
+          override_facts(facts, aio_agent_version: '1.0.0', is_pe: true, os: { architecture: 'sun4u', release: { major: '10', }, }, platform_tag: 'solaris-10-sparc')
         end
 
         it do

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -27,12 +27,7 @@ describe 'puppet_agent' do
   describe 'unsupported environment' do
     context 'when not SLES' do
       let(:facts) do
-        override_facts(facts,
-        {
-          os: {
-            name: 'OpenSuse',
-          }
-        })
+        override_facts(facts, os: { name: 'OpenSuse', })
       end
 
       it { expect { catalogue }.to raise_error(%r{OpenSuse not supported}) }
@@ -45,16 +40,7 @@ describe 'puppet_agent' do
         ['11', '12', '15'].each do |os_version|
           context "when SLES #{os_version}" do
             let(:facts) do
-              override_facts(facts,
-                              {
-                                is_pe: false,
-                                os: {
-                                  release: {
-                                    major: os_version,
-                                  },
-                                },
-                                platform_tag: "sles-#{os_version}-x86_64",
-                              })
+              override_facts(facts, is_pe: false, os: { release: { major: os_version, }, }, platform_tag: "sles-#{os_version}-x86_64")
             end
 
             let(:params) do
@@ -247,15 +233,7 @@ SCRIPT
         ['11', '12', '15'].each do |os_version|
           context "when SLES #{os_version}" do
             let(:facts) do
-              override_facts(facts,
-              {
-                os: {
-                  release: {
-                    major: os_version,
-                  },
-                },
-                platform_tag: "sles-#{os_version}-x86_64",
-              })
+              override_facts(facts, os: { release: { major: os_version, }, }, platform_tag: "sles-#{os_version}-x86_64")
             end
 
             context 'with manage_pki_dir => true' do


### PR DESCRIPTION
This PR fixes an issue with rspec tests not using keyword arguments with the `override_facts` helper method, which causes issues with later versions of Ruby as keyword argument behavior changes from Ruby >= 3.

This PR also replaces puppet5 tests with nightly gems with puppet8 on Ruby 3.2. 

I tested these commits locally by running `bundle exec rake parallel_spec` on both Ruby 2.7.7 and Ruby 3.2.1.