### PR TITLE
(maint) Unpin Octokit gem

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -39,8 +39,6 @@ Gemfile:
       - gem: 'beaker-task_helper'
         version: '~> 1.9'
         condition: 'ENV["GEM_BOLT"]'
-      - gem: octokit
-        version: '4.21.0' # due to https://github.com/octokit/octokit.rb/issues/1391
       - gem: async
         version: '~> 1.30' # otherwise async 2.0.0(needs ruby >=3.1.0) is wrongly selected by bundler on jenkins while running with ruby 2.7.1
       - gem: puppet_litmus

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,6 @@ group :development do
   gem "nokogiri",                                                               require: false
   gem "bolt", '~> 3.0',                                                         require: false if ENV["GEM_BOLT"]
   gem "beaker-task_helper", '~> 1.9',                                           require: false if ENV["GEM_BOLT"]
-  gem "octokit", '4.21.0',                                                      require: false
   gem "async", '~> 1.30',                                                       require: false
 end
 group :system_tests do


### PR DESCRIPTION
In 99d7dcb we pinned Octokit to 4.21.0 due to an issue with authentication and the Faraday gem in Octokit 4.22.0. There was a fix for this issue in 4.23.0, so we no longer need to pin back.

This gem is used to generate changelogs in release prep, and other modules (i.e. Puppet core modules) have used newer versions of Octokit (4.25.0) without issue.

This commit removes the pin for Octokit to 4.21.0.