### PR TITLE
(maint) Enable puppetserver 8 nightlies

### DIFF
--- a/acceptance/helpers.rb
+++ b/acceptance/helpers.rb
@@ -87,9 +87,7 @@ module Beaker::DSL
       if args.is_a?(Symbol)
         collection = args.to_s
 
-        # Dirty, temporary workaround for when we have puppet8 agent nightlies but not server nightlies
-        # Once we have puppet8 server releases, remove the second conditional
-        unless collection.include?(server_collection) || collection == 'puppet8-nightly'
+        unless collection.include?(server_collection)
           skip_test(msg_prefix + "\nThis test requires a puppetserver from the #{collection} collection. Skipping the test ...")
         end
 

--- a/acceptance/pre_suite/00_master_setup.rb
+++ b/acceptance/pre_suite/00_master_setup.rb
@@ -30,14 +30,7 @@ test_name 'Pre-Suite: Install, configure, and start a compatible puppetserver on
 
   step 'Install puppetserver' do
     # puppetserver is distributed in "release streams" instead of collections.
-
-    # Dirty, temporary workaround for when we have puppet8 agent nightlies but not server nightlies
-    # Once we have puppet8 server releases, pare down to just what's in the else statement
-    opts = if install_options[:puppet_collection].include?('nightly')
-             { release_stream: 'puppet7' }
-           else
-             { release_stream: install_options[:puppet_collection] }
-           end
+    opts = { release_stream: install_options[:puppet_collection] }
 
     install_puppetserver_on(master, opts)
 


### PR DESCRIPTION
Nightlies for puppetserver 8 have started to ship as of yesterday.

This commit enables the puppet7 to puppet8 upgrade test to use puppetserver 8 nightlies.