### PR TITLE
(PA-5336) Update tests and tasks for puppet8

### DIFF
--- a/.github/workflows/task_acceptance_tests.yaml
+++ b/.github/workflows/task_acceptance_tests.yaml
@@ -15,7 +15,7 @@ jobs:
         os: [ 'centos-7', 'ubuntu-20.04', 'rocky-8' ]
 
     env:
-      ruby_version: 2.5
+      ruby_version: '3.1'
       GEM_BOLT: true
       BEAKER_debug: true
       BEAKER_set: docker/${{ matrix.os }}

--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -66,9 +66,7 @@ describe 'install task' do
     #   puppet_8_collection = 'puppet8-nightly'
     # else
     puppet_7_collection = 'puppet7'
-    # We currently only have nightly builds of puppet8 available. Update
-    # this to the normal collection once we have a release.
-    puppet_8_collection = 'puppet8-nightly'
+    puppet_8_collection = 'puppet8'
     # end
 
     # We can only test puppet 7 -> 7 upgrades if multiple Puppet releases
@@ -203,29 +201,13 @@ describe 'install task' do
 
     # Verify that it upgraded
     installed_version = nil
-    # With prerelease puppet8, the puppet_agent::version task returns the wrong
-    # output. To temporarily work around this, we'll run puppet --version.
-    # Revert this change once Puppet 8.0.0 has been released.
-    # results = run_task('puppet_agent::version', 'target', {})
-    results = if %r{win}.match?(target_platform)
-                run_command('c:/"program files"/"puppet labs"/puppet/bin/puppet --version', 'target')
-              else
-                run_command('/opt/puppetlabs/bin/puppet --version', 'target')
-              end
-    results.each do |res|
-      expect(res).to include('status' => 'success')
-      installed_version = res['value']['stdout']
-      expect(installed_version).not_to match(%r{^7\.\d+\.\d+})
-      expect(installed_version).to match(%r{^8\.\d+\.\d+})
-      # We don't get the expected output with prerelease puppet8
-      # expect(res['value']['source']).to be
-    end
-
-    # More prerelease puppet8 workarounds, this block can also be deleted
-    # once Puppet 8.0.0 has been released.
     results = run_task('puppet_agent::version', 'target', {})
     results.each do |res|
+      expect(res).to include('status' => 'success')
       installed_version = res['value']['version']
+      expect(installed_version).not_to match(%r{^7\.\d+\.\d+})
+      expect(installed_version).to match(%r{^8\.\d+\.\d+})
+      expect(res['value']['source']).to be
     end
 
     # Try installing the same version again

--- a/tasks/install.json
+++ b/tasks/install.json
@@ -7,7 +7,7 @@
     },
     "collection": {
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
-      "type": "Optional[Enum[puppet7, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly]]"
+      "type": "Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly]]"
     },
     "absolute_source": {
       "description": "The absolute source location to find the Puppet agent package",

--- a/tasks/install_powershell.json
+++ b/tasks/install_powershell.json
@@ -8,7 +8,7 @@
     },
     "collection": {
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
-      "type": "Optional[Enum[puppet7, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly]]"
+      "type": "Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly]]"
     },
     "absolute_source": {
       "description": "The absolute source location to find the Puppet agent package",

--- a/tasks/install_shell.json
+++ b/tasks/install_shell.json
@@ -9,7 +9,7 @@
     },
     "collection": {
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
-      "type": "Optional[Enum[puppet7, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly]]"
+      "type": "Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly]]"
     },
     "absolute_source": {
       "description": "The absolute source location to find the Puppet agent package",


### PR DESCRIPTION
This commit updates acceptance tests and tasks for the puppet8 final release. Previously, these things only accounted for the nightly releases.