### PR TITLE
(maint) Release prep

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -58,4 +58,4 @@ spec/default_facts.yml:
 spec/spec_helper.rb:
   unmanaged: true
 Rakefile:
-  changelog_since_tag: 'v4.12.1'
+  changelog_since_tag: 'v4.13.0'

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,28 @@
+## [v4.14.0] - 2023-04-27
+
+### Summary
+
+Add support for Puppet 8.
+
+### Features
+
+- (PA-5336) Update tests and tasks for puppet8 ([#650](https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/650))
+
+## [v4.13.0] - 2023-03-21
+
+### Summary
+
+Add support for Puppet 8 nightlies, additional platform support, new features for run task/plan and install task.
+
+### Features
+
+- Add support for absolute_source in puppet_agent::install task ([#484](https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/484))
+- (FM-8969) Add support for macOS 12 ARM ([#615](https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/615))
+- Support for Linux Mint 21 ([#616](https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/616))
+- (FM-8983) Add Fedora 36 ([#619](https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/619))
+- run task/plan: Allow noop and environment option ([#632](https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/632/))
+- (MODULES-11361) Puppet 8 compatibility work ([#636](https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/636))
+
 ## [v4.12.1] - 2022-07-13
 
 ### Summary

--- a/Rakefile
+++ b/Rakefile
@@ -50,7 +50,7 @@ if Bundler.rubygems.find_name('github_changelog_generator').any?
     raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?
     config.user = "#{changelog_user}"
     config.project = "#{changelog_project}"
-    config.since_tag = "v4.12.1"
+    config.since_tag = "v4.13.0"
     config.future_release = "#{changelog_future_release}"
     config.exclude_labels = ['maintenance']
     config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."


### PR DESCRIPTION
This PR comprises changes necessary for GitHub Changelog Generator to not get rate-limited by GitHub (as seen [here](https://github.com/puppetlabs/puppetlabs-puppet_agent/actions/runs/4823900586/jobs/8592997755)) when attempting to iterate through this repository's pull requests and issues.