### PR TITLE
Implement stdlib 9 compatibility

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -17,5 +17,3 @@ fixtures:
     facts:
       repo: "puppetlabs/facts"
       ref: "1.4.0"
-  symlinks:
-    puppet_agent: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,7 @@
 fixtures:
+  repositories:
+    stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'
   forge_modules:
-    stdlib:
-      repo: "puppetlabs/stdlib"
-      ref: "8.4.0"
     inifile:
       repo: "puppetlabs/inifile"
       ref: "5.3.0"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,8 +43,9 @@ class puppet_agent::params {
   # The `is_pe` fact currently works by echoing out the puppet version
   # and greping for "puppet enterprise". With Puppet 4 and PE 2015.2, there
   # is no longer a "PE Puppet", and so that fact will no longer work.
-  # Instead check for the `is_pe` fact or if a PE provided function is available
-  $_is_pe = (getvar('::is_pe') or is_function_available('pe_compiling_server_version'))
+  # Instead check for the `is_pe` fact or if the `pe_anchor` resource type
+  # provided by the puppet_enterprise module exist.
+  $_is_pe = (getvar('::is_pe') or defined('pe_anchor'))
   if $_is_pe {
     # Calculate the default collection
     $_pe_version = pe_build_version()

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -69,17 +69,9 @@ class puppet_agent::params {
     else {
       $collection = 'puppet8'
     }
-    # The aio puppet-agent version currently installed on the compiling master
-    # (only used in PE)
-    if is_function_available('pe_compiling_server_aio_build') {
-      $master_agent_version = pe_compiling_server_aio_build()
-    } else {
-      $master_agent_version = undef
-    }
   } else {
     $_pe_version = undef
     $pe_repo_dir = undef
-    $master_agent_version = undef
     $collection = 'PC1'
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 5.1.0 < 9.0.0"
+      "version_requirement": ">= 5.1.0 < 10.0.0"
     },
     {
       "name": "puppetlabs-inifile",

--- a/spec/classes/puppet_agent_osfamily_aix_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_aix_spec.rb
@@ -35,7 +35,6 @@ describe 'puppet_agent' do
 
     before(:each) do
       Puppet::Parser::Functions.newfunction(:pe_build_version, type: :rvalue) { |_args| '2000.0.0' }
-      Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, type: :rvalue) { |_args| '1.10.100' }
     end
 
     it { is_expected.to contain_file('/opt/puppetlabs') }
@@ -75,7 +74,6 @@ describe 'puppet_agent' do
 
     before(:each) do
       Puppet::Parser::Functions.newfunction(:pe_build_version, type: :rvalue) { |_args| '2000.0.0' }
-      Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, type: :rvalue) { |_args| '1.10.100' }
     end
 
     it {

--- a/spec/classes/puppet_agent_osfamily_darwin_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_darwin_spec.rb
@@ -1,15 +1,10 @@
 require 'spec_helper'
 
 describe 'puppet_agent' do
-  master_package_version = '1.10.100'
   before(:each) do
     # Need to mock the PE functions
     Puppet::Parser::Functions.newfunction(:pe_build_version, type: :rvalue) do |_args|
       '2000.0.0'
-    end
-
-    Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, type: :rvalue) do |_args|
-      master_package_version
     end
 
     allow(Puppet::FileSystem).to receive(:exist?).and_call_original

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -38,10 +38,6 @@ describe 'puppet_agent' do
       Puppet::Parser::Functions.newfunction(:pe_build_version, type: :rvalue) do |_args|
         '2000.0.0'
       end
-
-      Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, type: :rvalue) do |_args|
-        package_version
-      end
     end
 
     let(:facts) do

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -168,10 +168,6 @@ SCRIPT
         Puppet::Parser::Functions.newfunction(:pe_build_version, type: :rvalue) do |_args|
           '2000.0.0'
         end
-
-        Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, type: :rvalue) do |_args|
-          '5.5.4'
-        end
       end
 
       let(:facts) do

--- a/spec/classes/puppet_agent_osfamily_solaris_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_solaris_spec.rb
@@ -100,10 +100,6 @@ EOF
         pe_version
       end
 
-      Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, type: :rvalue) do |_args|
-        package_version
-      end
-
       # Ensure we get a versionable package provider
       pkg = Puppet::Type.type(:package)
       allow(pkg).to receive(:defaultprovider).and_return(pkg.provider(:pkg))
@@ -309,10 +305,6 @@ EOF
         # Need to mock the PE functions
         Puppet::Parser::Functions.newfunction(:pe_build_version, type: :rvalue) do |_args|
           pe_version
-        end
-
-        Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, type: :rvalue) do |_args|
-          package_version
         end
       end
 

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -222,10 +222,6 @@ SCRIPT
       Puppet::Parser::Functions.newfunction(:pe_build_version, type: :rvalue) do |_args|
         '2000.0.0'
       end
-
-      Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, type: :rvalue) do |_args|
-        package_version
-      end
     end
 
     describe 'supported environment' do

--- a/spec/classes/puppet_agent_osfamily_windows_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_windows_spec.rb
@@ -13,10 +13,6 @@ describe 'puppet_agent' do
       pe_version
     end
 
-    Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, type: :rvalue) do |_args|
-      package_version
-    end
-
     allow(Puppet::Util).to receive(:absolute_path?).and_call_original
     allow(Puppet::Util).to receive(:absolute_path?).with(version_file).and_return true
     allow(Puppet::FileSystem).to receive(:exist?).and_call_original

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -237,7 +237,7 @@ describe 'puppet_agent' do
         before(:each) do
           Puppet::Parser::Functions.newfunction(:pe_build_version, type: :rvalue) { |_args| '2000.0.0' }
           Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, type: :rvalue) { |_args| '1.10.100' }
-          Puppet::Parser::Functions.newfunction(:pe_compiling_server_version, type: :rvalue) { |_args| '2.20.200' }
+          Puppet::Parser::Functions.newfunction(:defined, type: :rvalue) { |_args| true }
         end
 
         context 'package_version is initialized automatically' do

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -201,14 +201,6 @@ describe 'puppet_agent' do
           end
         end
 
-        context 'package_version is undef if pe_compiling_server_aio_build is not defined' do
-          let(:facts) do
-            global_facts(facts, os).merge(is_pe: true)
-          end
-
-          it { is_expected.to contain_class('puppet_agent').with_package_version(nil) }
-        end
-
         context 'package_version is same as master when set to auto' do
           let(:params) { { package_version: 'auto' } }
           let(:node_params) { { serverversion: '7.6.5' } }
@@ -267,10 +259,6 @@ describe 'puppet_agent' do
             # Need to mock the PE functions
             Puppet::Parser::Functions.newfunction(:pe_build_version, type: :rvalue) do |_args|
               '2000.0.0'
-            end
-
-            Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, type: :rvalue) do |_args|
-              '1.10.100'
             end
           end
         end

--- a/spec/classes/puppet_agent_windows_install_spec.rb
+++ b/spec/classes/puppet_agent_windows_install_spec.rb
@@ -33,10 +33,6 @@ RSpec.describe 'puppet_agent', tag: 'win' do
           Puppet::Parser::Functions.newfunction(:pe_build_version, type: :rvalue) do |_args|
             '4.10.100'
           end
-
-          Puppet::Parser::Functions.newfunction(:pe_compiling_server_aio_build, type: :rvalue) do |_args|
-            package_version
-          end
         end
 
         let(:facts) { facts.merge({ is_pe: true }) }


### PR DESCRIPTION
stdlib 9 dropped the `is_function_available()` function. I reworked the code to check if `pe_anchor` is defined. The code now works with Puppet core functions and is compatible with Puppet 7/8, probably 6, and does not rely on stdlib.