### PR TITLE
Update solaris to add pkg publisher

### DIFF
--- a/manifests/osfamily/solaris.pp
+++ b/manifests/osfamily/solaris.pp
@@ -107,6 +107,12 @@ class puppet_agent::osfamily::solaris {
           logoutput   => 'on_failure',
           refreshonly => true,
         }
+        ~> exec { 'puppet_agent add publisher to pkg':
+          command     => "pkg set-publisher -e -g ${pkgrepo_dir} ${publisher}",
+          path        => '/bin:/usr/bin:/sbin:/usr/sbin',
+          logoutput   => 'on_failure',
+          refreshonly => true,
+        }
         # Make sure the pkg publishers are all available.  Broken
         # publisher entries will stop the installation process.
         # This must happen before removing any packages.


### PR DESCRIPTION
The Solaris class only set up the repo, it didn't configure the pkg tool to use it. This adds the extra command to configure the "client" side of this to allow the pkg tool to see packages in the repo previously configured.