### PR TITLE
Support for debian absolute_path to be dynamic

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -61,7 +61,10 @@ class puppet_agent::install (
       $_install_options = $install_options
       if $::puppet_agent::absolute_source {
         # absolute_source means we use dpkg on debian based platforms
-        $_package_version = 'present'
+        if ($package_version != 'present' and $package_version != 'latest') {
+          fail('When using $absolute_source on Debian, $package_version must be set to "present" or "latest"')
+        }
+        $_package_version = $package_version
         $_provider = 'dpkg'
         # The source package should have been downloaded by puppet_agent::prepare::package to the local_packages_dir
         $_source = "${::puppet_agent::params::local_packages_dir}/${::puppet_agent::prepare::package::package_file_name}"


### PR DESCRIPTION
For some reason absolute_path for Debian systems is statically set to 'present' in install.pp.
This seems to be because dpkg can't accept $package_version if it is set to a version or 'auto'.

This makes you unable to use a puppet installer locally placed on the system to upgrade your puppet agent on Debian.

Why not set $_package_version = $package_version and then just make sure that it is either 'present' or 'latest' and otherwise fail?

