### PR TITLE
(maint) Make spec tests pass on windows

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -126,6 +126,7 @@ class puppet_agent (
   $wait_for_pxp_agent_exit = undef,
   $wait_for_puppet_run     = undef,
   Array[Puppet_agent::Config] $config = [],
+  $version_file_path       = $facts['os']['family'] ? { 'windows' => "${facts['env_windows_installdir']}\\VERSION", default => '/opt/puppetlabs/puppet/VERSION' }
 ) inherits ::puppet_agent::params {
   # The configure class uses $puppet_agent::config to manage settings in
   # puppet.conf, and will always be present. It does not require management of
@@ -161,7 +162,7 @@ class puppet_agent (
     # The AIO package version and Puppet version can, on rare occasion, diverge.
     # This logic checks for the AIO version of the server, since that's what the package manager cares about.
     if $package_version == 'auto' {
-      $master_or_package_version = chomp(file('/opt/puppetlabs/puppet/VERSION'))
+      $master_or_package_version = chomp(file($version_file_path))
     } else {
       $master_or_package_version = $package_version
     }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -5,7 +5,7 @@ describe 'puppet_agent class' do
   context 'default parameters in apply' do
     before(:all) do
       setup_puppet_on default
-      pp = "class { 'puppet_agent': package_version => 'auto'}"
+      pp = "class { 'puppet_agent': package_version => 'auto', collection => #{PUPPET_COLLECTION}}"
       apply_manifest(pp, catch_failures: true)
     end
     after(:all) { teardown_puppet_on default }

--- a/spec/classes/puppet_agent_osfamily_windows_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_windows_spec.rb
@@ -6,6 +6,7 @@ describe 'puppet_agent' do
 
   let(:params) { { package_version: package_version } }
   let(:version_file) { '/opt/puppetlabs/puppet/VERSION' }
+  let(:windows_version_file) { 'C:\Program Files\Puppet Labs\Puppet\VERSION' }
 
   before(:each) do
     # Need to mock the PE functions
@@ -15,10 +16,13 @@ describe 'puppet_agent' do
 
     allow(Puppet::Util).to receive(:absolute_path?).and_call_original
     allow(Puppet::Util).to receive(:absolute_path?).with(version_file).and_return true
+    allow(Puppet::Util).to receive(:absolute_path?).with(windows_version_file).and_return true
     allow(Puppet::FileSystem).to receive(:exist?).and_call_original
     allow(Puppet::FileSystem).to receive(:read_preserve_line_endings).and_call_original
     allow(Puppet::FileSystem).to receive(:exist?).with(version_file).and_return true
+    allow(Puppet::FileSystem).to receive(:exist?).with(windows_version_file).and_return true
     allow(Puppet::FileSystem).to receive(:read_preserve_line_endings).with(version_file).and_return "1.10.100\n"
+    allow(Puppet::FileSystem).to receive(:read_preserve_line_endings).with(windows_version_file).and_return "1.10.100\n"
   end
 
   [['x64', 'x86_64'], ['x86', 'i386']].each do |arch, tag|
@@ -65,6 +69,7 @@ describe 'puppet_agent' do
           aio_agent_version: '1.0.0',
           clientcert: 'foo.example.vm',
           env_temp_variable: 'C:/tmp',
+          env_windows_installdir: windows_version_file.chomp('\VERSION'),
           is_pe: true,
           os: {
             architecture: arch,
@@ -104,6 +109,7 @@ describe 'puppet_agent' do
         clientcert: 'foo.example.vm',
         env_temp_variable: 'C:/tmp',
         is_pe: true,
+        env_windows_installdir: windows_version_file.chomp('\VERSION'),
         fips_enabled: true,
         os: {
           architecture: arch,

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -22,6 +22,7 @@ end
 # Project root
 PROJ_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 TEST_FILES = File.expand_path(File.join(File.dirname(__FILE__), 'acceptance', 'files'))
+PUPPET_COLLECTION = 'puppet7'.freeze
 
 def install_modules_on(host)
   install_ca_certs_on(host)
@@ -37,7 +38,7 @@ unless ENV['BEAKER_provision'] == 'no'
   master['puppetservice'] = 'puppetserver'
   master['puppetserver-confdir'] = '/etc/puppetlabs/puppetserver/conf.d'
   master['type'] = 'aio'
-  install_puppet_agent_on master, { version: ENV['PUPPET_CLIENT_VERSION'] || '7.23.0', puppet_collection: 'puppet7' }
+  install_puppet_agent_on master, { version: ENV['PUPPET_CLIENT_VERSION'] || '7.23.0', puppet_collection: PUPPET_COLLECTION }
   install_modules_on master
   stop_firewall_on master
 end
@@ -71,7 +72,7 @@ def setup_puppet_on(host, opts = {})
 
   puts "Setup aio puppet on #{host}"
   configure_type_defaults_on host
-  install_puppet_agent_on host, { version: ENV['PUPPET_CLIENT_VERSION'] || '7.23.0', puppet_collection: 'puppet7' }
+  install_puppet_agent_on host, { version: ENV['PUPPET_CLIENT_VERSION'] || '7.23.0', puppet_collection: PUPPET_COLLECTION }
 
   puppet_opts = agent_opts(master.to_s)
   if %r{windows}i.match?(host['platform'])


### PR DESCRIPTION
Windows requires the current puppet collection to be specified in the puppet_agent class, so that is refactored to be globally specified in the `spec_helper_acceptance`. Additionally, logic was added to specifiy default install paths for the VERSION file for both linux and windows.