### PR TITLE
(PA-5721) Add puppet8 and drop puppet5 support from AIX

### DIFF
--- a/manifests/osfamily/aix.pp
+++ b/manifests/osfamily/aix.pp
@@ -15,14 +15,14 @@ class puppet_agent::osfamily::aix {
   # multiple version of AIX. The support sequence is as follows:
   #
   # puppet 5 up to 5.5.22:
-  #     * AIX verison 6.1 < aix-6.1-power package
-  #     * AIX verison 7.1 < aix-7.1-power package
-  #     * AIX verison 7.2 < aix-7.1-power package
+  #     * AIX version 6.1 < aix-6.1-power package
+  #     * AIX version 7.1 < aix-7.1-power package
+  #     * AIX version 7.2 < aix-7.1-power package
   #
-  # puppet 6 up to 6.19.1 and puppet 7.0.0 (not released in PE):
-  #     * AIX verison 6.1 < aix-7.1-power package
-  #     * AIX verison 7.1 < aix-7.1-power package
-  #     * AIX verison 7.2 < aix-7.1-power package
+  # puppet 6 up to 6.19.1 and puppet 7.0.0:
+  #     * AIX version 6.1 < aix-7.1-power package
+  #     * AIX version 7.1 < aix-7.1-power package
+  #     * AIX version 7.2 < aix-7.1-power package
   #
   # All other versions will now _only_ use the aix-7.1-power packages (i.e. we now only ship
   # one package to support all aix versions).
@@ -31,16 +31,8 @@ class puppet_agent::osfamily::aix {
   # on puppet collection, package version and AIX version.
   $_aix_ver_number = regsubst($::platform_tag,'aix-(\d+\.\d+)-power','\1')
   if $_aix_ver_number {
-    if $::puppet_agent::collection =~ /(PC1|puppet5)/ {
-      # 5.5.22 is the last puppet5 release that ships AIX 6.1 packages
-      if versioncmp($::puppet_agent::prepare::package_version, '5.5.22') > 0 {
-        $aix_ver_number = '7.1'
-      } else {
-        $aix_ver_number = $_aix_ver_number ? {
-          /^7\.2$/ => '7.1',
-          default  => $_aix_ver_number,
-        }
-      }
+    if $::puppet_agent::collection =~ /^puppet7/ {
+      $aix_ver_number = '7.1'
     } else {
       # 6.19.1 is the last puppet6 release that ships AIX 6.1 packages
       $aix_ver_number = versioncmp($::puppet_agent::prepare::package_version, '6.19.1') ? {

--- a/manifests/osfamily/aix.pp
+++ b/manifests/osfamily/aix.pp
@@ -24,6 +24,9 @@ class puppet_agent::osfamily::aix {
   #     * AIX version 7.1 < aix-7.1-power package
   #     * AIX version 7.2 < aix-7.1-power package
   #
+  # puppet 8:
+  #     * AIX version 7.2 < aix-7.2-power package
+  #
   # All other versions will now _only_ use the aix-7.1-power packages (i.e. we now only ship
   # one package to support all aix versions).
   #
@@ -31,7 +34,9 @@ class puppet_agent::osfamily::aix {
   # on puppet collection, package version and AIX version.
   $_aix_ver_number = regsubst($::platform_tag,'aix-(\d+\.\d+)-power','\1')
   if $_aix_ver_number {
-    if $::puppet_agent::collection =~ /^puppet7/ {
+    if $::puppet_agent::collection =~ /^puppet8/ {
+      $aix_ver_number = '7.2'
+    } elsif $::puppet_agent::collection =~ /^puppet7/ {
       $aix_ver_number = '7.1'
     } else {
       # 6.19.1 is the last puppet6 release that ships AIX 6.1 packages

--- a/spec/classes/puppet_agent_osfamily_aix_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_aix_spec.rb
@@ -19,7 +19,6 @@ describe 'puppet_agent' do
     allow(Puppet::FileSystem).to receive(:exist?).and_call_original
     allow(Puppet::FileSystem).to receive(:read_preserve_line_endings).and_call_original
     allow(Puppet::FileSystem).to receive(:exist?).with('/opt/puppetlabs/puppet/VERSION').and_return true
-    allow(Puppet::FileSystem).to receive(:read_preserve_line_endings).with('/opt/puppetlabs/puppet/VERSION').and_return "5.10.200\n"
   end
 
   shared_examples 'aix' do |aixver, pkg_aixver, powerver|
@@ -61,13 +60,13 @@ describe 'puppet_agent' do
     let(:facts) do
       common_facts.merge({
                            architecture: 'PowerPC_POWER8',
-                           platform_tag: 'aix-6.1-power',
+                           platform_tag: 'aix-7.1-power',
                          })
     end
     let(:params) do
       {
-        package_version: '5.10.100.1',
-        collection: 'puppet5',
+        package_version: '7.10.100.1',
+        collection: 'puppet7',
         source: 'https://fake-pe-master.com',
       }
     end
@@ -77,55 +76,8 @@ describe 'puppet_agent' do
     end
 
     it {
-      is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-5.10.100.1-1.aix7.1.ppc.rpm').with_source('https://fake-pe-master.com/packages/2000.0.0/aix-7.1-power/puppet-agent-5.10.100.1-1.aix7.1.ppc.rpm')
+      is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-7.10.100.1-1.aix7.1.ppc.rpm').with_source('https://fake-pe-master.com/packages/2000.0.0/aix-7.1-power/puppet-agent-7.10.100.1-1.aix7.1.ppc.rpm')
     }
-  end
-
-  context 'with a PC1 collection' do
-    let(:params) do
-      {
-        package_version: '1.10.100',
-        collection: 'PC1',
-      }
-    end
-
-    [['7.2', '7.1', '8'], ['7.1', '7.1', '8'], ['7.1', '7.1', '7'], ['6.1', '6.1', '7']].each do |aixver, pkg_aixver, powerver|
-      context "aix #{aixver}" do
-        include_examples 'aix', aixver, pkg_aixver, powerver
-      end
-    end
-  end
-
-  context 'with a puppet5 collection' do
-    context 'with versions up to 5.5.22' do
-      let(:params) do
-        {
-          package_version: '5.4.3',
-          collection: 'puppet5',
-        }
-      end
-
-      [['7.2', '7.1', '8'], ['7.1', '7.1', '8'], ['7.1', '7.1', '7'], ['6.1', '6.1', '7']].each do |aixver, pkg_aixver, powerver|
-        context "aix #{aixver}" do
-          include_examples 'aix', aixver, pkg_aixver, powerver
-        end
-      end
-    end
-
-    context 'with versions higher than 5.5.22' do
-      let(:params) do
-        {
-          package_version: '5.5.23',
-          collection: 'puppet5',
-        }
-      end
-
-      [['7.2', '7.1', '8'], ['7.1', '7.1', '8'], ['7.1', '7.1', '7'], ['6.1', '7.1', '7']].each do |aixver, pkg_aixver, powerver|
-        context "aix #{aixver}" do
-          include_examples 'aix', aixver, pkg_aixver, powerver
-        end
-      end
-    end
   end
 
   context 'with a puppet6 collection' do
@@ -185,16 +137,20 @@ describe 'puppet_agent' do
     end
     let(:facts) do
       common_facts.merge({
-                           serverversion: '5.10.200'
+                           serverversion: '7.10.200'
                          })
     end
-    let(:rpmname) { 'puppet-agent-5.10.200-1.aix7.1.ppc.rpm' }
+    let(:rpmname) { 'puppet-agent-7.10.200-1.aix7.1.ppc.rpm' }
+
+    before(:each) do
+      allow(Puppet::FileSystem).to receive(:read_preserve_line_endings).with('/opt/puppetlabs/puppet/VERSION').and_return "7.10.200\n"
+    end
 
     it {
       is_expected.to contain_package('puppet-agent')
         .with({
                 'source'    => "/opt/puppetlabs/packages/#{rpmname}",
-                'ensure'    => '5.10.200',
+                'ensure'    => '7.10.200',
                 'provider'  => 'rpm',
               })
     }

--- a/spec/classes/puppet_agent_osfamily_aix_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_aix_spec.rb
@@ -129,6 +129,23 @@ describe 'puppet_agent' do
     end
   end
 
+  context 'with a puppet8 collection' do
+    context 'with versions greater than or equal to 8.0.0' do
+      let(:params) do
+        {
+          package_version: '8.0.0',
+          collection: 'puppet8',
+        }
+      end
+
+      [['7.2', '7.2', '7']].each do |aixver, pkg_aixver, powerver|
+        context "aix #{aixver}" do
+          include_examples 'aix', aixver, pkg_aixver, powerver
+        end
+      end
+    end
+  end
+
   context 'with package_version auto' do
     let(:params) do
       {


### PR DESCRIPTION
Drop puppet5/PE 2018.x support for AIX

AIX 7.1 is not supported in puppet8 and will be removed from puppet7 in the near future.