### PR TITLE
(maint) Update commits.rake to check for "Release prep"

### DIFF
--- a/rakelib/commits.rake
+++ b/rakelib/commits.rake
@@ -7,7 +7,7 @@ task(:commits) do
   %x{git log --no-merges --pretty=%s #{commit_range}}.each_line do |commit_summary|
     # This regex tests for the currently supported commit summary tokens.
     # The exception tries to explain it in more full.
-    if /^\((maint|packaging|doc|docs|pa-\d+)\)|revert/i.match(commit_summary).nil?
+    if /^Release prep|\((maint|packaging|doc|docs|pa-\d+)\)|revert/i.match(commit_summary).nil?
       raise "\n\n\n\tThis commit summary didn't match CONTRIBUTING.md guidelines:\n" \
         "\n\t\t#{commit_summary}\n" \
         "\tThe commit summary (i.e. the first line of the commit message) should start with one of:\n"  \


### PR DESCRIPTION
Currently, the "Static Code Analysis / Run checks" will fail on release prep PRs because the check does not include "Release prep". This commit updates the commits Rake task to check for "Release prep" in the PR title/name.