### PR TITLE
(PA-5266) Change checksum algorithm to SHA256 

### DIFF
--- a/manifests/prepare/package.pp
+++ b/manifests/prepare/package.pp
@@ -27,12 +27,11 @@ class puppet_agent::prepare::package (
   }
 
   file { $local_package_file_path:
-    ensure   => file,
-    owner    => $puppet_agent::params::user,
-    group    => $puppet_agent::params::group,
-    mode     => $mode,
-    source   => $source,
-    require  => File[$puppet_agent::params::local_packages_dir],
-    checksum => sha256lite,
+    ensure  => file,
+    owner   => $puppet_agent::params::user,
+    group   => $puppet_agent::params::group,
+    mode    => $mode,
+    source  => $source,
+    require => File[$puppet_agent::params::local_packages_dir],
   }
 }

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -292,14 +292,13 @@ SCRIPT
 
       it {
         is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-6.12.0.rpm')
-          .with('path'     => '/opt/puppetlabs/packages/puppet-agent-6.12.0.rpm')
-          .with('ensure'   => 'file')
-          .with('owner'    => '0')
-          .with('group'    => '0')
-          .with('mode'     => '0644')
-          .with('source'   => 'http://just-some-download/url:90/puppet-agent-6.12.0.rpm')
+          .with('path'   => '/opt/puppetlabs/packages/puppet-agent-6.12.0.rpm')
+          .with('ensure' => 'file')
+          .with('owner'  => '0')
+          .with('group'  => '0')
+          .with('mode'   => '0644')
+          .with('source' => 'http://just-some-download/url:90/puppet-agent-6.12.0.rpm')
           .that_requires('File[/opt/puppetlabs/packages]')
-          .with('checksum' => 'sha256lite')
       }
 
       it {


### PR DESCRIPTION
Prior to this commit, the puppet_agent::prepare::package class used the sha256lite algorithm in the file resource for local installation packages.

In certain circumstances (e.g. when a download is interrupted), this checksum, which only checks the first N bytes, does not provide sufficient information to determine if the file is actually there.

This commit updates the file resource to use the more complete sha256 algorithm to handle cases like this.