### PR TITLE
(maint) Update optional parameters

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -64,8 +64,7 @@
 
 ### <a name="puppet_agent"></a>`puppet_agent`
 
-example for clients in dmz:s that need to use proxy to reach the repo
-  provided by puppetserver.
+Upgrades Puppet 4 and newer to the requested version.
 
 #### Parameters
 
@@ -343,6 +342,8 @@ Default value: `[]`
 Data type: `Optional`
 
 This is to be able to configure yum-repo with proxy, needed for
+example for clients in DMZs that need to use proxy to reach the repo
+provided by puppetserver.
 
 Default value: `undef`
 
@@ -388,15 +389,15 @@ The following parameters are available in the `puppet_agent::install` class:
 
 ##### <a name="-puppet_agent--install--package_version"></a>`package_version`
 
-Data type: `String`
+Data type: `Optional[String]`
 
 The puppet-agent version to install.
 
-Default value: `'present'`
+Default value: `undef`
 
 ##### <a name="-puppet_agent--install--install_dir"></a>`install_dir`
 
-Data type: `Optional`
+Data type: `Optional[[Stdlib::Absolutepath]]`
 
 The directory the puppet agent should be installed to. This is only applicable for
 windows operating systems.
@@ -405,7 +406,7 @@ Default value: `undef`
 
 ##### <a name="-puppet_agent--install--install_options"></a>`install_options`
 
-Data type: `Array`
+Data type: `Optional[Array]`
 
 An array of additional options to pass when installing puppet-agent. Each option in
 the array can either be a string or a hash. Each option will automatically be quoted
@@ -415,7 +416,7 @@ the installation command, forward slashes won't be automatically converted like 
 are in `file` resources.) Note also that backslashes in double-quoted strings _must_
 be escaped and backslashes in single-quoted strings _can_ be escaped.
 
-Default value: `[]`
+Default value: `undef`
 
 ### <a name="puppet_agent--install--darwin"></a>`puppet_agent::install::darwin`
 
@@ -430,13 +431,13 @@ The following parameters are available in the `puppet_agent::install::darwin` cl
 
 ##### <a name="-puppet_agent--install--darwin--package_version"></a>`package_version`
 
-Data type: `Optional`
+Data type: `String`
 
 The puppet-agent version to install.
 
 ##### <a name="-puppet_agent--install--darwin--install_options"></a>`install_options`
 
-Data type: `Array`
+Data type: `Optional[Array]`
 
 An array of additional options to pass when installing puppet-agent. Each option in
 the array can either be a string or a hash. Each option will automatically be quoted
@@ -446,7 +447,7 @@ the installation command, forward slashes won't be automatically converted like 
 are in `file` resources.) Note also that backslashes in double-quoted strings _must_
 be escaped and backslashes in single-quoted strings _can_ be escaped.
 
-Default value: `[]`
+Default value: `undef`
 
 ### <a name="puppet_agent--install--solaris"></a>`puppet_agent::install::solaris`
 
@@ -461,13 +462,13 @@ The following parameters are available in the `puppet_agent::install::solaris` c
 
 ##### <a name="-puppet_agent--install--solaris--package_version"></a>`package_version`
 
-Data type: `Optional`
+Data type: `String`
 
 The puppet-agent version to install.
 
 ##### <a name="-puppet_agent--install--solaris--install_options"></a>`install_options`
 
-Data type: `Array`
+Data type: `Optional[Array]`
 
 An array of additional options to pass when installing puppet-agent. Each option in
 the array can either be a string or a hash. Each option will automatically be quoted
@@ -477,7 +478,7 @@ the installation command, forward slashes won't be automatically converted like 
 are in `file` resources.) Note also that backslashes in double-quoted strings _must_
 be escaped and backslashes in single-quoted strings _can_ be escaped.
 
-Default value: `[]`
+Default value: `undef`
 
 ### <a name="puppet_agent--install--suse"></a>`puppet_agent::install::suse`
 
@@ -492,13 +493,13 @@ The following parameters are available in the `puppet_agent::install::suse` clas
 
 ##### <a name="-puppet_agent--install--suse--package_version"></a>`package_version`
 
-Data type: `Optional`
+Data type: `String`
 
 The puppet-agent version to install.
 
 ##### <a name="-puppet_agent--install--suse--install_options"></a>`install_options`
 
-Data type: `Array`
+Data type: `Optional[Array]`
 
 An array of additional options to pass when installing puppet-agent.
 Each option in the array can either be a string or a hash.
@@ -509,7 +510,7 @@ command, forward slashes won't be automatically converted like they are in
 `file` resources.) Note also that backslashes in double-quoted strings
 _must_ be escaped and backslashes in single-quoted strings _can_ be escaped.
 
-Default value: `[]`
+Default value: `undef`
 
 ### <a name="puppet_agent--install--windows"></a>`puppet_agent::install::windows`
 
@@ -608,9 +609,10 @@ The following parameters are available in the `puppet_agent::prepare::package` c
 
 ##### <a name="-puppet_agent--prepare--package--source"></a>`source`
 
-Data type: `Optional`
+Data type: `Variant[String, Array]`
 
-
+The source file for the puppet-agent package. Can use any of the data types
+and protocols that the File resource's source attribute can.
 
 ### <a name="puppet_agent--prepare--puppet_config"></a>`puppet_agent::prepare::puppet_config`
 
@@ -624,7 +626,7 @@ The following parameters are available in the `puppet_agent::prepare::puppet_con
 
 ##### <a name="-puppet_agent--prepare--puppet_config--package_version"></a>`package_version`
 
-Data type: `Optional`
+Data type: `String`
 
 The puppet-agent version to install.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -95,8 +95,8 @@
 #   This parameter is constrained to managing only a predetermined set of configuration
 #   settings, e.g. runinterval.
 # @param proxy
-#    This is to be able to configure yum-repo with proxy, needed for
-#   example for clients in dmz:s that need to use proxy to reach the repo
+#   This is to be able to configure yum-repo with proxy, needed for
+#   example for clients in DMZs that need to use proxy to reach the repo
 #   provided by puppetserver.
 # @param version_file_path
 #    The default install path for the VERSION file

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,9 +14,9 @@
 #   are in `file` resources.) Note also that backslashes in double-quoted strings _must_
 #   be escaped and backslashes in single-quoted strings _can_ be escaped.
 class puppet_agent::install (
-  String   $package_version = 'present',
-  Optional $install_dir     = undef,
-  Array    $install_options = [],
+  Optional[String]                 $package_version = undef,
+  Optional[[Stdlib::Absolutepath]] $install_dir     = undef,
+  Optional[Array]                  $install_options = undef,
 ) {
   assert_private()
 

--- a/manifests/install/darwin.pp
+++ b/manifests/install/darwin.pp
@@ -12,8 +12,8 @@
 #   are in `file` resources.) Note also that backslashes in double-quoted strings _must_
 #   be escaped and backslashes in single-quoted strings _can_ be escaped.
 class puppet_agent::install::darwin (
-  Optional $package_version,
-  Array    $install_options = [],
+  String          $package_version,
+  Optional[Array] $install_options = undef,
 ) {
   assert_private()
   $install_script = 'osx_install.sh.erb'

--- a/manifests/install/solaris.pp
+++ b/manifests/install/solaris.pp
@@ -12,8 +12,8 @@
 #   are in `file` resources.) Note also that backslashes in double-quoted strings _must_
 #   be escaped and backslashes in single-quoted strings _can_ be escaped.
 class puppet_agent::install::solaris (
-  Optional $package_version,
-  Array    $install_options = [],
+  String          $package_version,
+  Optional[Array] $install_options = undef,
 ) {
   assert_private()
   if $facts['os']['release']['major'] == '10' {

--- a/manifests/install/suse.pp
+++ b/manifests/install/suse.pp
@@ -13,8 +13,8 @@
 #   `file` resources.) Note also that backslashes in double-quoted strings
 #   _must_ be escaped and backslashes in single-quoted strings _can_ be escaped.
 class puppet_agent::install::suse (
-  Optional $package_version,
-  Array    $install_options = [],
+  String          $package_version,
+  Optional[Array] $install_options = undef,
 ) {
   assert_private()
 

--- a/manifests/prepare/package.pp
+++ b/manifests/prepare/package.pp
@@ -3,8 +3,10 @@
 # working with a remote https repository.
 #
 # @param source
+#   The source file for the puppet-agent package. Can use any of the data types
+#   and protocols that the File resource's source attribute can.
 class puppet_agent::prepare::package (
-  Optional $source,
+  Variant[String, Array] $source,
 ) {
   assert_private()
 

--- a/manifests/prepare/puppet_config.pp
+++ b/manifests/prepare/puppet_config.pp
@@ -3,7 +3,7 @@
 # @param package_version
 #   The puppet-agent version to install.
 class puppet_agent::prepare::puppet_config (
-  Optional $package_version,
+  String $package_version,
 ) {
   assert_private()
   $puppetconf = $puppet_agent::params::config


### PR DESCRIPTION
As part of 404df9d all parameters in this module were assigned a data type. However, some required parameters were mistakenly classed as Optional and vice-versa.

Puppet's documentation states "If a class parameter lacks a default value, the parameter is considered required."[1]

This commit updates all parameters with default values to Optional (and whatever other relevant data type) and all parameters without default value as required. The REFERENCE.md has been updated to reflect these changes.

Additionally, this commit updates all Optional parameters be set as undef, as suggested by the optional_default puppet-lint check.

[1] https://www.puppet.com/docs/puppet/7/lang_classes#class-parameters-and-variables