### PR TITLE
Match allowed datatypes to yumrepo skip_if_unavailable support

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -357,9 +357,9 @@ Default value: `$facts['os']['family'] ? { 'windows' => "${facts['env_windows_in
 
 ##### <a name="-puppet_agent--skip_if_unavailable"></a>`skip_if_unavailable`
 
-Data type: `String`
+Data type: `Variant[Boolean, String]`
 
-
+For yum-based repositories, set the skip_if_unavailable option of the `yumrepo` type.
 
 Default value: `'absent'`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,6 +101,7 @@
 # @param version_file_path
 #    The default install path for the VERSION file
 # @param skip_if_unavailable
+#    For yum-based repositories, set the skip_if_unavailable option of the `yumrepo` type.
 # @param disable_proxy
 class puppet_agent (
   String                         $arch                    = $facts['os']['architecture'],
@@ -125,7 +126,7 @@ class puppet_agent (
   Boolean                        $disable_proxy           = false,
   Optional                       $proxy                   = undef,
   Array                          $install_options         = [],
-  String                         $skip_if_unavailable     = 'absent',
+  Variant[Boolean, String]       $skip_if_unavailable     = 'absent',
   Boolean                        $msi_move_locked_files   = false,
   Optional                       $wait_for_pxp_agent_exit = undef,
   Optional                       $wait_for_puppet_run     = undef,


### PR DESCRIPTION
In PR #663 an overly strict datatype was set for the skip_if_unavailable parameter. The yumrepo type supports a variety of string values and boolean values.