### PR TITLE
(PA-5820) Correct parameter types

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -389,15 +389,15 @@ The following parameters are available in the `puppet_agent::install` class:
 
 ##### <a name="-puppet_agent--install--package_version"></a>`package_version`
 
-Data type: `Optional[String]`
+Data type: `String`
 
 The puppet-agent version to install.
 
-Default value: `undef`
+Default value: `'present'`
 
 ##### <a name="-puppet_agent--install--install_dir"></a>`install_dir`
 
-Data type: `Optional[[Stdlib::Absolutepath]]`
+Data type: `Optional[Stdlib::Absolutepath]`
 
 The directory the puppet agent should be installed to. This is only applicable for
 windows operating systems.
@@ -406,7 +406,7 @@ Default value: `undef`
 
 ##### <a name="-puppet_agent--install--install_options"></a>`install_options`
 
-Data type: `Optional[Array]`
+Data type: `Array[Variant[String, Hash]]`
 
 An array of additional options to pass when installing puppet-agent. Each option in
 the array can either be a string or a hash. Each option will automatically be quoted
@@ -416,7 +416,7 @@ the installation command, forward slashes won't be automatically converted like 
 are in `file` resources.) Note also that backslashes in double-quoted strings _must_
 be escaped and backslashes in single-quoted strings _can_ be escaped.
 
-Default value: `undef`
+Default value: `[]`
 
 ### <a name="puppet_agent--install--darwin"></a>`puppet_agent::install::darwin`
 
@@ -437,7 +437,7 @@ The puppet-agent version to install.
 
 ##### <a name="-puppet_agent--install--darwin--install_options"></a>`install_options`
 
-Data type: `Optional[Array]`
+Data type: `Array[Variant[String, Hash]]`
 
 An array of additional options to pass when installing puppet-agent. Each option in
 the array can either be a string or a hash. Each option will automatically be quoted
@@ -447,7 +447,7 @@ the installation command, forward slashes won't be automatically converted like 
 are in `file` resources.) Note also that backslashes in double-quoted strings _must_
 be escaped and backslashes in single-quoted strings _can_ be escaped.
 
-Default value: `undef`
+Default value: `[]`
 
 ### <a name="puppet_agent--install--solaris"></a>`puppet_agent::install::solaris`
 
@@ -468,7 +468,7 @@ The puppet-agent version to install.
 
 ##### <a name="-puppet_agent--install--solaris--install_options"></a>`install_options`
 
-Data type: `Optional[Array]`
+Data type: `Array[Variant[String, Hash]]`
 
 An array of additional options to pass when installing puppet-agent. Each option in
 the array can either be a string or a hash. Each option will automatically be quoted
@@ -478,7 +478,7 @@ the installation command, forward slashes won't be automatically converted like 
 are in `file` resources.) Note also that backslashes in double-quoted strings _must_
 be escaped and backslashes in single-quoted strings _can_ be escaped.
 
-Default value: `undef`
+Default value: `[]`
 
 ### <a name="puppet_agent--install--suse"></a>`puppet_agent::install::suse`
 
@@ -499,7 +499,7 @@ The puppet-agent version to install.
 
 ##### <a name="-puppet_agent--install--suse--install_options"></a>`install_options`
 
-Data type: `Optional[Array]`
+Data type: `Array[Variant[String, Hash]]`
 
 An array of additional options to pass when installing puppet-agent.
 Each option in the array can either be a string or a hash.
@@ -510,7 +510,7 @@ command, forward slashes won't be automatically converted like they are in
 `file` resources.) Note also that backslashes in double-quoted strings
 _must_ be escaped and backslashes in single-quoted strings _can_ be escaped.
 
-Default value: `undef`
+Default value: `[]`
 
 ### <a name="puppet_agent--install--windows"></a>`puppet_agent::install::windows`
 
@@ -525,7 +525,7 @@ The following parameters are available in the `puppet_agent::install::windows` c
 
 ##### <a name="-puppet_agent--install--windows--install_options"></a>`install_options`
 
-Data type: `Array`
+Data type: `Array[Variant[String, Hash]]`
 
 An array of additional options to pass when installing puppet-agent. Each option in
 the array can either be a string or a hash. Each option will automatically be quoted

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,9 +14,9 @@
 #   are in `file` resources.) Note also that backslashes in double-quoted strings _must_
 #   be escaped and backslashes in single-quoted strings _can_ be escaped.
 class puppet_agent::install (
-  Optional[String]                 $package_version = undef,
-  Optional[[Stdlib::Absolutepath]] $install_dir     = undef,
-  Optional[Array]                  $install_options = undef,
+  String                         $package_version = 'present',
+  Optional[Stdlib::Absolutepath] $install_dir     = undef,
+  Array[Variant[String, Hash]]   $install_options = [],
 ) {
   assert_private()
 

--- a/manifests/install/darwin.pp
+++ b/manifests/install/darwin.pp
@@ -12,8 +12,8 @@
 #   are in `file` resources.) Note also that backslashes in double-quoted strings _must_
 #   be escaped and backslashes in single-quoted strings _can_ be escaped.
 class puppet_agent::install::darwin (
-  String          $package_version,
-  Optional[Array] $install_options = undef,
+  String                       $package_version,
+  Array[Variant[String, Hash]] $install_options = [],
 ) {
   assert_private()
   $install_script = 'osx_install.sh.erb'

--- a/manifests/install/solaris.pp
+++ b/manifests/install/solaris.pp
@@ -12,8 +12,8 @@
 #   are in `file` resources.) Note also that backslashes in double-quoted strings _must_
 #   be escaped and backslashes in single-quoted strings _can_ be escaped.
 class puppet_agent::install::solaris (
-  String          $package_version,
-  Optional[Array] $install_options = undef,
+  String                       $package_version,
+  Array[Variant[String, Hash]] $install_options = [],
 ) {
   assert_private()
   if $facts['os']['release']['major'] == '10' {

--- a/manifests/install/suse.pp
+++ b/manifests/install/suse.pp
@@ -13,8 +13,8 @@
 #   `file` resources.) Note also that backslashes in double-quoted strings
 #   _must_ be escaped and backslashes in single-quoted strings _can_ be escaped.
 class puppet_agent::install::suse (
-  String          $package_version,
-  Optional[Array] $install_options = undef,
+  String                       $package_version,
+  Array[Variant[String, Hash]] $install_options = [],
 ) {
   assert_private()
 

--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -14,7 +14,7 @@
 #   windows operating systems.
 class puppet_agent::install::windows (
   Optional $install_dir           = undef,
-  Array    $install_options       = [],
+  Array[Variant[String, Hash]] $install_options = [],
 ) {
   assert_private()
 


### PR DESCRIPTION
Previously, 74e022d erroneously typed the $package_version and $install_options parameters as Optional.

This commit updates those parameters to be required, and gives a more specific type to $install_options.