### PR TITLE
(PA-5065) Add Ubuntu 22.04 (ARM64) to the puppet_agent module

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -52,11 +52,11 @@ describe 'install task' do
                          '7.19.0'
                        when %r{osx-11}
                          '7.7.0'
-                       when %r{osx-12}, %r{ubuntu-22.04}
+                       when %r{osx-12}, %r{ubuntu-22.04-amd64}
                          '7.18.0'
                        when %r{osx-13}
                          '7.26.0'
-                       when %r{el-9-aarch64}
+                       when %r{el-9-aarch64}, %r{ubuntu-22.04-aarch64}
                          'latest'
                        else
                          '7.18.0'
@@ -71,7 +71,7 @@ describe 'install task' do
     # else
     # end
     case target_platform
-    when %r{el-9-aarch64}
+    when %r{el-9-aarch64}, %r{ubuntu-22.04-aarch64}
       puppet_7_collection = 'puppet7-nightly'
       puppet_8_collection = 'puppet8-nightly'
     else


### PR DESCRIPTION
Below is the output generated by my test
```bash
install task
Installed puppet-agent on ip-10-227-6-48.amz-dev.puppet.net: success

Ensuring installed puppet-agent on ip-10-227-6-48.amz-dev.puppet.net: success
Upgraded puppet-agent to latest puppet7 on ip-10-227-6-48.amz-dev.puppet.net: success
Upgraded puppet-agent to puppet8 on ip-10-227-6-48.amz-dev.puppet.net: success
  works with version and install tasks

Finished in 3 minutes 52.5 seconds (files took 2 minutes 2.7 seconds to load)
1 example, 0 failures
```