### PR TITLE
(PA-5826) Only read Windows VERSION file during puppet apply

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -349,11 +349,11 @@ Default value: `undef`
 
 ##### <a name="-puppet_agent--version_file_path"></a>`version_file_path`
 
-Data type: `String`
+Data type: `Stdlib::Absolutepath`
 
 The default install path for the VERSION file
 
-Default value: `$facts['os']['family'] ? { 'windows' => "${facts['env_windows_installdir']}\\VERSION", default => '/opt/puppetlabs/puppet/VERSION'`
+Default value: `'/opt/puppetlabs/puppet/VERSION'`
 
 ##### <a name="-puppet_agent--skip_if_unavailable"></a>`skip_if_unavailable`
 

--- a/lib/facter/puppet_runmode.rb
+++ b/lib/facter/puppet_runmode.rb
@@ -1,0 +1,3 @@
+Facter.add(:puppet_runmode) do
+  setcode { Puppet.run_mode.name.to_s }
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -131,7 +131,7 @@ class puppet_agent (
   Optional                       $wait_for_pxp_agent_exit = undef,
   Optional                       $wait_for_puppet_run     = undef,
   Array[Puppet_agent::Config]    $config                  = [],
-  String                         $version_file_path       = $facts['os']['family'] ? { 'windows' => "${facts['env_windows_installdir']}\\VERSION", default => '/opt/puppetlabs/puppet/VERSION' }
+  Stdlib::Absolutepath           $version_file_path       = '/opt/puppetlabs/puppet/VERSION'
 ) inherits puppet_agent::params {
   # The configure class uses $puppet_agent::config to manage settings in
   # puppet.conf, and will always be present. It does not require management of
@@ -167,7 +167,11 @@ class puppet_agent (
     # The AIO package version and Puppet version can, on rare occasion, diverge.
     # This logic checks for the AIO version of the server, since that's what the package manager cares about.
     if $package_version == 'auto' {
-      $master_or_package_version = chomp(file($version_file_path))
+      if $facts['os']['family'] == 'windows' and $facts['puppet_runmode'] == 'user' {
+        $master_or_package_version = chomp(file("${facts['env_windows_installdir']}\\VERSION"))
+      } else {
+        $master_or_package_version = chomp(file($version_file_path))
+      }
     } else {
       $master_or_package_version = $package_version
     }

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -274,6 +274,37 @@ SCRIPT
         it { is_expected.to contain_package('puppet-agent').with_ensure(params[:package_version].to_s) }
       end
 
+      context 'with auto package version' do
+        let(:params) do
+          {
+            manage_repo: false,
+            package_version: 'auto'
+          }
+        end
+
+        context 'with Windows agent' do
+          let(:facts) do
+            override_facts(
+              super(),
+              os: { family: 'windows', 'windows' => { 'system32' => 'C:\Windows\System32' } },
+              'env_windows_installdir' => 'C:\Program Files\Puppet Labs\Puppet',
+              'puppet_agent_appdata' => 'C:\ProgramData',
+              'puppet_confdir' => 'C:\ProgramData\PuppetLabs\puppet',
+              'puppet_runmode' => 'agent',
+            )
+          end
+
+          before :each do
+            allow(Puppet::FileSystem).to receive(:exist?).and_call_original
+            allow(Puppet::FileSystem).to receive(:read_preserve_line_endings).and_call_original
+            allow(Puppet::FileSystem).to receive(:exist?).with('/opt/puppetlabs/puppet/VERSION').and_return true
+            allow(Puppet::FileSystem).to receive(:read_preserve_line_endings).with('/opt/puppetlabs/puppet/VERSION').and_return "7.6.5\n"
+          end
+
+          it { is_expected.to contain_class('puppet_agent::install::windows') }
+        end
+      end
+
       it { is_expected.to contain_class('puppet_agent::osfamily::redhat') }
     end
 

--- a/spec/classes/puppet_agent_osfamily_windows_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_windows_spec.rb
@@ -94,6 +94,23 @@ describe 'puppet_agent' do
           'source' => "puppet:///pe_packages/#{pe_version}/windows-#{tag}/puppet-agent-#{arch}.msi",
         )
       }
+
+      describe 'when applying' do
+        let(:facts) do
+          override_facts(
+            super(),
+            puppet_runmode: 'user',
+          )
+        end
+
+        it { is_expected.to contain_file("#{appdata}\\Puppetlabs") }
+        it { is_expected.to contain_file("#{appdata}\\Puppetlabs\\packages") }
+        it {
+          is_expected.to contain_file("#{appdata}\\Puppetlabs\\packages\\puppet-agent-#{arch}.msi").with(
+            'source' => "puppet:///pe_packages/#{pe_version}/windows-#{tag}/puppet-agent-#{arch}.msi",
+          )
+        }
+      end
     end
   end
 


### PR DESCRIPTION
Previously, puppetserver attempted to load the wrong VERSION file when managing `package_version => auto` and compiling catalogs for Windows nodes as can be seen by the new test:

    Evaluation Error: Error while evaluating a Function Call, Could not find any files from C:\Program Files\Puppet Labs\Puppet\VERSION (file: path/to/init.pp, line: 170, column: 42)

This adds a `puppet_runmode` fact. When running as puppet agent, the run mode will be `agent`. When running as puppet apply, it will be `user`. If it's the latter and we're a Windows host, then look for the VERSION file locally.