### PR TITLE
(MODULES-9695) Debian: use modern APT keyring format

### DIFF
--- a/acceptance/helpers.rb
+++ b/acceptance/helpers.rb
@@ -177,9 +177,9 @@ module Beaker::DSL
     # @param [String] environment The puppet environment to install the modules to, this must
     #   be a valid environment in the puppet install on the host.
     def install_puppet_agent_module_on(host, environment)
-      on(host, puppet('module', 'install', 'puppetlabs-stdlib',     '--version', '8.4.0', '--environment', environment), { acceptable_exit_codes: [0] })
-      on(host, puppet('module', 'install', 'puppetlabs-inifile',    '--version', '5.3.0', '--environment', environment), { acceptable_exit_codes: [0] })
-      on(host, puppet('module', 'install', 'puppetlabs-apt',        '--version', '9.0.0', '--environment', environment), { acceptable_exit_codes: [0] })
+      on(host, puppet('module', 'install', 'puppetlabs-stdlib',     '--version', '9.0.0', '--environment', environment), { acceptable_exit_codes: [0] })
+      on(host, puppet('module', 'install', 'puppetlabs-inifile',    '--version', '6.1.0', '--environment', environment), { acceptable_exit_codes: [0] })
+      on(host, puppet('module', 'install', 'puppetlabs-apt',        '--version', '9.4.0', '--environment', environment), { acceptable_exit_codes: [0] })
 
       install_dev_puppet_module_on(host,
                                    source: File.join(File.dirname(__FILE__), '..'),

--- a/acceptance/helpers.rb
+++ b/acceptance/helpers.rb
@@ -235,6 +235,15 @@ module Beaker::DSL
                                   end
 
           install_puppet_agent_on(host, agent_install_options)
+
+          # beaker-puppet doesn't add signing information to the apt source list, but this module does.
+          # This discrepancy causes apt to error, so we manually add signing info.
+          if %r{debian|ubuntu}.match?(host['platform'])
+            step '(Agent) Add apt signing information' do
+              on(host, "sed -e 's/^deb http/deb [signed-by=\\/etc\\/apt\\/keyrings\\/GPG-KEY-puppet-20250406.asc] http/' /etc/apt/sources.list.d/puppet*.list -i")
+            end
+          end
+
           teardowns << -> do
             remove_installed_agent(host)
           end

--- a/manifests/osfamily/debian.pp
+++ b/manifests/osfamily/debian.pp
@@ -71,44 +71,15 @@ class puppet_agent::osfamily::debian {
       } else {
         $source = $puppet_agent::apt_source
       }
-      $legacy_keyname = 'GPG-KEY-puppet'
-      $legacy_gpg_path = "/etc/pki/deb-gpg/${legacy_keyname}"
+
       $keyname = 'GPG-KEY-puppet-20250406'
-      $gpg_path = "/etc/pki/deb-gpg/${keyname}"
-
-      if getvar('::puppet_agent::manage_pki_dir') == true {
-        file { ['/etc/pki', '/etc/pki/deb-gpg']:
-          ensure => directory,
-        }
-      }
-
-      file { $legacy_gpg_path:
-        ensure => file,
-        owner  => 0,
-        group  => 0,
-        mode   => '0644',
-        source => "puppet:///modules/puppet_agent/${legacy_keyname}",
-      }
-
-      apt::key { 'legacy key':
-        id     => '6F6B15509CF8E59E6E469F327F438280EF8D349F',
-        source => $legacy_gpg_path,
-      }
-
-      file { $gpg_path:
-        ensure => file,
-        owner  => 0,
-        group  => 0,
-        mode   => '0644',
-        source => "puppet:///modules/puppet_agent/${keyname}",
-      }
 
       apt::source { 'pc_repo':
         location => $source,
         repos    => $puppet_agent::collection,
         key      => {
-          'id'     => 'D6811ED3ADEEB8441AF5AA8F4528B6CD9E61EF26',
-          'source' => $gpg_path,
+          'name'    => "${keyname}.asc",
+          'content' => file("${module_name}/${keyname}"),
         },
         notify   => Exec['pc_repo_force'],
       }

--- a/metadata.json
+++ b/metadata.json
@@ -75,7 +75,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.0.0 < 9.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
   "pdk-version": "3.2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -10,15 +10,15 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 5.1.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs-inifile",
-      "version_requirement": ">= 2.4.0 < 7.0.0"
+      "version_requirement": ">= 6.1.0 < 7.0.0"
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">= 7.7.1 < 10.0.0"
+      "version_requirement": ">= 9.2.0 < 10.0.0"
     },
     {
       "name": "puppetlabs-facts",

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -152,43 +152,13 @@ describe 'puppet_agent' do
       }
 
       it {
-        is_expected.to contain_file('/etc/pki/deb-gpg/GPG-KEY-puppet-20250406')
-          .with({
-                  'ensure' => 'file',
-                  'owner'  => '0',
-                  'group'  => '0',
-                  'mode'   => '0644',
-                  'source' => 'puppet:///modules/puppet_agent/GPG-KEY-puppet-20250406',
-                })
-      }
-
-      it {
-        is_expected.to contain_file('/etc/pki/deb-gpg/GPG-KEY-puppet')
-          .with({
-                  'ensure' => 'file',
-                  'owner'  => '0',
-                  'group'  => '0',
-                  'mode'   => '0644',
-                  'source' => 'puppet:///modules/puppet_agent/GPG-KEY-puppet',
-                })
-      }
-
-      it {
-        is_expected.to contain_apt__key('legacy key')
-          .with({
-                  'id'     => '6F6B15509CF8E59E6E469F327F438280EF8D349F',
-                  'source' => '/etc/pki/deb-gpg/GPG-KEY-puppet',
-                })
-      }
-
-      it {
         is_expected.to contain_apt__source('pc_repo')
           .with({
                   'location' => 'https://master.example.vm:8140/packages/2000.0.0/debian-7-x86_64',
                   'repos'    => 'PC1',
                   'key'      => {
-                    'id'     => 'D6811ED3ADEEB8441AF5AA8F4528B6CD9E61EF26',
-                    'source' => '/etc/pki/deb-gpg/GPG-KEY-puppet-20250406',
+                    'name'    => 'GPG-KEY-puppet-20250406.asc',
+                    'content' => Puppet::FileSystem.read_preserve_line_endings('files/GPG-KEY-puppet-20250406'),
                   },
                 })
       }
@@ -209,8 +179,8 @@ describe 'puppet_agent' do
                   'location' => 'https://fake-apt-mirror.com/packages/2000.0.0/debian-7-x86_64',
                   'repos'    => 'PC1',
                   'key'      => {
-                    'id'     => 'D6811ED3ADEEB8441AF5AA8F4528B6CD9E61EF26',
-                    'source' => '/etc/pki/deb-gpg/GPG-KEY-puppet-20250406',
+                    'name'    => 'GPG-KEY-puppet-20250406.asc',
+                    'content' => Puppet::FileSystem.read_preserve_line_endings('files/GPG-KEY-puppet-20250406'),
                   },
                 })
       }
@@ -225,7 +195,6 @@ describe 'puppet_agent' do
       end
 
       it { is_expected.not_to contain_apt__setting('conf-pc_repo') }
-      it { is_expected.not_to contain_apt__key('legacy key') }
       it { is_expected.not_to contain_apt__source('pc_repo') }
     end
 
@@ -246,21 +215,13 @@ describe 'puppet_agent' do
       end
 
       it {
-        is_expected.to contain_apt__key('legacy key')
-          .with({
-                  'id'     => '6F6B15509CF8E59E6E469F327F438280EF8D349F',
-                  'source' => '/etc/pki/deb-gpg/GPG-KEY-puppet',
-                })
-      }
-
-      it {
         is_expected.to contain_apt__source('pc_repo')
           .with({
                   'location' => 'https://apt.puppet.com',
                   'repos'    => 'puppet5',
                   'key'      => {
-                    'id'     => 'D6811ED3ADEEB8441AF5AA8F4528B6CD9E61EF26',
-                    'source' => '/etc/pki/deb-gpg/GPG-KEY-puppet-20250406',
+                    'name'    => 'GPG-KEY-puppet-20250406.asc',
+                    'content' => Puppet::FileSystem.read_preserve_line_endings('files/GPG-KEY-puppet-20250406'),
                   },
                 })
       }
@@ -282,8 +243,8 @@ describe 'puppet_agent' do
                   'location' => 'https://fake-apt-mirror.com/',
                   'repos'    => 'puppet5',
                   'key'      => {
-                    'id'     => 'D6811ED3ADEEB8441AF5AA8F4528B6CD9E61EF26',
-                    'source' => '/etc/pki/deb-gpg/GPG-KEY-puppet-20250406',
+                    'name'    => 'GPG-KEY-puppet-20250406.asc',
+                    'content' => Puppet::FileSystem.read_preserve_line_endings('files/GPG-KEY-puppet-20250406'),
                   },
                 })
       }
@@ -297,7 +258,6 @@ describe 'puppet_agent' do
         }
       end
 
-      it { is_expected.not_to contain_apt__key('legacy key') }
       it { is_expected.not_to contain_apt__source('pc_repo') }
     end
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -116,7 +116,7 @@ def teardown_puppet_on(host)
   # the machine after each run.
   case host['platform']
   when %r{debian|ubuntu}
-    on host, '/opt/puppetlabs/bin/puppet module install puppetlabs-apt --version 9.0.0', { acceptable_exit_codes: [0, 1] }
+    on host, '/opt/puppetlabs/bin/puppet module install puppetlabs-apt --version 9.4.0', { acceptable_exit_codes: [0, 1] }
     clean_repo = "include apt\napt::source { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"
   when %r{fedora|el|centos}
     clean_repo = "yumrepo { 'pc_repo': ensure => absent, notify => Package['puppet-agent'] }"


### PR DESCRIPTION
This updates `puppet_agent::osfamily::debian` to use modern APT keyrings (https://github.com/puppetlabs/puppetlabs-apt/pull/1128) instead of the deprecated `apt-key` method used by `apt::key` and `apt::source.key` without `name`.

For this to work properly, it needs a release of puppetlabs-apt which contains https://github.com/puppetlabs/puppetlabs-apt/pull/1128, which should be the release after v9.1.0.

This also removes the legacy key, because keys not used for signing package sources aren't needed.

`/etc/pki` is not needed anymore (also this directory is a RedHatism) because keyrings are now stored in the default location of `/etc/apt/keyrings`. We don't clean it up though, in case people are using the files there for something else.