### PR TITLE
.fixtures.yml: test with the main branches of modules

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,18 +1,7 @@
 fixtures:
   repositories:
-    stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'
-  forge_modules:
-    inifile:
-      repo: "puppetlabs/inifile"
-      ref: "5.3.0"
-    apt:
-      repo: "puppetlabs/apt"
-      ref: "9.0.0"
-    translate:
-      repo: "puppetlabs/translate"
-      ref: "1.2.0"
-    yumrepo_core:
-      repo: "puppetlabs/yumrepo_core"
-    facts:
-      repo: "puppetlabs/facts"
-      ref: "1.4.0"
+    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
+    apt: https://github.com/puppetlabs/puppetlabs-apt.git
+    inifile: https://github.com/puppetlabs/puppetlabs-inifile.git
+    yumrepo_core: https://github.com/puppetlabs/puppetlabs-yumrepo_core.git
+    facts: https://github.com/puppetlabs/puppetlabs-facts.git


### PR DESCRIPTION
This is how we run unit tests on Vox Pupuli modules. This was already done for puppetlabs-stdlib in #657.

This also removes the unused and deprecated translate module.
