### PR TITLE
(maint) Unnest module and class names in Ruby tasks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,8 +37,7 @@ Style/BlockDelimiters:
     be consistent then.
   EnforcedStyle: braces_for_chaining
 Style/ClassAndModuleChildren:
-  Description: Compact style reduces the required amount of indentation.
-  EnforcedStyle: compact
+  Enabled: false
 Style/EmptyElse:
   Description: Enforce against empty else clauses, but allow `nil` for clarity.
   EnforcedStyle: empty

--- a/.sync.yml
+++ b/.sync.yml
@@ -7,6 +7,8 @@
       Enabled: false
     RSpec/SubjectStub:
       Enabled: false
+    Style/ClassAndModuleChildren:
+      Enabled: false
 Gemfile:
   optional:
     ":development":

--- a/files/rb_task_helper.rb
+++ b/files/rb_task_helper.rb
@@ -1,59 +1,62 @@
 # frozen_string_literal: true
 
 # Puppet Agent task helper
-module PuppetAgent::RbTaskHelper
-  private
+module PuppetAgent
+  # Puppet Agent Ruby task helper
+  module RbTaskHelper
+    private
 
-  def error_result(error_type, error_message)
-    {
-      '_error' => {
-        'msg' => error_message,
-        'kind' => error_type,
-        'details' => {},
-      },
-    }
-  end
+    def error_result(error_type, error_message)
+      {
+        '_error' => {
+          'msg' => error_message,
+          'kind' => error_type,
+          'details' => {},
+        },
+      }
+    end
 
-  def puppet_bin_present?
-    File.exist?(puppet_bin)
-  end
+    def puppet_bin_present?
+      File.exist?(puppet_bin)
+    end
 
-  # Returns the path to the Puppet agent executable
-  def puppet_bin
-    @puppet_bin ||= if Puppet.features.microsoft_windows?
-                      puppet_bin_windows
-                    else
-                      '/opt/puppetlabs/bin/puppet'
-                    end
-  end
-
-  # Returns the path to the Puppet agent executable on Windows
-  def puppet_bin_windows
-    require 'win32/registry'
-
-    install_dir = begin
-                    Win32::Registry::HKEY_LOCAL_MACHINE.open('SOFTWARE\Puppet Labs\Puppet') do |reg|
-                      # Rescue missing key
-                      dir = begin
-                              reg['RememberedInstallDir64']
-                            rescue StandardError
-                              ''
-                            end
-                      # Both keys may exist, make sure the dir exists
-                      break dir if File.exist?(dir)
-
-                      # Rescue missing key
-                      begin
-                        reg['RememberedInstallDir']
-                      rescue StandardError
-                        ''
+    # Returns the path to the Puppet agent executable
+    def puppet_bin
+      @puppet_bin ||= if Puppet.features.microsoft_windows?
+                        puppet_bin_windows
+                      else
+                        '/opt/puppetlabs/bin/puppet'
                       end
-                    end
-                  rescue Win32::Registry::Error
-                    # Rescue missing registry path
-                    ''
-                  end
+    end
 
-    File.join(install_dir, 'bin', 'puppet.bat')
+    # Returns the path to the Puppet agent executable on Windows
+    def puppet_bin_windows
+      require 'win32/registry'
+
+      install_dir = begin
+                      Win32::Registry::HKEY_LOCAL_MACHINE.open('SOFTWARE\Puppet Labs\Puppet') do |reg|
+                        # Rescue missing key
+                        dir = begin
+                                reg['RememberedInstallDir64']
+                              rescue StandardError
+                                ''
+                              end
+                        # Both keys may exist, make sure the dir exists
+                        break dir if File.exist?(dir)
+
+                        # Rescue missing key
+                        begin
+                          reg['RememberedInstallDir']
+                        rescue StandardError
+                          ''
+                        end
+                      end
+                    rescue Win32::Registry::Error
+                      # Rescue missing registry path
+                      ''
+                    end
+
+      File.join(install_dir, 'bin', 'puppet.bat')
+    end
   end
 end


### PR DESCRIPTION
Prior to this commit a bug that had previously been resolved in : 

https://github.com/puppetlabs/puppetlabs-puppet_agent/commit/2911a0a4af4255895647e20b6ca138eef93806b8

Had been reintroduced by application of rubocop recommendations.

This commit reverts this change, and also adds in the correct PDK compatible block for the cop in question so this wont happen automatically again
