### PR TITLE
(PA-5581) Add Amazon Linux 2023 (Intel and ARM) to the puppet_agent m…

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -56,7 +56,7 @@ describe 'install task' do
                          '7.18.0'
                        when %r{osx-13}
                          '7.26.0'
-                       when %r{el-9-aarch64}, %r{ubuntu-22.04-aarch64}
+                       when %r{el-9-aarch64}, %r{ubuntu-22.04-aarch64}, %r{amazon-2023-x86_64}, %r{amazon-2023-aarch64}
                          'latest'
                        else
                          '7.18.0'
@@ -71,7 +71,7 @@ describe 'install task' do
     # else
     # end
     case target_platform
-    when %r{el-9-aarch64}, %r{ubuntu-22.04-aarch64}
+    when %r{el-9-aarch64}, %r{ubuntu-22.04-aarch64}, %r{amazon-2023-x86_64}, %r{amazon-2023-aarch64}
       puppet_7_collection = 'puppet7-nightly'
       puppet_8_collection = 'puppet8-nightly'
     else

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -601,7 +601,12 @@ case $platform in
   "Amzn"|"Amazon Linux")
     info "Amazon platform! Lets get you an RPM..."
     filetype="rpm"
-    filename="${collection}-release-el-${platform_version}.noarch.rpm"
+    platform_package="el"
+    # For Amazon Linux 2023 and onwards we can use the 'amazon' packages created instead of 'el' packages
+    if (( $platform_version >= 2023 )); then
+      platform_package="amazon"
+    fi
+    filename="${collection}-release-${platform_package}-${platform_version}.noarch.rpm"
     download_url="${yum_source}/${filename}"
     ;;
   "Fedora")


### PR DESCRIPTION
…odule task acceptance

 - Target nightly collections for Amazon Linux 2023 since only nightly builds are available for it for now.
 - Install puppet script installs 'el' package for amazon. From Amazon Linux 2023 onwards we have 'amazon' named packages available, so the condition added should install the 'amazon' package for versions 2023 and above.