### PR TITLE
Add Debian 12 bookworm support

### DIFF
--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -8,12 +8,12 @@ describe 'puppet_agent' do
       family: 'Debian',
       name: 'Debian',
       distro: {
-        codename: 'stretch',
+        codename: 'buster',
         id: 'Debian',
       },
       release: {
-        full: '9.0',
-        major: '9',
+        full: '10.0',
+        major: '10',
       },
     },
     puppet_master_server: 'master.example.vm',

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -621,6 +621,7 @@ case $platform in
     case $major_version in
       "10") deb_codename="buster";;
       "11") deb_codename="bullseye";;
+      "12") deb_codename="bookworm";;
     esac
     filetype="deb"
     filename="${collection}-release-${deb_codename}.deb"


### PR DESCRIPTION
Public nighty builds are currently available and working if component is puppet8-nightly or puppet7-nightly.