### PR TITLE
Pin to beaker-puppet 2.x by default

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -19,7 +19,7 @@ end
 gem "rake", "~> 12.3"
 
 gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4')
-gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || 'https://github.com/voxpupuli/beaker-puppet#master')
+gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 2')
 
 gem "beaker-docker", *location_for(ENV['BEAKER_DOCKER_VERSION'] || '~> 0')
 gem "beaker-vagrant", *location_for(ENV['BEAKER_VAGRANT_VERSION'] || '~> 0')


### PR DESCRIPTION
If BEAKER_PUPPET_VERSION is not defined, then bundle install will fail, because this module is still using beaker 4, but the head of beaker-puppet requires beaker 5.

This module is not yet beaker 5 compatible, so pin to an earlier beaker-puppet.