### PR TITLE
[PA-6142]: Upgraded beaker, beaker-puppet & beaker-abs gem

### DIFF
--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -18,11 +18,11 @@ end
 
 gem "rake", "~> 12.3"
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4')
-gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 2')
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 5')
+gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 3')
 
 gem "beaker-docker", *location_for(ENV['BEAKER_DOCKER_VERSION'] || '~> 0')
 gem "beaker-vagrant", *location_for(ENV['BEAKER_VAGRANT_VERSION'] || '~> 0')
 gem "beaker-vmpooler", *location_for(ENV['BEAKER_VMPOOLER_VERSION'] || '~> 1')
 gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '~> 2')
-gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0')
+gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 1')


### PR DESCRIPTION
[puppetlabs-puppet-agent-module_intn-sys_pa-acceptance_7-nightly_to_8-nightly-main](https://jenkins-platform.delivery.puppetlabs.net/view/puppet-agent/view/puppetlabs-puppet_agent%20module/view/main/job/forge-module_puppetlabs-puppet-agent-module_intn-sys_pa-acceptance_7-nightly_to_8-nightly-main/)

Above pipeline is failing for Amazon Linux 2023 with ‘unsupported platform’ error.
Amazon Linux 2023 platform was added in Beaker_puppet 3.0.0. Therefore we need to update the gems in Gemfile.