### PR TITLE
[Fix #703] use 'type' instead of 'which' for increased portability

### DIFF
--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -144,7 +144,7 @@ fi
 # Track to handle puppet5 to puppet6
 if [ -f /opt/puppetlabs/puppet/VERSION ]; then
   installed_version=`cat /opt/puppetlabs/puppet/VERSION`
-elif which puppet >/dev/null 2>&1; then
+elif type -p puppet >/dev/null; then
   installed_version=`puppet --version`
 else
   installed_version=uninstalled


### PR DESCRIPTION
Fixes #703 by using the `type` shell builtin instead of the (maybe not installed) `which` binary.