### PR TITLE
Add GPG check to SUSE repository

### DIFF
--- a/manifests/osfamily/suse.pp
+++ b/manifests/osfamily/suse.pp
@@ -140,6 +140,7 @@ fi
             $repo_settings = {
               'name'        => $repo_name,
               'enabled'     => '1',
+              'gpgcheck'    => '1',
               'autorefresh' => '0',
               'baseurl'     => "${source}?ssl_verify=no",
               'type'        => 'rpm-md',

--- a/spec/classes/puppet_agent_osfamily_suse_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_suse_spec.rb
@@ -149,6 +149,7 @@ SCRIPT
                 {
                   'name'        => 'pc_repo',
                   'enabled'     => '1',
+                  'gpgcheck'    => '1',
                   'autorefresh' => '0',
                   'baseurl'     => "http://yum.puppet.com/puppet6/sles/#{os_version}/x86_64?ssl_verify=no",
                   'type'        => 'rpm-md',
@@ -177,6 +178,7 @@ SCRIPT
                 [
                   'name',
                   'enabled',
+                  'gpgcheck',
                   'autorefresh',
                   'baseurl',
                   'type',
@@ -287,6 +289,7 @@ SCRIPT
                 {
                   'name'        => 'pc_repo',
                   'enabled'     => '1',
+                  'gpgcheck'    => '1',
                   'autorefresh' => '0',
                   'baseurl'     => "https://master.example.vm:8140/packages/2000.0.0/sles-#{os_version}-x86_64?ssl_verify=no",
                   'type'        => 'rpm-md',
@@ -314,6 +317,7 @@ SCRIPT
                 [
                   'name',
                   'enabled',
+                  'gpgcheck',
                   'autorefresh',
                   'baseurl',
                   'type',
@@ -359,6 +363,7 @@ SCRIPT
                 [
                   'name',
                   'enabled',
+                  'gpgcheck',
                   'autorefresh',
                   'baseurl',
                   'type',


### PR DESCRIPTION
This PR adds a GPG check to SUSE repos created by this module. This mirrors behavior already found in public release packages (see https://github.com/puppetlabs/puppetlabs-release/blob/main/source/yum.puppet.com/puppet-release.sles.template#L6) and the pe_repo module.

I tested this on SLES 12: 

```
leaky-toolmaker:~ # /opt/puppetlabs/puppet/bin/puppet --version
7.28.0
leaky-toolmaker:~ # cat /etc/zypp/repos.d/pc_repo.repo
[pc_repo]
name = pc_repo
enabled = 1
gpgcheck = 1
autorefresh = 0
baseurl = http://yum.puppet.com/sles/12/PC1/x86_64?ssl_verify=no
type = rpm-md
leaky-toolmaker:~ # cat test.pp
class { '::puppet_agent':
  package_version => '7.29.1',
}
leaky-toolmaker:~ # /opt/puppetlabs/bin/puppet apply test.pp
Notice: Compiled catalog for leaky-toolmaker.delivery.puppetlabs.net in environment production in 0.15 seconds
Notice: /Stage[main]/Puppet_agent::Osfamily::Suse/File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406]/ensure: defined content as '{sha256}4d5a9c73f97235eebe8c69f728aa2efcc8e1ee02282f972efdbbbd3a430be454'
Notice: /Stage[main]/Puppet_agent::Osfamily::Suse/File[/etc/pki/rpm-gpg/RPM-GPG-KEY-puppet]/ensure: defined content as '{sha256}7908698a5b6c4ff2d555edd1a6d594d1c2071481e1e1f7fd753274a1ab201675'
Notice: /Stage[main]/Puppet_agent::Osfamily::Suse/Exec[import-GPG-KEY-puppet]/returns: executed successfully
Notice: /Stage[main]/Puppet_agent::Osfamily::Suse/Ini_setting[zypper pc_repo name]/ensure: created
Notice: /Stage[main]/Puppet_agent::Osfamily::Suse/Ini_setting[zypper pc_repo enabled]/ensure: created
Notice: /Stage[main]/Puppet_agent::Osfamily::Suse/Ini_setting[zypper pc_repo gpgcheck]/ensure: created
Notice: /Stage[main]/Puppet_agent::Osfamily::Suse/Ini_setting[zypper pc_repo autorefresh]/ensure: created
Notice: /Stage[main]/Puppet_agent::Osfamily::Suse/Ini_setting[zypper pc_repo baseurl]/ensure: created
Notice: /Stage[main]/Puppet_agent::Osfamily::Suse/Ini_setting[zypper pc_repo type]/ensure: created
Notice: /Stage[main]/Puppet_agent::Osfamily::Suse/Exec[refresh-pc_repo]/returns: executed successfully
Notice: /Stage[main]/Puppet_agent::Install::Suse/Package[puppet-agent]/ensure: ensure changed '7.28.0-1.sles12' to '7.29.1'
Notice: Stopping run after puppet-agent upgrade. Run puppet agent -t or apply your manifest again to finish the transaction.
Notice: Applied catalog in 5.81 seconds
```
