### PR TITLE
(PA-5318) Add Debian 11 (ARM) to the puppet_agent module task acceptance

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -47,7 +47,8 @@ describe 'install task' do
       ubuntu-22\.04-aarch64|
       amazon-2023|
       osx-14|
-      debian-12
+      debian-12|
+      debian-11-aarch64
     }x
   end
 
@@ -57,7 +58,7 @@ describe 'install task' do
     # official packages won't be released until later. During the N+1 release, you'll
     # want to change `target_platform` to be the first version (N) that added the OS.
     puppet_7_version = case target_platform
-                       when %r{debian-11}
+                       when %r{debian-11-amd64}
                          '7.9.0'
                        when %r{el-9-x86_64}
                          '7.14.0'
@@ -102,7 +103,7 @@ describe 'install task' do
     #                               true
     #                             end
     multiple_puppet7_versions = case target_platform
-                                when %r{osx-13|osx-14|el-9-aarch64}
+                                when %r{osx-13|osx-14|el-9-aarch64|debian-11-aarch64}
                                   false
                                 else
                                   true


### PR DESCRIPTION
### Testing Done
```bash
install task
Installed puppet-agent on ip-10-227-4-74.amz-dev.puppet.net: success
Ensuring installed puppet-agent on ip-10-227-4-74.amz-dev.puppet.net: success
Upgraded puppet-agent to latest puppet7 on ip-10-227-4-74.amz-dev.puppet.net: success
Upgraded puppet-agent to puppet8 on ip-10-227-4-74.amz-dev.puppet.net: success
  works with version and install tasks

Finished in 2 minutes 42.1 seconds (files took 1 minute 28.17 seconds to load)
1 example, 0 failures
