### PR TITLE
Fix strftime() deprecation warning

### DIFF
--- a/manifests/install/windows.pp
+++ b/manifests/install/windows.pp
@@ -57,7 +57,7 @@ class puppet_agent::install::windows (
     $_puppet_run_wait = undef
   }
 
-  $_timestamp = strftime('%Y_%m_%d-%H_%M')
+  $_timestamp = Timestamp().strftime('%Y_%m_%d-%H_%M')
   $_logfile = windows_native_path("${facts['env_temp_variable']}/puppet-${_timestamp}-installer.log")
 
   notice ("Puppet upgrade log file at ${_logfile}")


### PR DESCRIPTION
When running on Puppet 8, a warning is produced:
```
The argument signature (String format, [String timezone]) is deprecated for #strftime. See #strftime documentation and Timespan type for more info
```

Pass a timestamp as the first parameter to use a non-deprecated
signature of the function `(Timespan $time_object, String $format)`.
