### PR TITLE
puppet_agent::run: properly validate environment parameter

### DIFF
--- a/tasks/run.rb
+++ b/tasks/run.rb
@@ -142,7 +142,7 @@ class PuppetAgent::Runner
   end
 
   def environment(params)
-    (params['environment'].length > 1) ? "--environment=#{params['environment']}" : ''
+    (params['environment'] && !params['environment'].empty?) ? "--environment=#{params['environment']}" : ''
   end
 
   # Attempts to run the Puppet agent, returning the mtime for the last run report


### PR DESCRIPTION
previously we assumed that an environment exists in the params hash. And we didn't allow environment names with a single character. This PR fixes both.