### PR TITLE
Beaker bump and PDK update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: "Publish module"
 
 on:
   workflow_dispatch:
-  
+ 
 jobs:
   release: 
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_release.yml@main"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ require:
 - rubocop-performance
 - rubocop-rspec
 AllCops:
+  NewCops: enable
   DisplayCopNames: true
   TargetRubyVersion: '2.6'
   Include:
@@ -37,8 +38,6 @@ Style/BlockDelimiters:
     be consistent then.
   EnforcedStyle: braces_for_chaining
 Style/ClassAndModuleChildren:
-  Description: Compact style reduces the required amount of indentation.
-  EnforcedStyle: compact
   Enabled: false
 Style/EmptyElse:
   Description: Enforce against empty else clauses, but allow `nil` for clarity.
@@ -532,6 +531,8 @@ Lint/DuplicateBranch:
   Enabled: false
 Lint/DuplicateMagicComment:
   Enabled: false
+Lint/DuplicateMatchPattern:
+  Enabled: false
 Lint/DuplicateRegexpCharacterClassElement:
   Enabled: false
 Lint/EmptyBlock:
@@ -648,6 +649,8 @@ Style/ComparableClamp:
   Enabled: false
 Style/ConcatArrayLiterals:
   Enabled: false
+Style/DataInheritance:
+  Enabled: false
 Style/DirEmpty:
   Enabled: false
 Style/DocumentDynamicEvalDefinition:
@@ -715,6 +718,8 @@ Style/RedundantEach:
 Style/RedundantHeredocDelimiterQuotes:
   Enabled: false
 Style/RedundantInitialize:
+  Enabled: false
+Style/RedundantLineContinuation:
   Enabled: false
 Style/RedundantSelfAssignmentBranch:
   Enabled: false

--- a/.sync.yml
+++ b/.sync.yml
@@ -13,13 +13,11 @@ Gemfile:
   optional:
     ":development":
       - gem: beaker
-        version: '~> 5.0'
+        version: '~> 6.0'
         from_env: BEAKER_VERSION
       - gem: beaker-abs
         from_env: BEAKER_ABS_VERSION
         version: '~> 1.0'
-      - gem: beaker-docker
-        version: '~> 0.3'
       - gem: beaker-hostgenerator
         from_env: BEAKER_HOSTGENERATOR_VERSION
       - gem: beaker-rspec
@@ -27,7 +25,7 @@ Gemfile:
       # Prevent beaker-puppet from being installed on Ruby > 3.1 until beaker-puppet supports newer Rubies (PA-6136)
       - gem: beaker-puppet
         from_env: BEAKER_PUPPET_VERSION
-        version: '~> 3.0'
+        version: '~> 4.0'
         condition: Gem::Requirement.create('< 3.2.0').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
       - gem: beaker-module_install_helper
       - gem: beaker-puppet_install_helper
@@ -42,7 +40,7 @@ Gemfile:
         version: '~> 1.30' # otherwise async 2.0.0(needs ruby >=3.1.0) is wrongly selected by bundler on jenkins while running with ruby 2.7.1
     ":system_tests":
       - gem: voxpupuli-acceptance
-        version: '~> 1.0'
+        version: '~> 3'
 
 appveyor.yml:
   delete: true

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
     "puppet.puppet-vscode",
-    "rebornix.Ruby"
+    "Shopify.ruby-lsp"
   ]
 }

--- a/Gemfile
+++ b/Gemfile
@@ -36,12 +36,11 @@ group :development do
   gem "rubocop-rspec", '= 2.19.0',                                             require: false
   gem "puppet-strings", '~> 4.0',                                              require: false
   gem "rb-readline", '= 0.5.5',                                                require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 5.0')
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 6.0')
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 1.0')
-  gem "beaker-docker", '~> 0.3',                                               require: false
   gem "beaker-hostgenerator"
   gem "beaker-rspec"
-  gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 3.0') if Gem::Requirement.create('< 3.2.0').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 4.0') if Gem::Requirement.create('< 3.2.0').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "beaker-module_install_helper",                                          require: false
   gem "beaker-puppet_install_helper",                                          require: false
   gem "nokogiri",                                                              require: false
@@ -50,9 +49,9 @@ group :development do
   gem "async", '~> 1.30',                                                      require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 1.0',        require: false, platforms: [:ruby, :x64_mingw]
-  gem "serverspec", '~> 2.41',          require: false
-  gem "voxpupuli-acceptance", '~> 1.0', require: false
+  gem "puppet_litmus", '~> 1.0',      require: false, platforms: [:ruby, :x64_mingw]
+  gem "serverspec", '~> 2.41',        require: false
+  gem "voxpupuli-acceptance", '~> 3', require: false
 end
 group :release_prep do
   gem "puppet-strings", '~> 4.0',         require: false

--- a/Gemfile
+++ b/Gemfile
@@ -20,21 +20,19 @@ group :development do
   gem "json", '= 2.6.1',                                                       require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.3',                                                       require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "racc", '~> 1.4.0',                                                      require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "deep_merge", '~> 1.0',                                                  require: false
   gem "voxpupuli-puppet-lint-plugins", '~> 5.0',                               require: false
   gem "facterdb", '~> 1.18',                                                   require: false
-  gem "metadata-json-lint", '~> 3.0',                                          require: false
-  gem "puppetlabs_spec_helper", '~> 6.0',                                      require: false
-  gem "rspec-puppet-facts", '~> 2.0',                                          require: false
-  gem "codecov", '~> 0.2',                                                     require: false
+  gem "metadata-json-lint", '~> 4.0',                                          require: false
+  gem "rspec-puppet-facts", '~> 3.0',                                          require: false
   gem "dependency_checker", '~> 1.0.0',                                        require: false
   gem "parallel_tests", '= 3.12.1',                                            require: false
   gem "pry", '~> 0.10',                                                        require: false
-  gem "simplecov-console", '~> 0.5',                                           require: false
+  gem "simplecov-console", '~> 0.9',                                           require: false
   gem "puppet-debugger", '~> 1.0',                                             require: false
-  gem "rubocop", '= 1.48.1',                                                   require: false
+  gem "rubocop", '~> 1.50.0',                                                  require: false
   gem "rubocop-performance", '= 1.16.0',                                       require: false
   gem "rubocop-rspec", '= 2.19.0',                                             require: false
-  gem "puppet-strings", '~> 4.0',                                              require: false
   gem "rb-readline", '= 0.5.5',                                                require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 6.0')
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 1.0')
@@ -48,14 +46,15 @@ group :development do
   gem "beaker-task_helper", '~> 1.9',                                          require: false if ENV["GEM_BOLT"]
   gem "async", '~> 1.30',                                                      require: false
 end
+group :development, :release_prep do
+  gem "puppet-strings", '~> 4.0',         require: false
+  gem "puppetlabs_spec_helper", '~> 7.0', require: false
+end
 group :system_tests do
   gem "puppet_litmus", '~> 1.0',      require: false, platforms: [:ruby, :x64_mingw]
+  gem "CFPropertyList", '< 3.0.7',    require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "serverspec", '~> 2.41',        require: false
   gem "voxpupuli-acceptance", '~> 3', require: false
-end
-group :release_prep do
-  gem "puppet-strings", '~> 4.0',         require: false
-  gem "puppetlabs_spec_helper", '~> 6.0', require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -4,87 +4,8 @@ require 'bundler'
 require 'puppet_litmus/rake_tasks' if Gem.loaded_specs.key? 'puppet_litmus'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
-require 'github_changelog_generator/task' if Gem.loaded_specs.key? 'github_changelog_generator'
 require 'puppet-strings/tasks' if Gem.loaded_specs.key? 'puppet-strings'
 require 'voxpupuli/acceptance/rake' if Gem.loaded_specs.key? 'voxpupuli-acceptance'
 
-def changelog_user
-  return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = nil || JSON.load(File.read('metadata.json'))['author']
-  raise "unable to find the changelog_user in .sync.yml, or the author in metadata.json" if returnVal.nil?
-  puts "GitHubChangelogGenerator user:#{returnVal}"
-  returnVal
-end
-
-def changelog_project
-  return unless Rake.application.top_level_tasks.include? "changelog"
-
-  returnVal = nil
-  returnVal ||= begin
-    metadata_source = JSON.load(File.read('metadata.json'))['source']
-    metadata_source_match = metadata_source && metadata_source.match(%r{.*\/([^\/]*?)(?:\.git)?\Z})
-
-    metadata_source_match && metadata_source_match[1]
-  end
-
-  raise "unable to find the changelog_project in .sync.yml or calculate it from the source in metadata.json" if returnVal.nil?
-
-  puts "GitHubChangelogGenerator project:#{returnVal}"
-  returnVal
-end
-
-def changelog_future_release
-  return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = "v%s" % JSON.load(File.read('metadata.json'))['version']
-  raise "unable to find the future_release (version) in metadata.json" if returnVal.nil?
-  puts "GitHubChangelogGenerator future_release:#{returnVal}"
-  returnVal
-end
-
 PuppetLint.configuration.send('disable_relative')
 PuppetLint.configuration.send('disable_puppet_url_without_modules')
-
-
-if Gem.loaded_specs.key? 'github_changelog_generator'
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    raise "Set CHANGELOG_GITHUB_TOKEN environment variable eg 'export CHANGELOG_GITHUB_TOKEN=valid_token_here'" if Rake.application.top_level_tasks.include? "changelog" and ENV['CHANGELOG_GITHUB_TOKEN'].nil?
-    config.user = "#{changelog_user}"
-    config.project = "#{changelog_project}"
-    config.future_release = "#{changelog_future_release}"
-    config.exclude_labels = ['maintenance']
-    config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
-    config.add_pr_wo_labels = true
-    config.issues = false
-    config.merge_prefix = "### UNCATEGORIZED PRS; LABEL THEM ON GITHUB"
-    config.configure_sections = {
-      "Changed" => {
-        "prefix" => "### Changed",
-        "labels" => ["backwards-incompatible"],
-      },
-      "Added" => {
-        "prefix" => "### Added",
-        "labels" => ["enhancement", "feature"],
-      },
-      "Fixed" => {
-        "prefix" => "### Fixed",
-        "labels" => ["bug", "documentation", "bugfix"],
-      },
-    }
-  end
-else
-  desc 'Generate a Changelog from GitHub'
-  task :changelog do
-    raise <<EOM
-The changelog tasks depends on recent features of the github_changelog_generator gem.
-Please manually add it to your .sync.yml for now, and run `pdk update`:
----
-Gemfile:
-  optional:
-    ':development':
-      - gem: 'github_changelog_generator'
-        version: '~> 1.15'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
-EOM
-  end
-end
-

--- a/acceptance/Gemfile
+++ b/acceptance/Gemfile
@@ -18,8 +18,8 @@ end
 
 gem "rake", "~> 12.3"
 
-gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 5')
-gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 3')
+gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 6')
+gem "beaker-puppet", *location_for(ENV['BEAKER_PUPPET_VERSION'] || '~> 4')
 
 gem "beaker-docker", *location_for(ENV['BEAKER_DOCKER_VERSION'] || '~> 0')
 gem "beaker-vagrant", *location_for(ENV['BEAKER_VAGRANT_VERSION'] || '~> 0')

--- a/metadata.json
+++ b/metadata.json
@@ -75,7 +75,7 @@
       "version_requirement": ">= 5.0.0 < 9.0.0"
     }
   ],
-  "pdk-version": "3.0.1",
+  "pdk-version": "3.2.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates#3.0.1",
   "template-ref": "tags/3.0.1-0-gd13288a"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -76,6 +76,6 @@
     }
   ],
   "pdk-version": "3.2.0",
-  "template-url": "https://github.com/puppetlabs/pdk-templates#3.0.1",
-  "template-ref": "tags/3.0.1-0-gd13288a"
+  "template-url": "https://github.com/puppetlabs/pdk-templates#3.2.0",
+  "template-ref": "tags/3.2.0-0-gb257ef1"
 }


### PR DESCRIPTION
This PR bumps Beaker and beaker-puppet to their latest major versions, along with updating to the latest PDK template.

Passing ad hoc job: https://jenkins-platform.delivery.puppetlabs.net/view/puppet-agent/view/puppetlabs-puppet_agent%20module/view/ad-hoc/job/forge-module_puppetlabs-puppet-agent-module_intn-sys_pa-acceptance_7-nightly_to_8-nightly-adhoc/lastSuccessfulBuild/