### PR TITLE
(PA-6277) change manifests for amazon 2 repo

### DIFF
--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -20,7 +20,6 @@ class puppet_agent::osfamily::redhat {
       'Amazon': {
         $major_version = $facts['os']['release']['major']
         $amz_el_version = "${major_version}" ? {
-          '2'              => '7',
           /^(2017|2018)$/  => '6',
           default          => $major_version,
         }

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -21,7 +21,7 @@ describe 'puppet_agent' do
     }
   end
 
-  [['Rocky', 'el/8', 8], ['AlmaLinux', 'el/8', 8], ['Fedora', 'fedora/f36', 36], ['CentOS', 'el/7', 7], ['Amazon', 'el/6', 2017], ['Amazon', 'el/6', 2018], ['Amazon', 'el/7', 2], ['Amazon', 'amazon/2023', 2023]].each do |os, urlbit, osmajor|
+  [['Rocky', 'el/8', 8], ['AlmaLinux', 'el/8', 8], ['Fedora', 'fedora/f36', 36], ['CentOS', 'el/7', 7], ['Amazon', 'el/6', 2017], ['Amazon', 'el/6', 2018], ['Amazon', 'amazon/2', 2], ['Amazon', 'amazon/2023', 2023]].each do |os, urlbit, osmajor|
     context "with #{os} and #{urlbit}" do
       let(:facts) do
         override_facts(super(), os: { name: os, release: { major: osmajor, }, })


### PR DESCRIPTION
Since we currently use the Amazon repository for Amazon Linux on the Yum repo instead of `el`, we are changing the manifest to fetch the correct package.