### PR TITLE
(PA-6677) Restore AL2 x86_64 install task and manifest

### DIFF
--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -39,7 +39,7 @@ class puppet_agent::osfamily::redhat {
     # lint:endignore
     if ($puppet_agent::is_pe and (!$puppet_agent::use_alternate_sources)) {
       $pe_server_version = pe_build_version()
-      # Install amazon packages on AL2 (only aarch64) and 2003 and up (all arch)
+      # Install amazon packages on AL2 (only aarch64) and 2023 and up (all arch)
       if $facts['os']['name'] == 'Amazon' {
         # lint:ignore:only_variable_string
         $pe_repo_dir = "${amz_el_version}" ? {

--- a/metadata.json
+++ b/metadata.json
@@ -67,6 +67,9 @@
     },
     {
       "operatingsystem": "Rocky"
+    },
+    {
+      "operatingsystem": "AmazonLinux"
     }
   ],
   "requirements": [

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -22,19 +22,19 @@ describe 'puppet_agent' do
   end
 
   [
-    ['Rocky', 'el/8', 8],
-    ['AlmaLinux', 'el/8', 8],
-    ['AlmaLinux', 'el/9', 9],
-    ['Fedora', 'fedora/f36', 36],
-    ['CentOS', 'el/7', 7],
-    ['Amazon', 'el/6', 2017],
-    ['Amazon', 'el/6', 2018],
-    ['Amazon', 'amazon/2', 2],
-    ['Amazon', 'amazon/2023', 2023],
+    ['Rocky', 'el/8', '8'],
+    ['AlmaLinux', 'el/8', '8'],
+    ['AlmaLinux', 'el/9', '9'],
+    ['Fedora', 'fedora/f36', '36'],
+    ['CentOS', 'el/7', '7'],
+    ['Amazon', 'el/6', '2017'],
+    ['Amazon', 'el/6', '2018'],
+    ['Amazon', 'amazon/2', '2'],
+    ['Amazon', 'amazon/2023', '2023'],
   ].each do |os, urlbit, osmajor|
     context "with #{os} and #{urlbit}" do
       let(:facts) do
-        override_facts(super(), os: { name: os, release: { major: osmajor, }, })
+        override_facts(super(), os: { name: os, release: { major: osmajor } })
       end
 
       script = <<-SCRIPT
@@ -170,7 +170,7 @@ SCRIPT
     end
   end
 
-  [['RedHat', 'el-7-x86_64', 'el-7-x86_64', 7], ['RedHat', 'el-8-x86_64', 'el-8-x86_64', 8], ['Amazon', '', 'el-6-x64', 6]].each do |os, tag, repodir, osmajor|
+  [['RedHat', 'el-7-x86_64', 'el-7-x86_64', '7'], ['RedHat', 'el-8-x86_64', 'el-8-x86_64', '8'], ['Amazon', '', 'el-6-x64', '6']].each do |os, tag, repodir, osmajor|
     context "when PE on #{os}" do
       before(:each) do
         # Need to mock the PE functions

--- a/spec/classes/puppet_agent_osfamily_redhat_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_redhat_spec.rb
@@ -22,19 +22,21 @@ describe 'puppet_agent' do
   end
 
   [
-    ['Rocky', 'el/8', '8'],
-    ['AlmaLinux', 'el/8', '8'],
-    ['AlmaLinux', 'el/9', '9'],
-    ['Fedora', 'fedora/f36', '36'],
-    ['CentOS', 'el/7', '7'],
-    ['Amazon', 'el/6', '2017'],
-    ['Amazon', 'el/6', '2018'],
-    ['Amazon', 'amazon/2', '2'],
-    ['Amazon', 'amazon/2023', '2023'],
-  ].each do |os, urlbit, osmajor|
+    ['Rocky', 'el/8', '8', 'x86_64'],
+    ['AlmaLinux', 'el/8', '8', 'x86_64'],
+    ['AlmaLinux', 'el/9', '9', 'x86_64'],
+    ['Fedora', 'fedora/f36', '36', 'x86_64'],
+    ['CentOS', 'el/7', '7', 'x86_64'],
+    ['Amazon', 'el/6', '2017', 'x86_64'],
+    ['Amazon', 'el/6', '2018', 'x86_64'],
+    ['Amazon', 'el/7', '2', 'x86_64'],
+    ['Amazon', 'amazon/2', '2', 'aarch64'],
+    ['Amazon', 'amazon/2023', '2023', 'x86_64'],
+    ['Amazon', 'amazon/2023', '2023', 'aarch64'],
+  ].each do |os, urlbit, osmajor, arch|
     context "with #{os} and #{urlbit}" do
       let(:facts) do
-        override_facts(super(), os: { name: os, release: { major: osmajor } })
+        override_facts(super(), os: { name: os, release: { major: osmajor }, architecture: arch })
       end
 
       script = <<-SCRIPT
@@ -148,7 +150,7 @@ SCRIPT
           is_expected.to contain_yumrepo('pc_repo')
             .with({
                     # We no longer expect the 'f' in fedora repos
-                    'baseurl'  => "http://yum.puppet.com/puppet5/#{urlbit.gsub('/f', '/')}/x64",
+                    'baseurl'  => "http://yum.puppet.com/puppet5/#{urlbit.gsub('/f', '/')}/#{arch}",
                     'enabled'  => 'true',
                     'gpgcheck' => '1',
                     'gpgkey'   => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet\n  file:///etc/pki/rpm-gpg/RPM-GPG-KEY-puppet-20250406",
@@ -165,7 +167,7 @@ SCRIPT
           }
         end
 
-        it { is_expected.to contain_yumrepo('pc_repo').with_baseurl("http://fake-yum.com/puppet5/#{urlbit.gsub('/f', '/')}/x64") }
+        it { is_expected.to contain_yumrepo('pc_repo').with_baseurl("http://fake-yum.com/puppet5/#{urlbit.gsub('/f', '/')}/#{arch}") }
       end
     end
   end

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -284,11 +284,6 @@ case $platform in
   "SLES")
     platform_version=$major_version
     ;;
-  "Amzn"|"Amazon Linux")
-    case $platform_version in
-      "2") platform_version="2";;
-    esac
-    ;;
 esac
 
 # Find which version of puppet is currently installed if any
@@ -662,8 +657,11 @@ case $platform in
     info "Amazon platform! Lets get you an RPM..."
     filetype="rpm"
     platform_package="el"
-    # For Amazon Linux 2023 and onwards we can use the 'amazon' packages created instead of 'el' packages
-    if (( $platform_version == 2023 || $platform_version == 2 )); then
+    arch="$(uname -p)"
+    # Install amazon packages on AL2 (only aarch64) and 2003 and up (all arch)
+    if [[ $platform_version == 2 && $arch == 'x86_64' ]]; then
+      platform_version="7"
+    elif (( platform_version == 2 || platform_version >= 2023 )); then
       platform_package="amazon"
     fi
     filename="${collection}-release-${platform_package}-${platform_version}.noarch.rpm"


### PR DESCRIPTION
Previous commits fixed AL2 aarch64, but broke x86_64.

Added `AmazonLinux` to metadata.json

After this is merged, install-puppet.sh needs to be regenerated

This should fix https://jenkins-enterprise.delivery.puppetlabs.net/view/pe-integration/view/pe-2021.7.x/job/enterprise_pe-acceptance-tests_integration-system_pe_full-agent-upgrade_nightly_2021.7.x/