### PR TITLE
(PA-6367) Update task_acceptance for Fedora 40 x86_64

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -42,7 +42,10 @@ describe 'install task' do
   # used for target_platform, which will use latest puppet_agent
   # in below mentioned test spec
   def latest_platform_list
-    %r{ubuntu-24}
+    %r{
+      ubuntu-24|
+      fedora-40
+    }x
   end
 
   it 'works with version and install tasks' do
@@ -104,7 +107,7 @@ describe 'install task' do
     #                               true
     #                             end
     multiple_puppet7_versions = case target_platform
-                                when %r{el-9-ppc64le|amazon-2|ubuntu-24}
+                                when %r{el-9-ppc64le|amazon-2|ubuntu-24|fedora-40}
                                   false
                                 else
                                   true


### PR DESCRIPTION
Added fedora-40 to 'latest_platform_list' method so that it considers builds from nightlies with the 'latest' tag since the versioned release package won't be available for fedora-40 yet given its a new platform we're just introducing. 
Also set 'multiple_puppet7_version' to false for the case of fedora-40 because we would only have just one puppet7 release initially.