### PR TITLE
Test updates

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -38,9 +38,9 @@ describe 'install task' do
     puts logger.info(out)
   end
 
-  # Added this method to simplify the 'case' condition
-  # used for target_platform, which will use latest puppet_agent
-  # in below mentioned test spec
+  # This method contains a list of platforms that are only available in nightly builds of puppet-agent. Once a regular
+  # release of puppet-agent includes support for these platforms, they can be removed from this method and added to
+  # the logic that determines the puppet_7_version variable below.
   def latest_platform_list
     # %r{operatingsystem-version-architecture}
   end
@@ -79,14 +79,7 @@ describe 'install task' do
                          '7.18.0'
                        end
 
-    # Platforms that only have nightly builds available. Once a platform
-    # is released, it should be removed from this list.
-    # case target_platform
-    # when %r{fedora-36}
-    #   puppet_7_collection = 'puppet7-nightly'
-    #   puppet_8_collection = 'puppet8-nightly'
-    # else
-    # end
+    # Use nightlies for unreleased platforms
     case target_platform
     when latest_platform_list
       puppet_7_collection = 'puppet7-nightly'

--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -42,10 +42,7 @@ describe 'install task' do
   # used for target_platform, which will use latest puppet_agent
   # in below mentioned test spec
   def latest_platform_list
-    %r{
-      ubuntu-24|
-      fedora-40
-    }x
+    # %r{operatingsystem-version-architecture}
   end
 
   it 'works with version and install tasks' do
@@ -72,8 +69,10 @@ describe 'install task' do
                          '7.28.0'
                        when %r{debian-12}
                          '7.29.0'
-                       when %r{el-9-ppc64le}, %r{amazon-2}
+                       when %r{el-9-ppc64le}, %r{amazon-2}, %r{fedora-40}
                          '7.31.0'
+                       when %r{ubuntu-24.04}
+                         '7.32.1'
                        when latest_platform_list
                          'latest'
                        else


### PR DESCRIPTION
After https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/711 was merged, it revealed a test failure with Fedora 40 relating to our test setup.

This PR updates our tests to use the correct versions of puppet-agent for Fedora 40 and Ubuntu 24.04.