### PR TITLE
Remove Litmus from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,6 @@ group :development, :release_prep do
   gem "puppetlabs_spec_helper", '~> 7.0', require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 1.0',      require: false, platforms: [:ruby, :x64_mingw]
   gem "CFPropertyList", '< 3.0.7',    require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "serverspec", '~> 2.41',        require: false
   gem "voxpupuli-acceptance", '~> 3', require: false


### PR DESCRIPTION
We do not use Litmus for tests and its dependencies are causing issues in our CI pipeline. This commit removes Litmus from the Gemfile.