### PR TITLE
(#732) run.rb: Combine stderr and stdout

### DIFF
--- a/tasks/run.rb
+++ b/tasks/run.rb
@@ -155,7 +155,8 @@ class PuppetAgent::Runner
     options = {
       failonfail:         false,
       custom_environment: get_env_fix_up,
-      override_locale:    false
+      override_locale:    false,
+      combine:            true # combine stdout and stderr
     }
 
     run_result = Puppet::Util::Execution.execute(command.reject(&:empty?), options)


### PR DESCRIPTION
By default, `Puppet::Util::Execution.execute` only returns stdout. Puppet writes errors to stderr. When the run task fails, it only shows the successful output:

```
$ bolt task run puppet_agent::run --targets puppet
Started on puppet...
Finished on puppet:
  Info: Using environment 'production'
  Info: Retrieving pluginfacts
  Info: Retrieving plugin
  Info: Loading facts
  Notice: Requesting catalog from puppet.local:8140 (10.0.1.1)
  Notice: Catalog compiled by puppet.local

  *long json here*
```

With the patch:

```
$ bolt task run puppet_agent::run --targets puppet
Started on puppet...
Finished on puppet:
  Info: Using environment 'production'
  Info: Retrieving pluginfacts
  Info: Retrieving plugin
  Info: Loading facts
  Notice: Requesting catalog from puppet.local:8140 (10.0.1.1)
  Notice: Catalog compiled by puppet.local
  Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, Failed to execute '/pdb/query/v4' on at least 1 of the following 'server_urls': https://puppetdb:8081 (file: /opt/puppetlabs/puppet/modules/infrastructure/manifests/puppet/puppetserver.pp, line: 11, column: 14) on node puppet.local
  Warning: Not using cache on failed catalog
  Error: Could not retrieve catalog; skipping run

  *long json here*
``