### PR TITLE
run.rb: Fail when the puppet agent run fails 

### DIFF
--- a/tasks/run.rb
+++ b/tasks/run.rb
@@ -155,7 +155,8 @@ class PuppetAgent::Runner
     options = {
       failonfail:         false,
       custom_environment: get_env_fix_up,
-      override_locale:    false
+      override_locale:    false,
+      combine:            true # combine stdout and stderr
     }
 
     run_result = Puppet::Util::Execution.execute(command.reject(&:empty?), options)

--- a/tasks/run.rb
+++ b/tasks/run.rb
@@ -153,7 +153,7 @@ class PuppetAgent::Runner
     command = [puppet_bin, 'agent', '-t', '--color', 'false', noop(params), environment(params)]
 
     options = {
-      failonfail:         false,
+      failonfail:         true, # fail the task when the puppet agent run fails
       custom_environment: get_env_fix_up,
       override_locale:    false,
       combine:            true # combine stdout and stderr


### PR DESCRIPTION
Also contains #739

without this:

```
$ bolt plan run puppet_agent::run --targets puppet
Starting: plan puppet_agent::run
Starting: Check for Puppet agent on puppet
Finished: Check for Puppet agent with 0 failures in 2.75 sec
Starting: Run Puppet agent on puppet
Finished: Run Puppet agent with 0 failures in 17.45 sec
Finished: plan puppet_agent::run in 20.21 sec
Finished on puppet:
  Info: Using environment 'production'
  Info: Retrieving pluginfacts
  Info: Retrieving plugin
  Info: Loading facts
  Notice: Requesting catalog from puppet.local:8140 (10.0.1.1)
  Notice: Catalog compiled by puppet.local
  Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, Failed to execute '/pdb/query/v4' on at least 1 of the following 'server_urls': https://puppetdb:8081 (file: /opt/puppetlabs/puppet/modules/infrastructure/manifests/puppet/puppetserver.pp, line: 11, column: 14) on node puppet.local
  Warning: Not using cache on failed catalog
  Error: Could not retrieve catalog; skipping run
  *long json*
Successful on 1 target: puppet
Ran on 1 target
```

with this change:

```
$ bolt plan run puppet_agent::run --targets puppet
Starting: plan puppet_agent::run
Starting: Check for Puppet agent on puppet
Finished: Check for Puppet agent with 0 failures in 2.81 sec
Starting: Run Puppet agent on puppet
Finished: Run Puppet agent with 1 failure in 12.69 sec
Finished: plan puppet_agent::run in 15.5 sec
Failed on puppet:
  The task failed with exit code 1 and no stdout, but stderr contained:
  /opt/puppetlabs/puppet/lib/ruby/vendor_ruby/puppet/util/execution.rb:312:in `execute': Execution of '/opt/puppetlabs/bin/puppet agent -t --color false' returned 1: Info: Using environment 'production' (Puppet::ExecutionFailure)
  Info: Retrieving pluginfacts
  Info: Retrieving plugin
  Info: Loading facts
  Notice: Requesting catalog from puppet.local:8140 (10.0.1.1)
  Notice: Catalog compiled by puppet.local
  Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, Failed to execute '/pdb/query/v4' on at least 1 of the following 'server_urls': https://puppetdb:8081 (file: /opt/puppetlabs/puppet/modules/infrastructure/manifests/puppet/puppetserver.pp, line: 11, column: 14) on node puppet.local
  Warning: Not using cache on failed catalog
  Error: Could not retrieve catalog; skipping run
  	from /tmp/ee90dd59-55df-44a5-8b46-6d5b5f41445a/puppet_agent/tasks/run.rb:162:in `try_run'
  	from /tmp/ee90dd59-55df-44a5-8b46-6d5b5f41445a/puppet_agent/tasks/run.rb:187:in `run'
  	from /tmp/ee90dd59-55df-44a5-8b46-6d5b5f41445a/puppet_agent/tasks/run.rb:246:in `<main>'
Failed on 1 target: puppet
Ran on 1 target
```