### PR TITLE
(#732) puppet_agent::run: mark failed puppet runs as failed task

### DIFF
--- a/tasks/run.rb
+++ b/tasks/run.rb
@@ -155,7 +155,8 @@ class PuppetAgent::Runner
     options = {
       failonfail:         false,
       custom_environment: get_env_fix_up,
-      override_locale:    false
+      override_locale:    false,
+      combine:            true # combine stdout and stderr
     }
 
     run_result = Puppet::Util::Execution.execute(command.reject(&:empty?), options)

--- a/tasks/run.rb
+++ b/tasks/run.rb
@@ -99,8 +99,16 @@ class PuppetAgent::Runner
         obj.tag = nil if obj.respond_to?(:tag=)
       end
 
+      ruby_report = report.to_ruby
+      # check if the run is marked as failed
+      if ruby_report['status'] == 'failed'
+        return error_result(
+          'puppet_agent/agent-run-error',
+          "Puppet agent run failed: #{run_result}",
+        )
+      end
       {
-        'report'   => report.to_ruby,
+        'report'   => ruby_report,
         'exitcode' => run_result.exitstatus,
         '_output'  => run_result
       }


### PR DESCRIPTION
* This is an alternative to https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/741
* this contains #739 

without this change:

```
Started on localhost...
Finished on localhost:
  Info: Refreshing CA certificate
  Info: CA certificate is unmodified, using existing CA certificate
  Info: Using environment 'production'
  Info: Retrieving pluginfacts
  Info: Retrieving plugin
  Info: Loading facts
  Notice: Requesting catalog from puppet.bastel:8140 (127.0.0.1)
  Notice: Catalog compiled by puppet.local
  Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Failed when searching for node puppet.bastel: Exception while executing '/etc/puppetlabs/puppet/node.rb': Cannot run program "/etc/puppetlabs/puppet/node.rb" (in directory "."): error=0, Failed to exec spawn helper: pid: 2133925, exit value: 1
  Warning: Not using cache on failed catalog
  Error: Could not retrieve catalog; skipping run
  {
 *long json*
    },
    "exitcode": 1
  }
Successful on 1 target: localhost
Ran on 1 target in 11.19 sec
```

With this change:

```
Started on localhost...
Failed on localhost:
  Puppet agent run failed: Info: Refreshing CA certificate
  Info: CA certificate is unmodified, using existing CA certificate
  Info: Using environment 'production'
  Info: Retrieving pluginfacts
  Info: Retrieving plugin
  Info: Loading facts
  Notice: Requesting catalog from puppet.bastel:8140 (127.0.0.1)
  Notice: Catalog compiled by puppet.local
  Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Failed when searching for node puppet.bastel: Exception while executing '/etc/puppetlabs/puppet/node.rb': Cannot run program "/etc/puppetlabs/puppet/node.rb" (in directory "."): error=0, Failed to exec spawn helper: pid: 2133837, exit value: 1
  Warning: Not using cache on failed catalog
  Error: Could not retrieve catalog; skipping run
Failed on 1 target: localhost
Ran on 1 target in 11.35 sec
```

The task is now properly marked as failed, when the puppet agent run
failed itself.