### PR TITLE
Constrain orchestrator_client

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -36,6 +36,11 @@ Gemfile:
       - gem: 'beaker-task_helper'
         version: '~> 1.9'
         condition: 'ENV["GEM_BOLT"]'
+      # The Faraday requirements in orchestrator_client 0.7.1 causes Bundler to
+      # resolve the dependency in unexpected ways and causes issues in CI
+      - gem: 'orchestrator_client'
+        version: '< 0.7.1'
+        condition: 'ENV["GEM_BOLT"]'
       - gem: async
         version: '~> 1.30' # otherwise async 2.0.0(needs ruby >=3.1.0) is wrongly selected by bundler on jenkins while running with ruby 2.7.1
     ":system_tests":

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ group :development do
   gem "nokogiri",                                                              require: false
   gem "bolt", '~> 3.0',                                                        require: false if ENV["GEM_BOLT"]
   gem "beaker-task_helper", '~> 1.9',                                          require: false if ENV["GEM_BOLT"]
+  gem "orchestrator_client", '< 0.7.1',                                        require: false if ENV["GEM_BOLT"]
   gem "async", '~> 1.30',                                                      require: false
 end
 group :development, :release_prep do


### PR DESCRIPTION
The 0.7.1 release of orchestrator_client broadened its dependency on Faraday (see puppetlabs/orchestrator_client-ruby@6f8661e). This change has caused Bundler to resolve Faraday in unexpected ways when there are other Gems with dependencies on Faraday.

This commit constrains orchestrator_client to < 0.7.1 until this issue is resolved.