### PR TITLE
Revert "Adopt to latest puppetlabs/apt changes"

### DIFF
--- a/manifests/osfamily/debian.pp
+++ b/manifests/osfamily/debian.pp
@@ -60,11 +60,13 @@ class puppet_agent::osfamily::debian {
         # Pass in an empty content string since apt requires it even though we are removing it
         apt::setting { 'list-puppet-enterprise-installer':
           ensure  => absent,
+          content => '',
         }
 
         apt::setting { 'conf-pe-repo':
           ensure   => absent,
           priority => '90',
+          content  => '',
         }
       } else {
         $source = $puppet_agent::apt_source

--- a/spec/classes/puppet_agent_osfamily_debian_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_debian_spec.rb
@@ -58,6 +58,7 @@ describe 'puppet_agent' do
         is_expected.to contain_apt__setting('conf-pe-repo')
           .with({
                   'priority' => 90,
+                  'content'  => '',
                   'ensure'   => 'absent',
                 })
       }
@@ -65,7 +66,8 @@ describe 'puppet_agent' do
       it {
         is_expected.to contain_apt__setting('list-puppet-enterprise-installer')
           .with({
-                  'ensure' => 'absent',
+                  'content' => '',
+                  'ensure'  => 'absent',
                 })
       }
     end


### PR DESCRIPTION
This reverts commit 84850a5b8642efe7b95e655c335bb6bb4d3e7bf2.

The latest `puppet_agent` module is not compatible with the most recently released `puppetlabs-apt` module, so reverting just this one commit from PR #740.

We will need to first release `puppetlabs-apt` and then re-revert this.