### PR TITLE
Update nightly repos for beaker tests

### DIFF
--- a/acceptance/tests/test_upgrade_puppet6_to_puppet7.rb
+++ b/acceptance/tests/test_upgrade_puppet6_to_puppet7.rb
@@ -21,10 +21,10 @@ node default {
 
   class { puppet_agent:
     package_version => $_package_version,
-    apt_source      => 'http://nightlies.puppet.com/apt',
-    yum_source      => 'http://nightlies.puppet.com/yum',
-    mac_source      => 'http://nightlies.puppet.com/downloads',
-    windows_source  => 'http://nightlies.puppet.com/downloads',
+    apt_source      => 'https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/apt',
+    yum_source      => 'https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/yum',
+    mac_source      => 'https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/downloads',
+    windows_source  => 'https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/downloads',
     collection      => 'puppet7-nightly',
     service_names   => []
   }

--- a/acceptance/tests/test_upgrade_puppet7_to_puppet8.rb
+++ b/acceptance/tests/test_upgrade_puppet7_to_puppet8.rb
@@ -21,10 +21,10 @@ node default {
 
   class { puppet_agent:
     package_version => $_package_version,
-    apt_source      => 'https://nightlies.puppet.com/apt',
-    yum_source      => 'https://nightlies.puppet.com/yum',
-    mac_source      => 'https://nightlies.puppet.com/downloads',
-    windows_source  => 'https://nightlies.puppet.com/downloads',
+    apt_source      => 'https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/apt',
+    yum_source      => 'https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/yum',
+    mac_source      => 'https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/downloads',
+    windows_source  => 'https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/downloads',
     collection      => 'puppet8-nightly',
     service_names   => []
   }


### PR DESCRIPTION
These tests already rely on internal infrastructure, so changing the nightly URLs shouldn't break anyone.

[update 6 -> 7: passed](https://jenkins-platform.delivery.puppetlabs.net/job/forge-module_puppetlabs-puppet-agent-module_intn-sys_pa-acceptance_6-nightly_to_7-nightly-adhoc/93/)
[update 7 -> 8: passed](https://jenkins-platform.delivery.puppetlabs.net/job/forge-module_puppetlabs-puppet-agent-module_intn-sys_pa-acceptance_7-nightly_to_8-nightly-adhoc/54/)

The tests didn't pass on macOS 12 ARM, because we aren't building packages for that anymore, so filed related PR https://github.com/puppetlabs/ci-job-configs/pull/9800