### PR TITLE
puppetlabs/apt: Require 10.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">= 9.2.0 < 10.0.0"
+      "version_requirement": ">= 10.0.0 < 11.0.0"
     },
     {
       "name": "puppetlabs-facts",


### PR DESCRIPTION
since https://github.com/puppetlabs/puppetlabs-apt/pull/1208, version 10 of puppetlabs/apt is required.