### PR TITLE
Install latest builds from internal nightlies in beaker tests

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -48,6 +48,16 @@ describe 'install task' do
     }x
   end
 
+  # This method lists sources to be used when installing packages that haven't been released yet (see above).
+  def latest_sources
+    {
+      'yum_source'     => 'https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/yum',
+      'apt_source'     => 'https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/apt',
+      'mac_source'     => 'https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/downloads',
+      'windows_source' => 'https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/downloads',
+    }
+  end
+
   it 'works with version and install tasks' do
     case target_platform
     when latest_platform_list
@@ -57,7 +67,7 @@ describe 'install task' do
       # Install an puppet8 nightly version
       results = run_task('puppet_agent::install', 'target', { 'collection' => 'puppet8-nightly',
                                                               'version' => 'latest',
-                                                              'stop_service' => true })
+                                                              'stop_service' => true }.merge(latest_sources))
 
       results.each do |result|
         logger.info("Installed puppet-agent on #{result['target']}: #{result['status']}")

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -137,7 +137,7 @@ if [ -n "$PT_mac_source" ]; then
   mac_source=$PT_mac_source
 else
   if [ "$nightly" = true ]; then
-    mac_source='https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/downloads'
+    mac_source='http://nightlies.puppet.com/downloads'
   else
     mac_source='http://downloads.puppet.com'
   fi

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -117,7 +117,7 @@ if [ -n "$PT_yum_source" ]; then
   yum_source=$PT_yum_source
 else
   if [ "$nightly" = true ]; then
-    yum_source='https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/yum'
+    yum_source='http://nightlies.puppet.com/yum'
   else
     yum_source='http://yum.puppet.com'
   fi


### PR DESCRIPTION
Modules that rely on litmus use the puppet_agent module to install the latest
released and nightly versions of `puppet-agent` packages:

    bundle exec rake 'litmus:install_agent[puppet7-nightly]'

Commits https://github.com/puppetlabs/puppetlabs-puppet_agent/commit/025aa705f2f72d89cd7ea0daf3f51f71522d6c70 and https://github.com/puppetlabs/puppetlabs-puppet_agent/commit/b2e73a87867738204e83b42df6fa02f29f379d47 changed the default location where nightly
builds are installed from. Since we haven't documented how to do that, revert
those changes. Instead specify the internal sources in the test for the
situation where a platform has been recently added, but hasn't been released
yet, for example, macOS 15 ARM.

We will need to revisit how to install `puppet*_nightly` puppet core builds.

Fixes #758 

Tested adhoc https://jenkins-platform.delivery.puppetlabs.net/view/puppet-agent/view/puppetlabs-puppet_agent%20module/view/ad-hoc/job/forge-module_puppetlabs-puppet-agent-module_intn-sys_pa-acceptance_7-nightly_to_8-nightly-adhoc/59/

Manual task redhat8

```
install task
Installed puppet-agent on tawny-mechanism.delivery.puppetlabs.net: success
Ensuring installed puppet-agent on tawny-mechanism.delivery.puppetlabs.net: success
Upgraded puppet-agent to latest puppet7 on tawny-mechanism.delivery.puppetlabs.net: success
Upgraded puppet-agent to puppet8 on tawny-mechanism.delivery.puppetlabs.net: success
.  works with version and install tasks
ssh connection to redhat8-64-1 has been terminated


Finished in 2 minutes 6.6 seconds (files took 1 minute 36.38 seconds to load)
1 example, 0 failures
```

Manual task macOS 15 ARM

```
install task
Installed puppet-agent on pix-arm64-macos15-5.nspooler-prod.puppet.net: success
.  works with version and install tasks
ssh connection to osx15-ARM64-1 has been terminated


Finished in 24.03 seconds (files took 23.02 seconds to load)
1 example, 0 failures
```

```
pix-arm64-macos15-5:~ root# /opt/puppetlabs/puppet/bin/puppet --version
8.11.0
```