### PR TITLE
Fix rpm upgrades to puppetcore

### DIFF
--- a/docker/bin/helpers/run-upgrade.sh
+++ b/docker/bin/helpers/run-upgrade.sh
@@ -11,10 +11,10 @@ puppet_version=( ${to_version//./ } )
 puppet_major=${puppet_version[0]}
 case $puppet_major in
 7)
-    to_collection=puppet7
+    to_collection=puppetcore7
     ;;
 8)
-    to_collection=puppet8
+    to_collection=puppetcore8
     ;;
 *)
     echo "Invalid version supplied" 1>&2

--- a/manifests/osfamily/redhat.pp
+++ b/manifests/osfamily/redhat.pp
@@ -60,6 +60,9 @@ class puppet_agent::osfamily::redhat {
     } else {
       if $puppet_agent::collection == 'PC1' {
         $source = "${puppet_agent::yum_source}/${platform_and_version}/${puppet_agent::collection}/${puppet_agent::arch}"
+      } elsif $puppet_agent::collection =~ /core/ {
+        $_collection = regsubst($puppet_agent::collection, /core/, '')
+        $source = "https://yum-puppetcore.puppet.com/${_collection}/${platform_and_version}/${puppet_agent::arch}"
       } else {
         $source = "${puppet_agent::yum_source}/${puppet_agent::collection}/${platform_and_version}/${puppet_agent::arch}"
       }

--- a/manifests/osfamily/suse.pp
+++ b/manifests/osfamily/suse.pp
@@ -50,6 +50,9 @@ class puppet_agent::osfamily::suse {
     } else {
       if $puppet_agent::collection == 'PC1' {
         $source = "${puppet_agent::yum_source}/sles/${facts['os']['release']['major']}/${puppet_agent::collection}/${puppet_agent::arch}"
+      } elsif $puppet_agent::collection =~ /core/ {
+        $_collection = regsubst($puppet_agent::collection, /core/, '')
+        $source = "https://yum-puppetcore.puppet.com/${_collection}/sles/${facts['os']['release']['major']}/${puppet_agent::arch}"
       } else {
         $source = "${puppet_agent::yum_source}/${puppet_agent::collection}/sles/${facts['os']['release']['major']}/${puppet_agent::arch}"
       }


### PR DESCRIPTION
An earlier version of PR #757 assumed the default yum_source was changing to yum-puppetcore.puppet.com. Later we decided not to introduce a breaking change and instead use puppetcore* collections to opt-into the new behavior. However, the PR wasn't updated to account for that. And I didn't notice the problem because the docker upgrade script was using the puppet8 collection.

Change the upgrade script to use puppetcore* collections and update the redhat and suse classes to install from yum-puppetcore.puppet.com when using the core repos.

    ❯ export PUPPET_FORGE_TOKEN=...
    ❯ docker/bin/upgrade.sh rocky 7.34.0 8.11.0
    ...
    Notice: /Stage[main]/Puppet_agent::Install/Package[puppet-agent]/ensure: ensure changed '7.34.0-1.el8' to '8.11.0'
    ❯ docker/bin/upgrade.sh sles 7.34.0 8.11.0
    ...
    Notice: /Stage[main]/Puppet_agent::Install::Suse/Package[puppet-agent]/ensure: ensure changed '7.34.0-1.sles15' to '8.11.0'