### PR TITLE
Use ubuntu-latest instead of 20.04

### DIFF
--- a/.github/workflows/task_acceptance_tests.yaml
+++ b/.github/workflows/task_acceptance_tests.yaml
@@ -20,7 +20,7 @@ jobs:
       BEAKER_debug: true
       BEAKER_set: docker/${{ matrix.os }}
 
-    runs-on: 'ubuntu-20.04'
+    runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout current PR code
         uses: actions/checkout@v4

--- a/manifests/osfamily/debian.pp
+++ b/manifests/osfamily/debian.pp
@@ -59,7 +59,7 @@ class puppet_agent::osfamily::debian {
 
         # Pass in an empty content string since apt requires it even though we are removing it
         apt::setting { 'list-puppet-enterprise-installer':
-          ensure  => absent,
+          ensure => absent,
         }
 
         apt::setting { 'conf-pe-repo':


### PR DESCRIPTION
The ubuntu 20.04 GitHub runner is deprecated and will be dropped April 1, so use latest.
    
The other ubuntu 20.04 instance is used to provision a docker container, so leave that as is.

Also appease puppet-lint.