### PR TITLE
Update module to support puppetcore on Windows

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6,6 +6,8 @@
 
 ### Classes
 
+#### Public Classes
+
 * [`puppet_agent`](#puppet_agent): Upgrades Puppet 4 and newer to the requested version.
 * [`puppet_agent::configure`](#puppet_agent--configure): Uses $puppet_agent::config to manage settings in puppet.conf.
 * [`puppet_agent::install`](#puppet_agent--install): This class is called from puppet_agent for install.
@@ -22,9 +24,12 @@
 * [`puppet_agent::osfamily::windows`](#puppet_agent--osfamily--windows): Determines the puppet-agent package location for Windows OSes.
 * [`puppet_agent::params`](#puppet_agent--params): Sets variables according to platform.
 * [`puppet_agent::prepare`](#puppet_agent--prepare): This class is called from puppet_agent to prepare for the upgrade.
-* [`puppet_agent::prepare::package`](#puppet_agent--prepare--package): Ensures correct puppet-agent package is downloaded locally.
 * [`puppet_agent::prepare::puppet_config`](#puppet_agent--prepare--puppet_config): Private class called from puppet_agent::prepare class.
 * [`puppet_agent::service`](#puppet_agent--service): Ensures that managed services are running.
+
+#### Private Classes
+
+* `puppet_agent::prepare::package`: Ensures correct puppet-agent package is downloaded locally.
 
 ### Resource types
 
@@ -614,35 +619,6 @@ The puppet-agent version to install.
 
 Default value: `undef`
 
-### <a name="puppet_agent--prepare--package"></a>`puppet_agent::prepare::package`
-
-for installation. This is used on platforms without package managers capable of
-working with a remote https repository.
-
-#### Parameters
-
-The following parameters are available in the `puppet_agent::prepare::package` class:
-
-* [`source`](#-puppet_agent--prepare--package--source)
-* [`package_file_name`](#-puppet_agent--prepare--package--package_file_name)
-
-##### <a name="-puppet_agent--prepare--package--source"></a>`source`
-
-Data type: `Variant[String, Array]`
-
-The source file for the puppet-agent package. Can use any of the data types
-and protocols that the File resource's source attribute can.
-
-##### <a name="-puppet_agent--prepare--package--package_file_name"></a>`package_file_name`
-
-Data type: `Optional[String]`
-
-The destination file name for the puppet-agent package. If no destination
-is given, then the basename component of the source will be used as the
-destination filename.
-
-Default value: `undef`
-
 ### <a name="puppet_agent--prepare--puppet_config"></a>`puppet_agent::prepare::puppet_config`
 
 Private class called from puppet_agent::prepare class.
@@ -1006,13 +982,13 @@ The number of retries in case of network connectivity failures
 
 ##### `username`
 
-Data type: `Optional[String]`
+Data type: `Optional[String[1]]`
 
 The username to use when downloading from a source location requiring authentication
 
 ##### `password`
 
-Data type: `Optional[String]`
+Data type: `Optional[Sensitive[String[1]]]`
 
 The password to use when downloading from a source location requiring authentication
 
@@ -1086,13 +1062,13 @@ The number of retries in case of network connectivity failures
 
 ##### `username`
 
-Data type: `Optional[String]`
+Data type: `Optional[String[1]]`
 
 The username to use when downloading from a source location requiring authentication
 
 ##### `password`
 
-Data type: `Optional[String]`
+Data type: `Optional[Sensitive[String[1]]]`
 
 The password to use when downloading from a source location requiring authentication
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -624,6 +624,7 @@ working with a remote https repository.
 The following parameters are available in the `puppet_agent::prepare::package` class:
 
 * [`source`](#-puppet_agent--prepare--package--source)
+* [`package_file_name`](#-puppet_agent--prepare--package--package_file_name)
 
 ##### <a name="-puppet_agent--prepare--package--source"></a>`source`
 
@@ -631,6 +632,16 @@ Data type: `Variant[String, Array]`
 
 The source file for the puppet-agent package. Can use any of the data types
 and protocols that the File resource's source attribute can.
+
+##### <a name="-puppet_agent--prepare--package--package_file_name"></a>`package_file_name`
+
+Data type: `Optional[String]`
+
+The destination file name for the puppet-agent package. If no destination
+is given, then the basename component of the source will be used as the
+destination filename.
+
+Default value: `undef`
 
 ### <a name="puppet_agent--prepare--puppet_config"></a>`puppet_agent::prepare::puppet_config`
 
@@ -992,6 +1003,18 @@ Whether to stop the puppet agent service after install
 Data type: `Optional[Integer]`
 
 The number of retries in case of network connectivity failures
+
+##### `username`
+
+Data type: `Optional[String]`
+
+The username to use when downloading from a source location requiring authentication
+
+##### `password`
+
+Data type: `Optional[String]`
+
+The password to use when downloading from a source location requiring authentication
 
 ### <a name="install_shell"></a>`install_shell`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,7 +3,9 @@
 # @param arch
 #   The package architecture. Defaults to the architecture fact.
 # @param collection
-#   The Puppet Collection to track. Defaults to 'PC1'.
+#   The Puppet Collection to track. Defaults to 'PC1'. Valid values are puppet7,
+#   puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly,
+#   puppetcore7, puppetcore8.
 # @param is_pe
 #   Install from Puppet Enterprise repos. Enabled if communicating with a PE master.
 # @param manage_pki_dir

--- a/manifests/osfamily/windows.pp
+++ b/manifests/osfamily/windows.pp
@@ -23,13 +23,22 @@ class puppet_agent::osfamily::windows {
   } else {
     if $puppet_agent::collection == 'PC1' {
       $source = "${puppet_agent::windows_source}/windows/${puppet_agent::package_name}-${puppet_agent::prepare::package_version}-${puppet_agent::arch}.msi"
+    } elsif $puppet_agent::collection =~ /core/ {
+      $source = 'https://artifacts-puppetcore.puppet.com/v1/download'
     } else {
       $source = "${puppet_agent::windows_source}/windows/${puppet_agent::collection}/${puppet_agent::package_name}-${puppet_agent::prepare::package_version}-${puppet_agent::arch}.msi"
     }
   }
 
+  $destination_name = if $puppet_agent::collection =~ /core/ {
+    "${puppet_agent::package_name}-${puppet_agent::prepare::package_version}-${puppet_agent::arch}.msi"
+  } else {
+    undef
+  }
+
   class { 'puppet_agent::prepare::package':
-    source => $source,
+    source           => $source,
+    destination_name => $destination_name,
   }
 
   contain puppet_agent::prepare::package

--- a/manifests/prepare/package.pp
+++ b/manifests/prepare/package.pp
@@ -35,6 +35,7 @@ class puppet_agent::prepare::package (
   if $puppet_agent::collection =~ /core/ and $facts['os']['family'] =~ /windows/ {
     $download_username = getvar('puppet_agent::username', 'forge-key')
     $download_password = unwrap(getvar('puppet_agent::password'))
+    $dev = count(split($puppet_agent::prepare::package_version, '\.')) > 3
 
     $_download_puppet = windows_native_path("${facts['env_temp_variable']}/download_puppet.ps1")
     file { $_download_puppet:

--- a/manifests/prepare/package.pp
+++ b/manifests/prepare/package.pp
@@ -2,16 +2,10 @@
 # for installation. This is used on platforms without package managers capable of
 # working with a remote https repository.
 #
-# @param source
-#   The source file for the puppet-agent package. Can use any of the data types
-#   and protocols that the File resource's source attribute can.
-# @param destination_name
-#   The destination file name for the puppet-agent package. If no destination
-#   is given, then the basename component of the source will be used as the
-#   destination name.
+# @api private
 class puppet_agent::prepare::package (
   Variant[String, Array] $source,
-  Optional[String] $destination_name = undef
+  Optional[String[1]] $destination_name = undef
 ) {
   assert_private()
 
@@ -19,15 +13,15 @@ class puppet_agent::prepare::package (
     ensure => directory,
   }
 
-  if $destination_name {
-    $package_file_name = $destination_name
+  $package_file_name = if $destination_name {
+    $destination_name
   } else {
     # In order for the 'basename' function to work correctly we need to change
     # any \s to /s (even for windows UNC paths) so that it will correctly pull off
     # the filename. Since this operation is only grabbing the base filename and not
     # any part of the path this should be safe, since the source will simply remain
     # what it was before and we can still pull off the filename.
-    $package_file_name = basename(regsubst($source, "\\\\", '/', 'G'))
+    basename(regsubst($source, "\\\\", '/', 'G'))
   }
 
   if $facts['os']['family'] =~ /windows/ {

--- a/manifests/prepare/package.pp
+++ b/manifests/prepare/package.pp
@@ -5,8 +5,13 @@
 # @param source
 #   The source file for the puppet-agent package. Can use any of the data types
 #   and protocols that the File resource's source attribute can.
+# @param destination_name
+#   The destination file name for the puppet-agent package. If no destination
+#   is given, then the basename component of the source will be used as the
+#   destination name.
 class puppet_agent::prepare::package (
   Variant[String, Array] $source,
+  Optional[String] $destination_name = undef
 ) {
   assert_private()
 
@@ -14,12 +19,17 @@ class puppet_agent::prepare::package (
     ensure => directory,
   }
 
-  # In order for the 'basename' function to work correctly we need to change
-  # any \s to /s (even for windows UNC paths) so that it will correctly pull off
-  # the filename. Since this operation is only grabbing the base filename and not
-  # any part of the path this should be safe, since the source will simply remain
-  # what it was before and we can still pull off the filename.
-  $package_file_name = basename(regsubst($source, "\\\\", '/', 'G'))
+  if $destination_name {
+    $package_file_name = $destination_name
+  } else {
+    # In order for the 'basename' function to work correctly we need to change
+    # any \s to /s (even for windows UNC paths) so that it will correctly pull off
+    # the filename. Since this operation is only grabbing the base filename and not
+    # any part of the path this should be safe, since the source will simply remain
+    # what it was before and we can still pull off the filename.
+    $package_file_name = basename(regsubst($source, "\\\\", '/', 'G'))
+  }
+
   if $facts['os']['family'] =~ /windows/ {
     $local_package_file_path = windows_native_path("${puppet_agent::params::local_packages_dir}/${package_file_name}")
     $mode = undef
@@ -28,12 +38,37 @@ class puppet_agent::prepare::package (
     $mode = '0644'
   }
 
-  file { $local_package_file_path:
-    ensure  => file,
-    owner   => $puppet_agent::params::user,
-    group   => $puppet_agent::params::group,
-    mode    => $mode,
-    source  => $source,
-    require => File[$puppet_agent::params::local_packages_dir],
+  if $puppet_agent::collection =~ /core/ and $facts['os']['family'] =~ /windows/ {
+    $download_username = getvar('puppet_agent::username', 'forge-key')
+    $download_password = unwrap(getvar('puppet_agent::password'))
+
+    $_download_puppet = windows_native_path("${facts['env_temp_variable']}/download_puppet.ps1")
+    file { $_download_puppet:
+      ensure  => file,
+      content => Sensitive(epp('puppet_agent/download_puppet.ps1.epp')),
+    }
+
+    exec { 'Download Puppet Agent':
+      command => [
+        "${facts['os']['windows']['system32']}\\WindowsPowerShell\\v1.0\\powershell.exe",
+        '-ExecutionPolicy',
+        'Bypass',
+        '-NoProfile',
+        '-NoLogo',
+        '-NonInteractive',
+        $_download_puppet
+      ],
+      creates => $local_package_file_path,
+      require => File[$puppet_agent::params::local_packages_dir],
+    }
+  } else {
+    file { $local_package_file_path:
+      ensure  => file,
+      owner   => $puppet_agent::params::user,
+      group   => $puppet_agent::params::group,
+      mode    => $mode,
+      source  => $source,
+      require => File[$puppet_agent::params::local_packages_dir],
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -23,6 +23,10 @@
     {
       "name": "puppetlabs-facts",
       "version_requirement": ">= 0.5.0 < 2.0.0"
+    },
+    {
+      "name": "puppetlabs-powershell",
+      "version_requirement": ">= 6.0.2 < 7.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/tasks/install_powershell.json
+++ b/tasks/install_powershell.json
@@ -45,11 +45,11 @@
     },
     "username": {
       "description": "The username to use when downloading from a source location requiring authentication",
-      "type": "Optional[String]"
+      "type": "Optional[String[1]]"
     },
     "password": {
       "description": "The password to use when downloading from a source location requiring authentication",
-      "type": "Optional[String]"
+      "type": "Optional[Sensitive[String[1]]]"
     }
   },
   "supports_noop": true

--- a/tasks/install_powershell.json
+++ b/tasks/install_powershell.json
@@ -42,6 +42,14 @@
       "description": "The number of retries in case of network connectivity failures",
       "type": "Optional[Integer]",
       "default": 5
+    },
+    "username": {
+      "description": "The username to use when downloading from a source location requiring authentication",
+      "type": "Optional[String]"
+    },
+    "password": {
+      "description": "The password to use when downloading from a source location requiring authentication",
+      "type": "Optional[String]"
     }
   },
   "supports_noop": true

--- a/tasks/install_powershell.ps1
+++ b/tasks/install_powershell.ps1
@@ -7,10 +7,20 @@ Param(
   [String]$install_options = 'REINSTALLMODE="amus"',
   [Bool]$stop_service = $False,
   [Int]$retry = 5,
-  [Bool]$_noop = $False
+  [Bool]$_noop = $False,
+  [String]$username = 'forge-key',
+  [String]$password
 )
 # If an error is encountered, the script will stop instead of the default of "Continue"
 $ErrorActionPreference = "Stop"
+
+try {
+  $os_version = (Get-WmiObject Win32_OperatingSystem).Version
+}
+catch [System.Management.Automation.CommandNotFoundException] {
+  $os_version = (Get-CimInstance -ClassName win32_OperatingSystem).Version
+}
+$major_os_version = ($os_version -split '\.')[0]
 
 try {
   if ((Get-WmiObject Win32_OperatingSystem).OSArchitecture -match '^32') {
@@ -27,9 +37,19 @@ catch [System.Management.Automation.CommandNotFoundException] {
   }
 }
 
+$fips = 'false'
+try {
+  if ((Get-ItemPropertyValue -Path 'HKLM:\System\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy' -Name Enabled) -ne 0) {
+    $fips = 'true'
+  }
+}
+catch {
+  Write-Output "Failed to lookup FIPS mode, assuming it is disabled"
+}
+
 function Test-PuppetInstalled {
   $rootPath = 'HKLM:\SOFTWARE\Puppet Labs\Puppet'
-  try { 
+  try {
     if (Get-ItemProperty -Path $rootPath) { RETURN $true }
   }
   catch {
@@ -98,12 +118,16 @@ if (Test-RunningServices) {
 # Change windows_source only if the collection is a nightly build, and the source was not explicitly specified.
 if (($collection -like '*nightly*') -And -Not ($PSBoundParameters.ContainsKey('windows_source'))) {
   $windows_source = 'https://nightlies.puppet.com/downloads'
+} elseif (($collection -like '*puppetcore*') -And -Not ($PSBoundParameters.ContainsKey('windows_source'))) {
+  $windows_source = 'https://artifacts-puppetcore.puppet.com/v1/download'
 }
 
 if ($absolute_source) {
     $msi_source = "$absolute_source"
 }
-else {
+elseif ($collection -like '*puppetcore*') {
+    $msi_source = "${windows_source}?version=${version}&os_name=windows&os_version=${major_os_version}&os_arch=${arch}&fips=${fips}"
+} else {
     $msi_source = "$windows_source/windows/${collection}/${msi_name}"
 }
 
@@ -125,15 +149,19 @@ function Set-Tls12 {
 }
 
 function DownloadPuppet {
-  Write-Output "Downloading the Puppet Agent installer on $env:COMPUTERNAME..."
+  Write-Output "Downloading the Puppet Agent installer on $env:COMPUTERNAME from ${msi_source}"
   Set-Tls12
 
   $webclient = New-Object system.net.webclient
-
+  if ($password) {
+    $credentials = [Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes("${username}:${password}"))
+    $webclient.Headers.Add("Authorization", "Basic ${credentials}")
+  }
   try {
     $webclient.DownloadFile($msi_source,$msi_dest)
   }
   catch [System.Net.WebException] {
+    Write-Host "Download exception: $($_.Exception.Message)"
     For ($attempt_number = 1; $attempt_number -le $retry; $attempt_number++) {
       try {
         Write-Output "Retrying... [$attempt_number/$retry]"
@@ -141,6 +169,7 @@ function DownloadPuppet {
         break
       }
       catch [System.Net.WebException] {
+        Write-Host "Download exception: $($_.Exception.Message)"
         if($attempt_number -eq $retry) {
           # If we can't find the msi, then we may not be configured correctly
           if($_.Exception.Response.StatusCode -eq [system.net.httpstatuscode]::NotFound) {

--- a/tasks/install_powershell.ps1
+++ b/tasks/install_powershell.ps1
@@ -124,9 +124,14 @@ if (($collection -like '*nightly*') -And -Not ($PSBoundParameters.ContainsKey('w
 
 if ($absolute_source) {
     $msi_source = "$absolute_source"
-}
-elseif ($collection -like '*puppetcore*') {
-    $msi_source = "${windows_source}?version=${version}&os_name=windows&os_version=${major_os_version}&os_arch=${arch}&fips=${fips}"
+} elseif ($collection -like '*puppetcore*') {
+    # dev param is case-sensitive, so don't use $True
+    if (($version -split '\.').count -gt 3) {
+        $dev = '&dev=true'
+    } else {
+        $dev = ''
+    }
+    $msi_source = "${windows_source}?version=${version}&os_name=windows&os_version=${major_os_version}&os_arch=${arch}&fips=${fips}${dev}"
 } else {
     $msi_source = "$windows_source/windows/${collection}/${msi_name}"
 }

--- a/tasks/install_shell.json
+++ b/tasks/install_shell.json
@@ -46,11 +46,11 @@
     },
     "username": {
       "description": "The username to use when downloading from a source location requiring authentication",
-      "type": "Optional[String]"
+      "type": "Optional[String[1]]"
     },
     "password": {
       "description": "The password to use when downloading from a source location requiring authentication",
-      "type": "Optional[String]"
+      "type": "Optional[Sensitive[String[1]]]"
     }
   },
   "files": ["facts/tasks/bash.sh"],

--- a/templates/download_puppet.ps1.epp
+++ b/templates/download_puppet.ps1.epp
@@ -1,9 +1,10 @@
 $body = @{
-    "version" = "<%= $puppet_agent::prepare::package_version %>"
-    "os_name" = "<%= $facts['os']['family'] %>"
+    "version"    = "<%= $puppet_agent::prepare::package_version %>"
+    "dev"        = "<%= $puppet_agent::prepare::package::dev %>"
+    "os_name"    = "<%= $facts['os']['family'] %>"
     "os_version" = "<%= $facts['os']['release']['major'] %>"
-    "os_arch" = "<%= $facts['os']['architecture'] %>"
-    "fips" = "<%= $facts['fips_enabled'] %>"
+    "os_arch"    = "<%= $facts['os']['architecture'] %>"
+    "fips"       = "<%= $facts['fips_enabled'] %>"
 }
 $username = "<%= $puppet_agent::prepare::package::download_username %>"
 $password = ConvertTo-SecureString "<%= $puppet_agent::prepare::package::download_password %>" -AsPlainText -Force

--- a/templates/download_puppet.ps1.epp
+++ b/templates/download_puppet.ps1.epp
@@ -1,0 +1,19 @@
+$body = @{
+    "version" = "<%= $puppet_agent::prepare::package_version %>"
+    "os_name" = "<%= $facts['os']['family'] %>"
+    "os_version" = "<%= $facts['os']['release']['major'] %>"
+    "os_arch" = "<%= $facts['os']['architecture'] %>"
+    "fips" = "<%= $facts['fips_enabled'] %>"
+}
+$username = "<%= $puppet_agent::prepare::package::download_username %>"
+$password = ConvertTo-SecureString "<%= $puppet_agent::prepare::package::download_password %>" -AsPlainText -Force
+$credential = New-Object System.Management.Automation.PSCredential($username, $password)
+try {
+    Invoke-WebRequest -Uri "<%= $puppet_agent::prepare::package::source %>" `
+      -Body $body `
+      -Credential $credential `
+      -OutFile "<%= $puppet_agent::prepare::package::local_package_file_path %>"
+} catch [System.Net.WebException] {
+    Write-Host "Network-related error: $($_.Exception.Message)"
+    exit 1
+}


### PR DESCRIPTION
This is analogous to https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/757 but for windows.

Updates the `puppet_agent::install_task` so it's possible to install msi-based packages from https://artifacts-puppetcore.puppet.com. Credentials are required when installing from puppetcore. The username defaults to `forge-key` and the password must be set to your forge API token.

When using WinRM, you must specify Windows credentials (using `--user` and `--password` arguments) to log into the host and puppetcore credentials to download the MSI (as `username` and `password` task parameters)

```
$ /opt/puppetlabs/bolt/bin/bolt task run puppet_agent::install \
  collection=puppetcore8 \
  version=8.11.0 \
  username=forge-key \
  password=... \
  --targets 'winrm://HOST' \
  --user Administrator \
  --password ...
```

Also updates the `puppet_agent` class so it's possible to manage agent versions over time:

```puppet
class { 'puppet_agent':
  package_version => '8.11.0',
  collection => 'puppetcore8',
  password => Sensitive(...)
}
```

The `puppet_agent::prepare::package` class on Windows normally uses a `file` resource to download the MSI from the `source`. However, due to a bug in puppet, it is not possible to pass credentials as the `userinfo` component of the URL, e.g. `https://forge-id:TOKEN@artifacts-puppetcore.puppet.com` So instead use a powershell script to download the MSI. That code is borrowed from https://github.com/klab-systems/puppet_core_agent, credit to @klab-systems