### PR TITLE
(PA-7222) Add Amazon FIPS 2023 (x86_64) support in task acceptance tests

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -45,7 +45,8 @@ describe 'install task' do
     %r{
       fedora-41|
       osx-15-arm64|
-      osx-15-x86_64
+      osx-15-x86_64|
+      amazonfips-2023
     }x
   end
 


### PR DESCRIPTION
This commit adds Amazon FIPS 2023 (x86_64) support to task acceptance tests. Support for puppet7 to puppet8 upgrade tests has not been added since puppet7 is EOL and its packages were not built for the platform.