### PR TITLE
Fix Ubuntu 24 puppet-agent installation by using version-specific collections

### DIFF
--- a/docs/adr/0001-ubuntu-24-collection-selection-for-puppet-agent-install-task.md
+++ b/docs/adr/0001-ubuntu-24-collection-selection-for-puppet-agent-install-task.md
@@ -14,7 +14,7 @@ This issue specifically affected Ubuntu 24, while other operating systems worked
 
 The puppet_agent::install task (implemented in install_shell.sh) provides a mechanism for installing the Puppet agent across various platforms. It accepts parameters including 'collection', which determines which package collection to use. If no collection is specified, it was defaulting to the generic 'puppet' collection.
 
-A temporary fix was implemented in Bolt's apply_prep.rb function, which added logic to determine the Puppet version and set the collection parameter accordingly. While this fix worked, it violated architectural separation of concerns by placing target-specific logic in the higher-level orchestration function.
+A temporary fix was implemented in Bolt's apply_prep.rb function, which added logic to determine the Puppet version and set the collection parameter accordingly. While this fix worked, it violated architectural separation of concerns by placing target-specific logic in the higher-level orchestration function. For more information, see [this pr](https://github.com/puppetlabs/bolt/pull/3376) and [this PR](https://github.com/puppetlabs/bolt-private/pull/16).
 
 ## Decision
 

--- a/docs/adr/0001-ubuntu-24-collection-selection-for-puppet-agent-install-task.md
+++ b/docs/adr/0001-ubuntu-24-collection-selection-for-puppet-agent-install-task.md
@@ -1,0 +1,54 @@
+# 1. Ubuntu 24 Collection Selection for puppet_agent::install Task
+
+Date: 2025-04-23
+
+## Status
+
+Proposed
+
+## Context
+
+When running Bolt apply with Ubuntu 24 (codename: noble), installations were failing because the puppet_agent::install task defaulted to using the generic 'puppet' collection, resulting in the installation of `puppet-release-noble.deb` instead of the version-specific `puppet8-release-noble.deb`.
+
+This issue specifically affected Ubuntu 24, while other operating systems worked correctly. The underlying cause was that the generic 'puppet' repository didn't properly support Ubuntu 24, whereas the version-specific repositories (like 'puppet8') did have proper packages available.
+
+The puppet_agent::install task (implemented in install_shell.sh) provides a mechanism for installing the Puppet agent across various platforms. It accepts parameters including 'collection', which determines which package collection to use. If no collection is specified, it was defaulting to the generic 'puppet' collection.
+
+A temporary fix was implemented in Bolt's apply_prep.rb function, which added logic to determine the Puppet version and set the collection parameter accordingly. While this fix worked, it violated architectural separation of concerns by placing target-specific logic in the higher-level orchestration function.
+
+## Decision
+
+Move the Puppet version detection and collection selection logic from Bolt's apply_prep function to the puppet_agent::install task's install_shell.sh script, which is the architecturally appropriate location for this functionality.
+
+The implementation enhances the collection selection logic to:
+
+1. First check if a collection was explicitly specified
+   - If so, use that collection as before
+   - This maintains backward compatibility and user control
+
+2. If no collection is specified, intelligently determine the appropriate collection:
+   - First try to detect Puppet version from `/opt/puppetlabs/puppet/VERSION`
+   - If that fails, try using the `puppet --version` command
+   - Use the major version to set the collection to `puppet{major_version}` (e.g., `puppet8`)
+   - Only fall back to the generic `puppet` collection as a last resort
+
+This ensures that for Ubuntu 24, the task will use puppet8-release-noble.deb (assuming Puppet 8) instead of puppet-release-noble.deb.
+
+Rationale:
+
+- The task script is the appropriate location for OS-specific installation logic, maintaining separation of concerns.
+- The task already handles platform-specific behavior, making it the natural location for this enhancement.
+
+## Consequences
+
+Positive:
+
+- Ubuntu 24 installations now work correctly out of the box.
+- The solution keeps high-level consumers, like bolt, agnostic to implementation details.
+- All platforms will now prefer version-specific collections by default, which is generally more reliable.
+
+Negative:
+
+- The install_shell.sh script becomes slightly more complex with additional logic.
+- The solution relies on either /opt/puppetlabs/puppet/VERSION existing or the puppet command being available, though it falls back gracefully if neither is available.
+- If a very different version of Puppet is running Bolt compared to what should be installed on the target, this approach might select a non-optimal collection. However, this is mitigated by the ability to explicitly specify a collection when needed.


### PR DESCRIPTION
## Outstanding tasks

- [ ] Verify works as expected with bolt
- [ ] What's the behaviour if `/opt/puppetlabs/puppet/VERSION` already exists? See [tim's comment](https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/774#discussion_r2055796152)

-----

## Issue

When running Bolt apply with Ubuntu 24 (noble), if no collection is explicitly specified, the task defaults to using the generic 'puppet' collection, resulting in installing 'puppet-release-noble.deb' instead of the version-specific 'puppet8-release-noble.deb'. This causes installation failures specific to Ubuntu 24, while other OSes work fine.

A previous fix attempted to address this in bolt's apply_prep function, but that placed OS-specific logic in the wrong architectural layer.

## Solution

This PR moves the solution to the correct location by enhancing the collection selection logic in install_shell.sh to:

1. First check if a collection was explicitly specified (unchanged)
   - If so, use that collection
   - This maintains backward compatibility and user control

2. If no collection is specified, intelligently determine the appropriate collection:
   - First try to detect Puppet version from `/opt/puppetlabs/puppet/VERSION`
   - If that fails, try using the `puppet --version` command
   - Use the major version to set the collection to `puppet{major_version}` (e.g., `puppet8`)
   - Only fall back to the generic `puppet` collection as a last resort

This ensures that:
- Ubuntu 24 installations correctly use puppet8-release-noble.deb
- The target-specific logic is in the proper architectural layer
- We maintain backward compatibility
- We have better logging to track which method was used
