### PR TITLE
bug: mark password as sensitive in puppet_agent::install task

### DIFF
--- a/tasks/install.json
+++ b/tasks/install.json
@@ -48,6 +48,7 @@
     },
     "password": {
       "description": "The password to use when downloading from a source location requiring authentication",
+      "sensitive": true,
       "type": "Optional[String]"
     }
   },

--- a/tasks/install_powershell.json
+++ b/tasks/install_powershell.json
@@ -49,6 +49,7 @@
     },
     "password": {
       "description": "The password to use when downloading from a source location requiring authentication",
+      "sensitive": true,
       "type": "Optional[Sensitive[String[1]]]"
     }
   },

--- a/tasks/install_shell.json
+++ b/tasks/install_shell.json
@@ -50,6 +50,7 @@
     },
     "password": {
       "description": "The password to use when downloading from a source location requiring authentication",
+      "sensitive": true,
       "type": "Optional[Sensitive[String[1]]]"
     }
   },


### PR DESCRIPTION
This commit marks `password` as sensitive in the install.json bolt task param metadata.

This prevents password from being shown in plaintext, in the bolt logs.

before:
```
Running task puppet_agent::install with '{"retry":5,"collection":"puppetcore8","version":"latest","password":"1234","_task":"puppet_agent::install"}' on [".."]
```

after:
```
Running task puppet_agent::install with '{"retry":5,"collection":"puppetcore8","version":"latest","password":"Sensitive [value redacted]","_task":"puppet_agent::install"}' on [".."]
```