### PR TITLE
(PA-7432) Install server packages from internal nightlies

### DIFF
--- a/acceptance/pre_suite/00_master_setup.rb
+++ b/acceptance/pre_suite/00_master_setup.rb
@@ -16,6 +16,7 @@ end
 
 # Install a puppet-agent package on the master:
 test_name "Pre-Suite: Install puppet-agent #{description} on the master" do
+  install_options[:nightly_yum_repo_url] = 'https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/yum'
   install_puppet_agent_on(master, install_options)
 
   agent_version = puppet_agent_version_on(master)
@@ -30,7 +31,10 @@ test_name 'Pre-Suite: Install, configure, and start a compatible puppetserver on
 
   step 'Install puppetserver' do
     # puppetserver is distributed in "release streams" instead of collections.
-    opts = { release_stream: install_options[:puppet_collection] }
+    opts = {
+      release_stream: install_options[:puppet_collection],
+      nightly_yum_repo_url: 'https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/yum'
+    }
 
     install_puppetserver_on(master, opts)
 


### PR DESCRIPTION
Previously, we installed puppet-agent and puppetserver packages from public nightlies, but those are no longer updated. Switch to using internal nightlies instead, with these caveats:

* I didn't change the nightly_apt_repo_url, because we only test with RHEL puppetservers during upgrade testing.

* This change doesn't affect agent-only nodes. Those will be handled in PA-7431