### PR TITLE
(PA-7196) Update the task acceptance tests for Redhat 10(x86_64)

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -46,7 +46,8 @@ describe 'install task' do
       fedora-41|
       osx-15-arm64|
       osx-15-x86_64|
-      amazonfips-2023
+      amazonfips-2023|
+      el-10
     }x
   end
 


### PR DESCRIPTION
We're adding support for only task acceptance tests in this PR and not upgrade tests since we don't have puppet 7 builds to upgrade from.

Tested on local:
```
Beaker::Hypervisor, found some abs boxes to create
Requesting VMs with job_id: swati.yamgar-1750673192570 Will retry for up to an hour.
Waiting 1s (x1) Total: 0 / 1
Waiting 2s (x2) Total: 0 / 1
Waiting 3s (x3) Total: 0 / 1
Waiting 4s (x4) Total: 0 / 1
Waiting 5s (x5) Total: 0 / 1, Ondemand VMPooler: requesting
Waiting 6s (x6) Total: 0 / 1, Ondemand VMPooler: requesting
Waiting 7s (x7) Total: 0 / 1, Ondemand VMPooler: redhat-10-x86_64 (ready: 0, pending: 1)
Waiting 8s (x8) Total: 0 / 1, Ondemand VMPooler: redhat-10-x86_64 (ready: 0, pending: 1)
Waiting 9s (x9) Total: 0 / 1, Ondemand VMPooler: redhat-10-x86_64 (ready: 0, pending: 1)
Waiting 10s (x10) Total: 0 / 1, Ondemand VMPooler: redhat-10-x86_64 (ready: 0, pending: 1)
Waiting 10s (x11) Total: 0 / 1, Ondemand VMPooler: redhat-10-x86_64 (ready: 0, pending: 1)
Waiting 10s (x12) Total: 0 / 1, Ondemand VMPooler: redhat-10-x86_64 (ready: 0, pending: 1)
  Warning: Skipping ip method to ssh to host as its value is not set. Refer to https://github.com/puppetlabs/beaker/tree/master/docs/how_to/ssh_connection_preference.md to remove this warning
verify_host_key: false is deprecated, use :never
  Warning: Skipping ip method to ssh to host as its value is not set. Refer to https://github.com/puppetlabs/beaker/tree/master/docs/how_to/ssh_connection_preference.md to remove this warning
verify_host_key: false is deprecated, use :never
Disabling updates.puppetlabs.com by modifying hosts file to resolve updates to 127.0.0.1 on sober-cutthroat.delivery.puppetlabs.net

install task
++++++++++++++++++++++++++++++
el-10-x86_64
++++++++++++++++++++++++++++++
Installed puppet-agent on sober-cutthroat.delivery.puppetlabs.net: success
  works with version and install tasks

Finished in 48.63 seconds (files took 2 minutes 5.9 seconds to load)
1 example, 0 failures
```
