### PR TITLE
Add puppetcore support for macOS

### DIFF
--- a/manifests/osfamily/darwin.pp
+++ b/manifests/osfamily/darwin.pp
@@ -20,12 +20,21 @@ class puppet_agent::osfamily::darwin {
     } else {
       $source = "puppet:///pe_packages/${pe_server_version}/${facts['platform_tag']}/${puppet_agent::package_name}-${puppet_agent::prepare::package_version}-1.osx${$productversion_major}.dmg"
     }
+  } elsif $puppet_agent::collection =~ /core/ {
+    $source = 'https://artifacts-puppetcore.puppet.com/v1/download'
   } else {
     $source = "${puppet_agent::mac_source}/mac/${puppet_agent::collection}/${productversion_major}/${puppet_agent::arch}/${puppet_agent::package_name}-${puppet_agent::prepare::package_version}-1.osx${$productversion_major}.dmg"
   }
 
+  $destination_name = if $puppet_agent::collection =~ /core/ {
+    "${puppet_agent::package_name}-${puppet_agent::prepare::package_version}-1.osx${$productversion_major}.dmg"
+  } else {
+    undef
+  }
+
   class { 'puppet_agent::prepare::package':
-    source => $source,
+    source           => $source,
+    destination_name => $destination_name,
   }
 
   contain puppet_agent::prepare::package

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -402,6 +402,13 @@ do_wget() {
     unable_to_retrieve_package
   fi
 
+  # check for 401
+  grep "ERROR 401" $tmp_stderr 2>&1 >/dev/null
+  if test $? -eq 0; then
+    critical "ERROR 401"
+    unable_to_retrieve_package
+  fi
+
   # check for bad return status or empty output
   if test $rc -ne 0 || test ! -s "$2"; then
     capture_tmp_stderr "wget"
@@ -425,6 +432,13 @@ do_curl() {
   grep "404 Not Found" $tmp_stderr 2>&1 >/dev/null
   if test $? -eq 0; then
     critical "ERROR 404"
+    unable_to_retrieve_package
+  fi
+
+  # check for 401
+  grep "401 Unauthorized" $tmp_stderr 2>&1 >/dev/null
+  if test $? -eq 0; then
+    critical "ERROR 401"
     unable_to_retrieve_package
   fi
 

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -123,58 +123,39 @@ else
   collection='puppet'
 fi
 
+if [[ "$collection" == "puppetcore"* && -z "$password" ]]; then
+  echo "A password parameter is required to install from puppetcore"
+  exit 1
+fi
+
 if [ -n "$PT_yum_source" ]; then
   yum_source=$PT_yum_source
+elif [[ "$collection" == "puppetcore"* ]]; then
+  yum_source='https://yum-puppetcore.puppet.com/public'
+elif [ "$nightly" = true ]; then
+  yum_source='http://nightlies.puppet.com/yum'
 else
-  if [[ "$collection" == "puppetcore"* ]]; then
-    yum_source='https://yum-puppetcore.puppet.com/public'
-    if [ -z "$password" ]; then
-      echo "A password parameter is required to install from ${yum_source}"
-      exit 1
-    fi
-  else
-    if [ "$nightly" = true ]; then
-      yum_source='http://nightlies.puppet.com/yum'
-    else
-      yum_source='http://yum.puppet.com'
-    fi
-  fi
+  yum_source='http://yum.puppet.com'
 fi
 
 if [ -n "$PT_apt_source" ]; then
   apt_source=$PT_apt_source
+elif [[ "$collection" == "puppetcore"* ]]; then
+  apt_source='https://apt-puppetcore.puppet.com/public'
+elif [ "$nightly" = true ]; then
+  apt_source='http://nightlies.puppet.com/apt'
 else
-  if [[ "$collection" == "puppetcore"* ]]; then
-    apt_source='https://apt-puppetcore.puppet.com/public'
-    if [ -z "$password" ]; then
-        echo "A password parameter is required to install from ${apt_source}"
-        exit 1
-    fi
-  else
-    if [ "$nightly" = true ]; then
-      apt_source='http://nightlies.puppet.com/apt'
-    else
-      apt_source='http://apt.puppet.com'
-    fi
-  fi
+  apt_source='http://apt.puppet.com'
 fi
 
 if [ -n "$PT_mac_source" ]; then
   mac_source=$PT_mac_source
+elif [[ "$collection" == "puppetcore"* ]]; then
+  mac_source='https://artifacts-puppetcore.puppet.com/v1/download'
+elif [ "$nightly" = true ]; then
+  mac_source='http://nightlies.puppet.com/downloads'
 else
-  if [[ "$collection" == "puppetcore"* ]]; then
-    mac_source='https://artifacts-puppetcore.puppet.com/v1/download'
-    if [ -z "$password" ]; then
-      echo "A password parameter is required to install from ${mac_source}"
-      exit 1
-    fi
-  else
-    if [ "$nightly" = true ]; then
-      mac_source='http://nightlies.puppet.com/downloads'
-    else
-      mac_source='http://downloads.puppet.com'
-    fi
-  fi
+  mac_source='http://downloads.puppet.com'
 fi
 
 if [ -n "$PT_retry" ]; then

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -429,14 +429,14 @@ do_curl() {
   rc=$?
 
   # check for 404
-  grep "404 Not Found" $tmp_stderr 2>&1 >/dev/null
+  grep "HTTP/.* 404" $tmp_stderr 2>&1 >/dev/null
   if test $? -eq 0; then
     critical "ERROR 404"
     unable_to_retrieve_package
   fi
 
   # check for 401
-  grep "401 Unauthorized" $tmp_stderr 2>&1 >/dev/null
+  grep "HTTP/.* 401" $tmp_stderr 2>&1 >/dev/null
   if test $? -eq 0; then
     critical "ERROR 401"
     unable_to_retrieve_package

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -162,10 +162,18 @@ fi
 if [ -n "$PT_mac_source" ]; then
   mac_source=$PT_mac_source
 else
-  if [ "$nightly" = true ]; then
-    mac_source='http://nightlies.puppet.com/downloads'
+  if [[ "$collection" == "puppetcore"* ]]; then
+    mac_source='https://artifacts-puppetcore.puppet.com/v1/download'
+    if [ -z "$password" ]; then
+      echo "A password parameter is required to install from ${mac_source}"
+      exit 1
+    fi
   else
-    mac_source='http://downloads.puppet.com'
+    if [ "$nightly" = true ]; then
+      mac_source='http://nightlies.puppet.com/downloads'
+    else
+      mac_source='http://downloads.puppet.com'
+    fi
   fi
 fi
 
@@ -396,10 +404,14 @@ run_cmd() {
   return $rc
 }
 
-# do_wget URL FILENAME
+# do_wget URL FILENAME [USERNAME] [PASSWORD]
 do_wget() {
   info "Trying wget..."
-  run_cmd "wget -O '$2' '$1' 2>$tmp_stderr"
+  if [[ -n "$3" && -n "$4" ]]; then
+    run_cmd "wget -O '$2' --user '$3' --password '$4' '$1' 2>$tmp_stderr"
+  else
+    run_cmd "wget -O '$2' '$1' 2>$tmp_stderr"
+  fi
   rc=$?
 
   # check for 404
@@ -418,10 +430,14 @@ do_wget() {
   return 0
 }
 
-# do_curl URL FILENAME
+# do_curl URL FILENAME [USERNAME] [PASSWORD]
 do_curl() {
   info "Trying curl..."
-  run_cmd "curl -1 -sL -D $tmp_stderr '$1' > '$2'"
+  if [[ -n "$3" && -n "$4" ]]; then
+    run_cmd "curl -1 -sL -u'$3:$4' -D $tmp_stderr '$1' > '$2'"
+  else
+    run_cmd "curl -1 -sL -D $tmp_stderr '$1' > '$2'"
+  fi
   rc=$?
 
   # check for 404
@@ -544,7 +560,7 @@ do_perl_ff() {
   return 1
 }
 
-# do_download URL FILENAME
+# do_download URL FILENAME [USERNAME] [PASSWORD]
 do_download() {
   info "Downloading $1"
   info "  to file $2"
@@ -553,11 +569,11 @@ do_download() {
   # perl, in particular may be present but LWP::Simple may not be installed
 
   if exists wget; then
-    do_wget $1 $2 && return 0
+    do_wget $1 $2 $3 $4 && return 0
   fi
 
   if exists curl; then
-    do_curl $1 $2 && return 0
+    do_curl $1 $2 $3 $4 && return 0
   fi
 
   if exists fetch; then
@@ -822,7 +838,16 @@ case $platform in
     if [[ $(uname -p) == "arm" ]]; then
         arch="arm64"
     fi
-    download_url="${mac_source}/mac/${collection}/${platform_version}/${arch}/${filename}"
+    if [[ "$collection" =~ "puppetcore" ]]; then
+      dots=$(echo "${version}" | grep -o '\.' | wc -l)
+      if (( dots >= 3 )); then
+        download_url="${mac_source}?version=${version}&os_name=osx&os_version=${platform_version}&os_arch=${arch}&dev=true"
+      else
+        download_url="${mac_source}?version=${version}&os_name=osx&os_version=${platform_version}&os_arch=${arch}"
+      fi
+    else
+      download_url="${mac_source}/mac/${collection}/${platform_version}/${arch}/${filename}"
+    fi
     ;;
   *)
     critical "Sorry $platform is not supported yet!"
@@ -837,7 +862,7 @@ fi
 if [[ $PT__noop != true ]]; then
   download_filename="${tmp_dir}/${filename}"
 
-  do_download "$download_url" "$download_filename"
+  do_download "$download_url" "$download_filename" "$username" "$password"
 
   install_file $filetype "$download_filename"
 

--- a/templates/download_puppet.sh.epp
+++ b/templates/download_puppet.sh.epp
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -x
+netrc=$(mktemp)
+trap 'rm -f "$netrc"' EXIT
+chmod 0600 "$netrc"
+cat <<EOF > "$netrc"
+machine artifacts-puppetcore.puppet.com
+login <%= $puppet_agent::prepare::package::download_username %>
+password <%= $puppet_agent::prepare::package::download_password %>
+EOF
+/opt/puppetlabs/puppet/bin/curl \
+ --get \
+ --fail \
+ --location \
+ --netrc-file "$netrc" \
+ --retry 3 \
+ --data-urlencode "version=<%= $puppet_agent::prepare::package_version %>" \
+ --data-urlencode "dev=<%= $puppet_agent::prepare::package::dev %>" \
+ --data-urlencode "os_name=<%= $puppet_agent::prepare::package::osname %>" \
+ --data-urlencode "os_version=<%= $puppet_agent::prepare::package::osversion %>" \
+ --data-urlencode "os_arch=<%= $puppet_agent::prepare::package::osarch %>" \
+ --data-urlencode "fips=<%= $puppet_agent::prepare::package::fips %>" \
+ --output "<%= $puppet_agent::prepare::package::local_package_file_path %>" \
+ "<%= $puppet_agent::prepare::package::source %>"
+


### PR DESCRIPTION
Adds support for installing puppetcore packages on macOS via bolt task:

```shell
/opt/puppetlabs/bolt/bin/bolt task run puppet_agent::install \
  collection=puppetcore8 \
  version=8.13.1 \
  username=forge-key \
  password=${PUPPET_FORGE_TOKEN} \
  --targets 'www.example.com'
```

And upgrading installed packages to puppetcore over time:

```ruby
class { 'puppet_agent':
  package_version => '8.13.1',
  collection      => 'puppetcore8',
  username        => 'forge-key',
  password        => Sensitive(...)
}
include 'puppet_agent'
```