### PR TITLE
 (ITHELP-116185) Add fix dns step to Task Acceptance Tests workflow

### DIFF
--- a/.github/workflows/task_acceptance_tests.yaml
+++ b/.github/workflows/task_acceptance_tests.yaml
@@ -24,9 +24,29 @@ jobs:
     steps:
 
       - name: Connect to Twingate
-        uses: twingate/github-action@v1
+        uses: twingate/github-action@v1.5
         with:
           service-key: ${{ secrets.TWINGATE_PUBLIC_REPO_KEY }}
+        env:
+          TWINGATE_LOG_LEVEL: debug
+
+      - name: Fix DNS
+        run: |
+          echo "=== Remove Azure DNS from eth0 interface ==="
+          sudo resolvectl dns eth0 ""
+
+          echo "=== Configure Twingate DNS properly ==="
+          sudo resolvectl dns sdwan0 100.95.0.251 100.95.0.252
+          sudo resolvectl domain sdwan0 delivery.puppetlabs.net
+
+          echo "=== Flush DNS cache ==="
+          sudo resolvectl flush-caches
+
+          echo "=== Check new configuration ==="
+          resolvectl status
+
+          echo "=== Test DNS resolution ==="
+          nslookup artifactory.delivery.puppetlabs.net
 
       - name: Checkout current PR code
         uses: actions/checkout@v4


### PR DESCRIPTION
In the Task Acceptance Tests workflow, Twingate was having trouble connecting to Artifactory due to running the job in Docker containers. The Docker containers used in the workflow run on Azure VM's and Microsoft adds their own nameservers, 168.63.129.16. It gets copied to resolv.conf and interferes with Twingate which caused DNS resolution failures with Artifactory.

To resolve this, this commit adds a "Fix DNS" step that removes the Azure DNS name server and adds Twingate's DNS server.