### PR TITLE
(CAT-2413) Update `install_powershell.ps1` to generate the correct link

### DIFF
--- a/tasks/install_powershell.ps1
+++ b/tasks/install_powershell.ps1
@@ -131,7 +131,7 @@ if ($absolute_source) {
     } else {
         $dev = ''
     }
-    $msi_source = "${windows_source}?version=${version}&os_name=windows&os_version=${major_os_version}&os_arch=${arch}&fips=${fips}${dev}"
+    $msi_source = "${windows_source}?type=native&version=${version}&os_name=windows&os_version=${major_os_version}&os_arch=${arch}&fips=${fips}${dev}"
 } else {
     $msi_source = "$windows_source/windows/${collection}/${msi_name}"
 }


### PR DESCRIPTION
As it stands the download link generated is missing the type variable and as such is considered invalid. This is likely a remnant of when the agent was the only product hosted on the site.