### PR TITLE
(CAT-2413) Defaults puppetcore agent version to newest if none given

### DIFF
--- a/tasks/install_powershell.ps1
+++ b/tasks/install_powershell.ps1
@@ -122,6 +122,15 @@ if (($collection -like '*puppetcore*-nightly*') -And -Not ($PSBoundParameters.Co
   $windows_source = 'https://nightlies.puppet.com/downloads'
 } elseif (($collection -like '*puppetcore*') -And -Not ($PSBoundParameters.ContainsKey('windows_source'))) {
   $windows_source = 'https://artifacts-puppetcore.puppet.com/v1/download'
+  # Puppetcore requires a version to be specified, so we will use the latest version if not specified.
+  # Or if the version is set to "latest".
+  if ($version -eq "" || !$version || $version -eq "latest") {
+    $response = Invoke-WebRequest -Uri "https://forgeapi.puppet.com/private/versions/puppet-agent" -UseBasicParsing
+    $jsonData = $response.Content | ConvertFrom-Json
+    $allVersions = $jsonData.PSObject.Properties.Name
+    $version8x = $allVersions | Where-Object { $_ -like "8.*" }
+    $version = $version8x | Sort-Object { [Version]$_ } | Select-Object -Last 1
+  }
 }
 
 if ($absolute_source) {


### PR DESCRIPTION
When puppetcore is selected without a specified version, this change defaults to the latest 8.x version available.

This prevents errors caused by the download site requiring a version parameter.

Relates to CAT-2413