### PR TITLE
Pass credentials to reusable workflow

### DIFF
--- a/.github/workflows/static_code_analysis.yaml
+++ b/.github/workflows/static_code_analysis.yaml
@@ -11,3 +11,4 @@ on:
 jobs:
   static_code_analysis:
     uses: "puppetlabs/phoenix-github-actions/.github/workflows/static_code_analysis.yaml@main"
+    secrets: inherit


### PR DESCRIPTION
The workflow was failing during bundle install because the secret PUPPET_FORGE_TOKEN wasn't passed:

    /opt/hostedtoolcache/Ruby/3.1.7/x64/bin/bundle lock
    Fetching source index from https://rubygems-puppetcore.puppet.com/

    Bad username or password for https://forge-key@rubygems-puppetcore.puppet.com/.