### PR TITLE
Drop puppet_litmus to resolve patron dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,6 @@ group :development, :release_prep do
   gem "puppet-blacksmith", '~> 7.0',      require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 1.0',      require: false, platforms: [:ruby, :x64_mingw]
   gem "CFPropertyList", '< 3.0.7',    require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "serverspec", '~> 2.41',        require: false
   gem "voxpupuli-acceptance", '~> 3', require: false


### PR DESCRIPTION
Commit 616132721841f41ab5a3c478b6d99134e67e600e introduced a puppet_litmus dependency which transitively caused bundler to try to install patron 0.13.4. In CI, we don't have libcurl headers installed, so patron failed to install its native extensions.

The problem is caused due to this chain of dependencies:

    puppet_litmus (1.6.1)
      bolt (~> 4.0)
        orchestrator_client (~> 0.7)
          faraday-net_http_persistent (>= 1.0, < 3.0)

When resolving dependencies, bundler first picked faraday-net_http_persistent 2.0.2 and worked backwards to faraday. Faraday 1.9.0 allows 2.x versions of faraday-* adapters, while faraday 1.10.4 requires 1.x versions. So bundler backtracked from faraday 1.10.4 to 1.9.0.

    $ BUNDLER_DEBUG_RESOLVER_TREE=1 bundle install
    ...
    attempting faraday-net_http_persistent 2.0.2
    knew: faraday-net_http_persistent >= 2.0.0 depends on Ruby >= 2.6.0
    fact: faraday-net_http_persistent >= 2.0.2, < 2.1.0 depends on faraday-net_http < 3
    fact: faraday-net_http_persistent >= 2.0.0, < 2.2.0 depends on net-http-persistent ~> 4.0
    selected faraday-net_http_persistent 2.0.2
    ...
    attempting faraday 1.9.0
    ...
    fact: faraday >= 1.9.0, < 1.9.1 depends on faraday-patron < 3
    ...
    selected faraday 1.9.0
    ...
    attempting faraday-patron 2.0.2
    ...
    selected faraday-patron 2.0.2
    derived: patron >= 0.4.2
    ...
    selected patron 0.13.4

Since we don't use litmus to test puppet_agent, just remove the gem dependency.