### PR TITLE
(maint) Upgrade to latest puppet 8.x agents

### DIFF
--- a/acceptance/tests/test_upgrade_puppet7_to_puppet8.rb
+++ b/acceptance/tests/test_upgrade_puppet7_to_puppet8.rb
@@ -6,7 +6,8 @@ require_relative '../helpers'
 test_name 'puppet_agent class: Upgrade agents from puppet7 to puppet8' do
   require_master_collection 'puppet8-nightly'
   exclude_pe_upgrade_platforms
-  latest_version = `curl https://builds.delivery.puppetlabs.net/passing-agent-SHAs/puppet-agent-main-version`
+  latest_version = `curl https://builds.delivery.puppetlabs.net/passing-agent-SHAs/puppet-agent-8.x-version`
+  logger.info("Using latest puppet-agent-8.x #{latest_version}")
 
   puppet_testing_environment = new_puppet_testing_environment
 


### PR DESCRIPTION
On agents without package managers, we query builds to get the latest version. Now that `puppet-agent-main-version` is the latest puppet 9.x version, use `puppet-agent-8.x-version` instead. Also log what version is being used:

```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    20  100    20    0     0     41      0 --:--:-- --:--:-- --:--:--    41
  Using latest puppet-agent-8.x 8.16.0.57.g2e9c77acb
```