### PR TITLE
(PA-8238) Add support for MacOS 26 in install_shell.sh

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -49,7 +49,8 @@ describe 'install task' do
       amazonfips-2023|
       el-10|
       debian-13-aarch64|
-      debian-13-amd64
+      debian-13-amd64|
+      osx-26
     }x
   end
 

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -277,6 +277,7 @@ if [ -f "$PT__installdir/facts/tasks/bash.sh" ]; then
       "13")    platform_version="13";;
       "14")    platform_version="14";;
       "15")    platform_version="15";;
+      "26")    platform_version="26";;
       *) echo "No builds for platform: $major_version"
          exit 1
          ;;


### PR DESCRIPTION
Tested on local

<img width="1791" height="479" alt="Screenshot 2026-04-15 at 1 24 31 PM" src="https://github.com/user-attachments/assets/9364f537-d54f-4814-a20d-1440a1c0c917" />

