### PR TITLE
(PA-8250) Allow installation of puppetcore9-nightly packages

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -43,6 +43,14 @@ Gemfile:
     ":system_tests":
       - gem: voxpupuli-acceptance
         version: '~> 3'
+      - gem: puppet_litmus
+        version:
+          - '~> 1.0'
+          - '!= 1.6.1'
+        condition: 'ENV["PUPPET_FORGE_TOKEN"].to_s.empty?'
+        platforms:
+          - ruby
+          - x64_mingw
 
 .github/workflows/release.yml:
   unmanaged: false

--- a/Gemfile
+++ b/Gemfile
@@ -75,11 +75,11 @@ group :development, :release_prep do
   gem "puppet-blacksmith", '~> 7.0',      require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 2.0',      require: false, platforms: [:ruby, :x64_mingw] if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gem "puppet_litmus", '~> 1.0',      require: false, platforms: [:ruby, :x64_mingw] if ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gem "CFPropertyList", '< 3.0.7',    require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "serverspec", '~> 2.41',        require: false
-  gem "voxpupuli-acceptance", '~> 3', require: false
+  gem "puppet_litmus", '~> 2.0',             require: false, platforms: [:ruby, :x64_mingw] if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
+  gem "puppet_litmus", '~> 1.0',             require: false, platforms: [:ruby, :x64_mingw] if ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
+  gem "CFPropertyList", '< 3.0.7',           require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "serverspec", '~> 2.41',               require: false
+  gem "voxpupuli-acceptance", '~> 3',        require: false
 end
 
 gems = {}

--- a/docker/bin/helpers/run-install.sh
+++ b/docker/bin/helpers/run-install.sh
@@ -18,6 +18,9 @@ if [[ -z "$to_collection" ]]; then
         8)
             to_collection=puppetcore8
             ;;
+        9)
+            to_collection=puppetcore9
+            ;;
         *)
             echo "$0: Invalid version supplied" 1>&2
             exit 1

--- a/metadata.json
+++ b/metadata.json
@@ -82,7 +82,7 @@
       "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
-  "pdk-version": "3.5.1",
+  "pdk-version": "3.6.1",
   "template-url": "https://github.com/puppetlabs/pdk-templates#3.5.1",
   "template-ref": "tags/3.5.1-0-g9d5b193"
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,11 @@ require 'spec_helper_local' if File.file?(File.join(File.dirname(__FILE__), 'spe
 
 include RspecPuppetFacts
 
-default_facts = {}
+default_facts = {
+  puppetversion: Puppet.version,
+  facterversion: Facter.version,
+  aio_agent_version: Puppet.version,
+}
 
 default_fact_files = [
   File.expand_path(File.join(File.dirname(__FILE__), 'default_facts.yml')),
@@ -22,15 +26,16 @@ default_fact_files.each do |f|
   next unless File.exist?(f) && File.readable?(f) && File.size?(f)
 
   begin
-    default_facts.merge!(YAML.safe_load(File.read(f), permitted_classes: [], permitted_symbols: [], aliases: true))
+    require 'deep_merge'
+    default_facts.deep_merge!(YAML.safe_load(File.read(f), permitted_classes: [], permitted_symbols: [], aliases: true))
   rescue StandardError => e
     RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
   end
 end
 
-# check if default_module_facts is defined and merge them if the case
-if @default_module_facts.is_a?(Hash)
-  default_facts.merge!(@default_module_facts)
+# read default_facts and merge them over what is provided by facterdb
+default_facts.each do |fact, value|
+  add_custom_fact fact, value, merge_facts: true
 end
 
 RSpec.configure do |c|

--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -38,22 +38,6 @@ describe 'install task' do
     puts logger.info(out)
   end
 
-  # This method contains a list of platforms that are only available in nightly builds of puppet-agent. Once a regular
-  # release of puppet-agent includes support for these platforms, they can be removed from this method and added to
-  # the logic that determines the puppet_7_version variable below.
-  def latest_platform_list
-    %r{
-      fedora-41|
-      osx-15-arm64|
-      osx-15-x86_64|
-      amazonfips-2023|
-      el-10|
-      debian-13-aarch64|
-      debian-13-amd64|
-      osx-26
-    }x
-  end
-
   # This method lists sources to be used when installing packages that haven't been released yet (see above).
   def latest_sources
     {
@@ -64,189 +48,73 @@ describe 'install task' do
     }
   end
 
-  it 'works with version and install tasks' do
-    case target_platform
-    when latest_platform_list
-      # Here we only install puppet-agent 8.x from nightlies as we don't support 7.x
-      # We have to consider tests to upgrade puppet 8.x to latest nightlies in future
+  it 'installs puppetcore8-nightly' do
+    results = run_task('puppet_agent::install', 'target',
+      {
+        'collection' => 'puppetcore8-nightly',
+        'version' => 'latest',
+        'stop_service' => true
+      }.merge(latest_sources))
 
-      # Install an puppet8 nightly version
-      results = run_task('puppet_agent::install', 'target', { 'collection' => 'puppet8-nightly',
-                                                              'version' => 'latest',
-                                                              'stop_service' => true }.merge(latest_sources))
+    results.each do |result|
+      logger.info("Installed puppet-agent on #{result['target']}: #{result['status']}")
+      log_output_errors(result)
+    end
 
-      results.each do |result|
-        logger.info("Installed puppet-agent on #{result['target']}: #{result['status']}")
-        log_output_errors(result)
-      end
+    expect(results).to all(include('status' => 'success'))
 
-      expect(results).to all(include('status' => 'success'))
+    # Check that puppet agent service has been stopped due to 'stop_service' parameter set to true
+    service = run_command('/opt/puppetlabs/bin/puppet resource service puppet', 'target')
+    output = service[0]['value']['stdout']
+    expect(output).to match(%r{ensure\s+=> 'stopped'})
 
-      # Check that puppet agent service has been stopped due to 'stop_service' parameter set to true
-      service = run_command('/opt/puppetlabs/bin/puppet resource service puppet', 'target')
-      output = service[0]['value']['stdout']
-      expect(output).to match(%r{ensure\s+=> 'stopped'})
+    # Check for idempotency
+    installed_versions = {}
+    results = run_task('puppet_agent::version', 'target', {})
+    results.each do |res|
+      expect(res).to include('status' => 'success')
+      installed_version = res['value']['version']
+      installed_versions[target_platform] = installed_version
+      expect(installed_version).to match(%r{^8\.\d+\.\d+})
+    end
 
-      # Check for puppet-agent version installed
-      results = run_task('puppet_agent::version', 'target', {})
-      results.each do |res|
-        expect(res).to include('status' => 'success')
-        expect(res['value']['version']).to match(%r{^8\.\d+\.\d+})
-      end
+    results = run_task('puppet_agent::install', 'target',
+      {
+        'collection' => 'puppetcore8-nightly',
+        'version'    => installed_versions[target_platform]
+      }.merge(latest_sources))
+
+    results.each do |res|
+      expect(res).to include('status' => 'success')
+      expect(res['value']['_output']).to match(%r{Puppet Agent #{installed_versions[target_platform]} detected. Nothing to do.})
+    end
+  end
+
+  # We don't have puppet9 builds for these
+  SKIP_PLATFORMS = Regexp.new(<<~END, Regexp::EXTENDED)
+    ^amazon-2-|
+    ^debian-10-|
+    ^el-7-|
+    ^fedora-36-|
+    ^fedora-40-|
+    ^redhatfips-7-|
+    ^sles-11-|
+    ^solaris-10-|
+    ^ubuntu-18.04-|
+    ^ubuntu-20.04-
+  END
+
+  it 'upgrades to puppetcore9-nightly' do
+    if target_platform.match?(SKIP_PLATFORMS)
+      logger.info("Platform #{target_platform} isn't supported in puppetcore9, skipping")
     else
-      # Specify the first released version for each target platform. When adding a new
-      # OS, you'll typically want to specify 'latest' to install from nightlies, since
-      # official packages won't be released until later. During the N+1 release, you'll
-      # want to change `target_platform` to be the first version (N) that added the OS.
-      puppet_7_version = case target_platform
-                         when %r{debian-11-amd64}
-                           '7.9.0'
-                         when %r{el-9-x86_64}
-                           '7.14.0'
-                         when %r{fedora-36}
-                           '7.19.0'
-                         when %r{osx-11}
-                           '7.7.0'
-                         when %r{osx-12}, %r{ubuntu-22.04-amd64}
-                           '7.18.0'
-                         when %r{osx-13}
-                           '7.26.0'
-                         when %r{el-9-aarch64}, %r{ubuntu-22.04-aarch64}
-                           '7.27.0'
-                         when %r{amazon-2023}, %r{osx-14}, %r{debian-11-aarch64}
-                           '7.28.0'
-                         when %r{debian-12}
-                           '7.29.0'
-                         when %r{el-9-ppc64le}, %r{amazon-2}, %r{fedora-40}
-                           '7.31.0'
-                         when %r{ubuntu-24.04}
-                           '7.32.1'
-                         else
-                           '7.18.0'
-                         end
-
-      puppet_7_collection = 'puppet7'
-
-      # We can only test puppet 7 -> 7 upgrades if multiple Puppet releases
-      # have supported a given platform.
-      multiple_puppet7_versions = true
-
-      # extra request is needed on windows hosts
-      # this will fail with "execution expired"
-      run_task('puppet_agent::version', 'target', {}) if target_platform.include?('win')
-
-      # Test the agent isn't already installed and that the version task works
-      results = run_task('puppet_agent::version', 'target', {})
-      results.each do |res|
-        expect(res).to include('status' => 'success')
-        expect(res['value']['version']).to eq(nil)
-      end
-
-      # Try to install an older puppet7 version
-      results = run_task('puppet_agent::install', 'target', { 'collection' => puppet_7_collection,
-                                                              'version' => puppet_7_version,
-                                                              'stop_service' => true })
-
+      results = run_task('puppet_agent::install', 'target',
+        {
+          'collection' => 'puppetcore9-nightly',
+          'version'    => 'latest',
+        }.merge(latest_sources))
       results.each do |result|
-        logger.info("Installed puppet-agent on #{result['target']}: #{result['status']}")
-        log_output_errors(result)
-      end
-
-      expect(results).to all(include('status' => 'success'))
-
-      # It installed a version older than latest puppet7
-      results = run_task('puppet_agent::version', 'target', {})
-      results.each do |res|
-        expect(res).to include('status' => 'success')
-        if puppet_7_version == 'latest'
-          expect(res['value']['version']).to match(%r{^7\.\d+\.\d+})
-        else
-          expect(res['value']['version']).to eq(puppet_7_version)
-        end
-        expect(res['value']['source']).to be
-        logger.info("Successfully installed puppet-agent version: #{res['value']['version']}")
-      end
-
-      # Check that puppet agent service has been stopped due to 'stop_service' parameter set to true
-      service = if target_platform.include?('win')
-                  run_command('c:/"program files"/"puppet labs"/puppet/bin/puppet resource service puppet', 'target')
-                else
-                  run_command('/opt/puppetlabs/bin/puppet resource service puppet', 'target')
-                end
-      output = service[0]['value']['stdout']
-      expect(output).to match(%r{ensure\s+=> 'stopped'})
-
-      # Try to upgrade with no specific version given in parameter
-      # Expect nothing to happen and receive a message regarding this
-      results = run_task('puppet_agent::install', 'target', { 'collection' => 'puppet8-nightly' }.merge(latest_sources))
-
-      results.each do |result|
-        logger.info("Ensuring installed puppet-agent on #{result['target']}: #{result['status']}")
-        log_output_errors(result)
-      end
-
-      results.each do |res|
-        expect(res).to include('status' => 'success')
-        expect(res['value']['_output']).to match(%r{Version parameter not defined and agent detected. Nothing to do.})
-      end
-
-      # Verify that the version didn't change
-      results = run_task('puppet_agent::version', 'target', {})
-      results.each do |res|
-        expect(res).to include('status' => 'success')
-        if puppet_7_version == 'latest'
-          expect(res['value']['version']).to match(%r{^7\.\d+\.\d+})
-        else
-          expect(res['value']['version']).to eq(puppet_7_version)
-        end
-        expect(res['value']['source']).to be
-      end
-
-      # An OS needs to be supported for more than one 7.x release to test the
-      # upgrade from puppet_7_version to latest
-      if multiple_puppet7_versions
-
-        # Upgrade to latest puppet7 version
-        results = run_task('puppet_agent::install', 'target', { 'collection' => 'puppet7', 'version' => 'latest' })
-
-        results.each do |result|
-          logger.info("Upgraded puppet-agent to latest puppet7 on #{result['target']}: #{result['status']}")
-          log_output_errors(result)
-        end
-
-        expect(results).to all(include('status' => 'success'))
-
-        # Verify that it upgraded
-        results = run_task('puppet_agent::version', 'target', {})
-        results.each do |res|
-          expect(res).to include('status' => 'success')
-          expect(res['value']['version']).not_to eq(puppet_7_version)
-          expect(res['value']['version']).to match(%r{^7\.\d+\.\d+})
-          expect(res['value']['source']).to be
-          logger.info("Successfully upgraded to puppet7 latest version: #{res['value']['version']}")
-        end
-      end
-
-      # Puppet Agent can't be upgraded on Windows nodes while 'puppet agent' service or 'pxp-agent' service are running
-      if target_platform.include?('win')
-        # Try to upgrade from puppet6 to puppet7 but fail due to puppet agent service already running
-        results = run_task('puppet_agent::install', 'target', { 'collection' => 'puppet7', 'version' => 'latest' })
-        results.each do |res|
-          expect(res).to include('status' => 'failure')
-          expect(res['value']['_error']['msg']).to match(%r{Puppet Agent upgrade cannot be done while Puppet services are still running.})
-        end
-
-        # Manually stop the puppet agent service
-        service = run_command('c:/"program files"/"puppet labs"/puppet/bin/puppet resource service puppet ensure=stopped', 'target')
-        output = service[0]['value']['stdout']
-        expect(output).to match(%r{ensure\s+=> 'stopped'})
-      end
-
-      # Succesfully upgrade from puppet7 to puppet8
-      results = run_task('puppet_agent::install', 'target', { 'collection' => 'puppet8-nightly',
-                                                              'version' => 'latest' }.merge(latest_sources))
-      results.each do |result|
-        logger.info("Upgraded puppet-agent to puppet8 on #{result['target']}: #{result['status']}")
+        logger.info("Upgraded puppet-agent to puppet9 on #{result['target']}: #{result['status']}")
         log_output_errors(result)
       end
 
@@ -258,19 +126,9 @@ describe 'install task' do
       results.each do |res|
         expect(res).to include('status' => 'success')
         installed_version = res['value']['version']
-        expect(installed_version).not_to match(%r{^7\.\d+\.\d+})
-        expect(installed_version).to match(%r{^8\.\d+\.\d+})
+        expect(installed_version).to match(%r{^(9\.\d+\.\d+|8\.99\.\d+)})
         expect(res['value']['source']).to be
-        logger.info("Successfully upgraded to puppet8 latest version: #{res['value']['version']}")
-      end
-
-      # Try installing the same version again
-      # Expect nothing to happen and receive a message regarding this
-      results = run_task('puppet_agent::install', 'target', { 'collection' => 'puppet8-nightly',
-                                                              'version' => installed_version }.merge(latest_sources))
-      results.each do |res|
-        expect(res).to include('status' => 'success')
-        expect(res['value']['_output']).to match(%r{Puppet Agent #{installed_version} detected. Nothing to do.})
+        logger.info("Successfully upgraded to puppet9 latest version: #{res['value']['version']}")
       end
     end
   end

--- a/task_spec/spec/acceptance/nodesets/docker/debian-13.yml
+++ b/task_spec/spec/acceptance/nodesets/docker/debian-13.yml
@@ -1,0 +1,13 @@
+HOSTS:
+  debian-13-x64:
+    roles:
+      - target
+    platform: debian-13-amd64
+    hypervisor: docker
+    image: debian:13
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - 'apt-get update && apt-get install -y net-tools wget locales strace lsof && echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && locale-gen'
+CONFIG:
+  trace_limit: 200

--- a/task_spec/spec/acceptance/nodesets/docker/sles-15.yml
+++ b/task_spec/spec/acceptance/nodesets/docker/sles-15.yml
@@ -1,0 +1,14 @@
+HOSTS:
+  sles-15-x64:
+    roles:
+      - target
+    platform: sles-15-x86_64
+    hypervisor: docker
+    image: registry.suse.com/suse/sle15:15.6
+    docker_preserve_image: true
+    docker_cmd: '["/bin/sh", "-c", "/usr/sbin/sshd && tail -f /dev/null"]'
+    # install various tools required to get the image up to usable levels
+    docker_image_commands:
+      - 'zypper install -y tar wget openssl iproute2 which'
+CONFIG:
+  trace_limit: 200

--- a/task_spec/spec/acceptance/nodesets/docker/ubuntu-24.04.yml
+++ b/task_spec/spec/acceptance/nodesets/docker/ubuntu-24.04.yml
@@ -1,0 +1,11 @@
+HOSTS:
+  ubuntu-2404-x64:
+    roles:
+      - target
+    platform: ubuntu-24.04-amd64
+    hypervisor: docker
+    image: ubuntu:24.04
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+CONFIG:
+  trace_limit: 200

--- a/tasks/install.json
+++ b/tasks/install.json
@@ -7,7 +7,7 @@
     },
     "collection": {
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
-      "type": "Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly, puppetcore7, puppetcore8, puppetcore8-nightly]]"
+      "type": "Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly, puppetcore7, puppetcore8, puppetcore8-nightly, puppetcore9-nightly]]"
     },
     "absolute_source": {
       "description": "The absolute source location to find the Puppet agent package",

--- a/tasks/install_powershell.json
+++ b/tasks/install_powershell.json
@@ -8,7 +8,7 @@
     },
     "collection": {
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
-      "type": "Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly, puppetcore7, puppetcore8, puppetcore8-nightly]]"
+      "type": "Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly, puppetcore7, puppetcore8, puppetcore8-nightly, puppetcore9-nightly]]"
     },
     "absolute_source": {
       "description": "The absolute source location to find the Puppet agent package",

--- a/tasks/install_shell.json
+++ b/tasks/install_shell.json
@@ -9,7 +9,7 @@
     },
     "collection": {
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
-      "type": "Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly, puppetcore7, puppetcore8, puppetcore8-nightly]]"
+      "type": "Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly, puppetcore7, puppetcore8, puppetcore8-nightly, puppetcore9-nightly]]"
     },
     "absolute_source": {
       "description": "The absolute source location to find the Puppet agent package",

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -620,7 +620,8 @@ install_file() {
       if test "x$installed_version" != "xuninstalled"; then
         info "Version ${installed_version} detected..."
         major=$(echo $installed_version | cut -d. -f1)
-        pkg="puppet${major}-release"
+        pkg=$(rpm -qa --qf '%{NAME}\n' | grep "^puppet${major}.*-release$" | head -1)
+        [ -z "$pkg" ] && pkg="puppet${major}-release"
 
         if echo $2 | grep $pkg; then
           info "No collection upgrade detected"
@@ -653,7 +654,8 @@ install_file() {
       if test "x$installed_version" != "xuninstalled"; then
         info "Version ${installed_version} detected..."
         major=$(echo $installed_version | cut -d. -f1)
-        pkg="puppet${major}-release"
+        pkg=$(rpm -qa --qf '%{NAME}\n' | grep "^puppet${major}.*-release$" | head -1)
+        [ -z "$pkg" ] && pkg="puppet${major}-release"
 
         if echo $2 | grep $pkg; then
           info "No collection upgrade detected"
@@ -684,7 +686,8 @@ install_file() {
       if test "x$installed_version" != "xuninstalled"; then
         info "Version ${installed_version} detected..."
         major=$(echo $installed_version | cut -d. -f1)
-        pkg="puppet${major}-release"
+        pkg=$(dpkg-query -W -f='${Package}\n' 2>/dev/null | grep "^puppet${major}.*-release$" | head -1)
+        [ -z "$pkg" ] && pkg="puppet${major}-release"
 
         if echo $2 | grep $pkg; then
           info "No collection upgrade detected"

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -45,6 +45,7 @@ assert_unmodified_apt_config() {
   puppet_list=/etc/apt/sources.list.d/puppet.list
   puppet7_list=/etc/apt/sources.list.d/puppet7.list
   puppet8_list=/etc/apt/sources.list.d/puppet8.list
+  puppet9_list=/etc/apt/sources.list.d/puppet9.list
 
   if [[ -f $puppet_list ]]; then
     list_file=puppet_list
@@ -52,6 +53,8 @@ assert_unmodified_apt_config() {
     list_file=puppet7_list
   elif [[ -f $puppet8_list ]]; then
     list_file=puppet8_list
+  elif [[ -f $puppet9_list ]]; then
+    list_file=puppet9_list
   fi
 
   # If puppet.list exists, get its md5sum on disk and its md5sum from the puppet-release package


### PR DESCRIPTION
Added puppetcore9-nightly collection to metadata

Erase/purge puppetN-nightly-release package when upgrading to puppetN+1 release packages.

Rewrote beaker test for the install task so it's more maintainable.

Ran pdk update using 3.6.1. The pdk templates are still at 3.5.1 and will be updated in a different ticket PA-7897

Added docker nodesets for debian-13, sles-15 and ubuntu-24.04

Tested on `amazon`, `rocky`, `sles`, `ubuntu` and `debian` using docker, for example

```
$ docker/bin/install.sh rocky 8.99.99.47.g513c12f01 puppetcore9-nightly
...
17:53:01 +0000 INFO: Version parameter defined: 8.99.99.47.g513c12f01
17:53:01 +0000 INFO: Downloading Puppet 8.99.99.47.g513c12f01 for el...
17:53:01 +0000 INFO: Red hat like platform! Lets get you an RPM...
17:53:01 +0000 INFO: Downloading https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/yum/puppet9-nightly-release-el-9.noarch.rpm
17:53:01 +0000 INFO:   to file /tmp/install.sh.8.34924/puppet9-nightly-release-el-9.noarch.rpm
17:53:01 +0000 INFO: Trying curl...
17:53:01 +0000 INFO: installing puppetlabs yum repo with rpm...
warning: /tmp/install.sh.8.34924/puppet9-nightly-release-el-9.noarch.rpm: Header V4 RSA/SHA512 Signature, key ID 9e61ef26: NOKEY
Verifying...                          ################################# [100%]
Preparing...                          ################################# [100%]
Updating / installing...
   1:puppet9-nightly-release-3.0.0-5.e################################# [100%]
Puppet 9 Nightly Repository el 9 - x86_64       7.3 MB/s | 935 kB     00:00    
Rocky Linux 9 - BaseOS                           13 MB/s |  19 MB     00:01    
Rocky Linux 9 - AppStream                       6.0 MB/s |  18 MB     00:03    
Rocky Linux 9 - Extras                           43 kB/s |  17 kB     00:00    
Dependencies resolved.
================================================================================
 Package               Arch   Version                     Repository       Size
================================================================================
Installing:
 puppet-agent          x86_64 8.99.99.47.g513c12f01-1.el9 puppet9-nightly  31 M
Upgrading:
 openssl               x86_64 1:3.5.1-7.el9_7             baseos          1.4 M
 openssl-libs          x86_64 1:3.5.1-7.el9_7             baseos          2.3 M
 systemd-libs          x86_64 252-55.el9_7.8.rocky.0.1    baseos          653 k
Installing dependencies:
 acl                   x86_64 2.3.1-4.el9                 baseos           69 k
 dbus                  x86_64 1:1.12.20-8.el9             baseos          6.8 k
 dbus-broker           x86_64 28-7.el9                    baseos          171 k
 dbus-common           noarch 1:1.12.20-8.el9             baseos           14 k
 kmod-libs             x86_64 28-11.el9                   baseos           62 k
 libseccomp            x86_64 2.5.2-2.el9                 baseos           71 k
 openssl-fips-provider x86_64 1:3.5.1-7.el9_7             baseos          812 k
 systemd               x86_64 252-55.el9_7.8.rocky.0.1    baseos          4.0 M
 systemd-pam           x86_64 252-55.el9_7.8.rocky.0.1    baseos          260 k
 systemd-rpm-macros    noarch 252-55.el9_7.8.rocky.0.1    baseos           48 k

Transaction Summary
================================================================================
Install  11 Packages
Upgrade   3 Packages

Total download size: 41 M
Downloading Packages:
(1/14): dbus-1.12.20-8.el9.x86_64.rpm            37 kB/s | 6.8 kB     00:00    
(2/14): acl-2.3.1-4.el9.x86_64.rpm              219 kB/s |  69 kB     00:00    
(3/14): dbus-common-1.12.20-8.el9.noarch.rpm     90 kB/s |  14 kB     00:00    
(4/14): dbus-broker-28-7.el9.x86_64.rpm         487 kB/s | 171 kB     00:00    
(5/14): kmod-libs-28-11.el9.x86_64.rpm          215 kB/s |  62 kB     00:00    
(6/14): libseccomp-2.5.2-2.el9.x86_64.rpm       231 kB/s |  71 kB     00:00    
(7/14): openssl-fips-provider-3.5.1-7.el9_7.x86 1.6 MB/s | 812 kB     00:00    
(8/14): puppet-agent-8.99.99.47.g513c12f01-1.el  21 MB/s |  31 MB     00:01    
(9/14): systemd-pam-252-55.el9_7.8.rocky.0.1.x8 631 kB/s | 260 kB     00:00    
(10/14): systemd-rpm-macros-252-55.el9_7.8.rock 178 kB/s |  48 kB     00:00    
(11/14): systemd-252-55.el9_7.8.rocky.0.1.x86_6 4.3 MB/s | 4.0 MB     00:00    
(12/14): systemd-libs-252-55.el9_7.8.rocky.0.1. 1.3 MB/s | 653 kB     00:00    
(13/14): openssl-3.5.1-7.el9_7.x86_64.rpm       2.3 MB/s | 1.4 MB     00:00    
(14/14): openssl-libs-3.5.1-7.el9_7.x86_64.rpm  3.0 MB/s | 2.3 MB     00:00    
--------------------------------------------------------------------------------
Total                                            16 MB/s |  41 MB     00:02     
Puppet 9 Nightly Repository el 9 - x86_64       3.0 MB/s | 3.1 kB     00:00    
Importing GPG key 0x9E61EF26:
 Userid     : "Puppet, Inc. Release Key (Puppet, Inc. Release Key) <release@puppet.com>"
 Fingerprint: D681 1ED3 ADEE B844 1AF5 AA8F 4528 B6CD 9E61 EF26
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-puppet9-nightly-release
Key imported successfully
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                        1/1 
  Upgrading        : openssl-libs-1:3.5.1-7.el9_7.x86_64                   1/17 
  Installing       : openssl-fips-provider-1:3.5.1-7.el9_7.x86_64          2/17 
  Upgrading        : systemd-libs-252-55.el9_7.8.rocky.0.1.x86_64          3/17 
  Running scriptlet: systemd-libs-252-55.el9_7.8.rocky.0.1.x86_64          3/17 
  Installing       : kmod-libs-28-11.el9.x86_64                            4/17 
  Installing       : systemd-rpm-macros-252-55.el9_7.8.rocky.0.1.noarch    5/17 
  Installing       : libseccomp-2.5.2-2.el9.x86_64                         6/17 
  Installing       : acl-2.3.1-4.el9.x86_64                                7/17 
  Installing       : dbus-1:1.12.20-8.el9.x86_64                           8/17 
  Installing       : systemd-pam-252-55.el9_7.8.rocky.0.1.x86_64           9/17 
  Running scriptlet: systemd-252-55.el9_7.8.rocky.0.1.x86_64              10/17 
  Installing       : systemd-252-55.el9_7.8.rocky.0.1.x86_64              10/17 
  Running scriptlet: systemd-252-55.el9_7.8.rocky.0.1.x86_64              10/17 
  Installing       : dbus-common-1:1.12.20-8.el9.noarch                   11/17 
  Running scriptlet: dbus-common-1:1.12.20-8.el9.noarch                   11/17 
Created symlink /etc/systemd/system/sockets.target.wants/dbus.socket → /usr/lib/systemd/system/dbus.socket.
Created symlink /etc/systemd/user/sockets.target.wants/dbus.socket → /usr/lib/systemd/user/dbus.socket.

  Running scriptlet: dbus-broker-28-7.el9.x86_64                          12/17 
  Installing       : dbus-broker-28-7.el9.x86_64                          12/17 
  Running scriptlet: dbus-broker-28-7.el9.x86_64                          12/17 
Created symlink /etc/systemd/system/dbus.service → /usr/lib/systemd/system/dbus-broker.service.
Created symlink /etc/systemd/user/dbus.service → /usr/lib/systemd/user/dbus-broker.service.

  Running scriptlet: puppet-agent-8.99.99.47.g513c12f01-1.el9.x86_64      13/17 
  Installing       : puppet-agent-8.99.99.47.g513c12f01-1.el9.x86_64      13/17 
  Running scriptlet: puppet-agent-8.99.99.47.g513c12f01-1.el9.x86_64      13/17 
  Upgrading        : openssl-1:3.5.1-7.el9_7.x86_64                       14/17 
  Cleanup          : openssl-1:3.2.2-6.el9_5.x86_64                       15/17 
  Cleanup          : systemd-libs-252-46.el9_5.2.0.1.x86_64               16/17 
  Cleanup          : openssl-libs-1:3.2.2-6.el9_5.x86_64                  17/17 
  Running scriptlet: puppet-agent-8.99.99.47.g513c12f01-1.el9.x86_64      17/17 
  Running scriptlet: openssl-libs-1:3.2.2-6.el9_5.x86_64                  17/17 
  Verifying        : puppet-agent-8.99.99.47.g513c12f01-1.el9.x86_64       1/17 
  Verifying        : acl-2.3.1-4.el9.x86_64                                2/17 
  Verifying        : dbus-1:1.12.20-8.el9.x86_64                           3/17 
  Verifying        : dbus-broker-28-7.el9.x86_64                           4/17 
  Verifying        : dbus-common-1:1.12.20-8.el9.noarch                    5/17 
  Verifying        : kmod-libs-28-11.el9.x86_64                            6/17 
  Verifying        : libseccomp-2.5.2-2.el9.x86_64                         7/17 
  Verifying        : openssl-fips-provider-1:3.5.1-7.el9_7.x86_64          8/17 
  Verifying        : systemd-252-55.el9_7.8.rocky.0.1.x86_64               9/17 
  Verifying        : systemd-pam-252-55.el9_7.8.rocky.0.1.x86_64          10/17 
  Verifying        : systemd-rpm-macros-252-55.el9_7.8.rocky.0.1.noarch   11/17 
  Verifying        : openssl-1:3.5.1-7.el9_7.x86_64                       12/17 
  Verifying        : openssl-1:3.2.2-6.el9_5.x86_64                       13/17 
  Verifying        : openssl-libs-1:3.5.1-7.el9_7.x86_64                  14/17 
  Verifying        : openssl-libs-1:3.2.2-6.el9_5.x86_64                  15/17 
  Verifying        : systemd-libs-252-55.el9_7.8.rocky.0.1.x86_64         16/17 
  Verifying        : systemd-libs-252-46.el9_5.2.0.1.x86_64               17/17 

Upgraded:
  openssl-1:3.5.1-7.el9_7.x86_64                                                
  openssl-libs-1:3.5.1-7.el9_7.x86_64                                           
  systemd-libs-252-55.el9_7.8.rocky.0.1.x86_64                                  
Installed:
  acl-2.3.1-4.el9.x86_64                                                        
  dbus-1:1.12.20-8.el9.x86_64                                                   
  dbus-broker-28-7.el9.x86_64                                                   
  dbus-common-1:1.12.20-8.el9.noarch                                            
  kmod-libs-28-11.el9.x86_64                                                    
  libseccomp-2.5.2-2.el9.x86_64                                                 
  openssl-fips-provider-1:3.5.1-7.el9_7.x86_64                                  
  puppet-agent-8.99.99.47.g513c12f01-1.el9.x86_64                               
  systemd-252-55.el9_7.8.rocky.0.1.x86_64                                       
  systemd-pam-252-55.el9_7.8.rocky.0.1.x86_64                                   
  systemd-rpm-macros-252-55.el9_7.8.rocky.0.1.noarch                            

Complete!
puppet 9.0.0
facter 4.19.0
Notice: Scope(Class[main]): puppet apply
Notice: Compiled catalog for 8ee95ab989e8 in environment production in 0.01 seconds
Notice: Applied catalog in 0.01 seconds
```

Tested on mac using bolt
```
/opt/puppetlabs/bolt/bin/bolt task --modulepath ~/work/modules.install run puppet_agent::install --no-host-key-check --targets pert-woodsmoke.delivery.puppetlabs.net collection=puppetcore9-nightly 
```

And same for windows:

```
/opt/puppetlabs/bolt/bin/bolt task --modulepath ~/work/modules.install run puppet_agent::install --stream --no-ssl-verify --targets winrm://standby-duke.delivery.puppetlabs.net collection=puppetcore9-nightly
```