### PR TITLE
(PA-8247) Add guard against other ruby process when installing

### DIFF
--- a/files/install_puppet.ps1
+++ b/files/install_puppet.ps1
@@ -320,6 +320,30 @@ try {
     $msi_arguments += " PUPPET_AGENT_STARTUP_MODE=`"$PuppetStartType`""
   }
   $msi_arguments += " $InstallArgs"
+
+  # Check & wait for other ruby process to end 
+  # This ensures no other ruby.exe processes are running before installing
+  if ($InstallDir) {
+    $escapedInstallDir = $InstallDir -replace '\\', '\\'
+  }
+  if (Test-Path "$escapedInstallDir\puppet\bin\ruby.exe") { # The first time an upgrade is run with InstallDir, ruby.exe will not yet exist there yet
+    $other_ruby_process_id = Get-CimInstance Win32_Process -Filter "Name='ruby.exe' AND ExecutablePath LIKE '$escapedInstallDir\\puppet\\bin\\ruby.exe'" | Select-Object -First 1 -ExpandProperty ProcessID
+  } else {
+    $other_ruby_process_id = Get-CimInstance Win32_Process -Filter "Name='ruby.exe' AND ExecutablePath LIKE 'C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin\\ruby.exe%'" | Select-Object -First 1 -ExpandProperty ProcessID
+  }
+  if ($other_ruby_process_id) {
+    Write-Log "Waiting for other ruby process to stop, PID: $other_ruby_process_id" $Logfile
+    $ruby_process = Get-Process -ID $other_ruby_process_id -ErrorAction SilentlyContinue
+    if ($ruby_process) {
+      if (!$ruby_process.WaitForExit($WaitForPuppetRun)){
+        Write-Log "ERROR: Timed out waiting for ruby!" $Logfile
+        throw
+      }
+    } else {
+      Write-Log "Ruby already finished" $Logfile
+    }
+  }
+
   Write-Log "Beginning MSI installation with Arguments: $msi_arguments" $Logfile
   Write-Log "****************************** Begin msiexec.exe output ******************************" $Logfile
   $startInfo = New-Object System.Diagnostics.ProcessStartInfo('msiexec.exe', $msi_arguments)


### PR DESCRIPTION
Previously, when installing puppet on Windows, if there is another already running ruby.exe process running during the install, it would fail with an `msiexec 1603` error:

	Error: Failed previous installation with: ScriptHalted MSI (s)
        (60:6C) [22:12:51:748]: Product: Puppet Agent (64-bit) -- Error
        1306. Another application has exclusive access to the file
        'C:\Program Files\Puppet Labs\Puppet\puppet\bin\ruby.exe'.
        Please shut down all other applications, then click Retry.
        ...
        ERROR: msiexec.exe installation failed!!! Return code 1603

This commit updates files/install_puppet.ps1 to guard against other ruby processes by waiting for it to finish before trying to install puppet. It will wait however long `$WaitForPuppetRun` is before erroring.