### PR TITLE
(PA-8041) Fix puppetcore8-nightly installs on rpm and mac

### DIFF
--- a/docker/bin/helpers/run-install.sh
+++ b/docker/bin/helpers/run-install.sh
@@ -27,6 +27,7 @@ fi
 export PT__installdir=../
 export PT_version=${to_version}
 export PT_collection=${to_collection}
+export PT_username=${PUPPET_FORGE_USERNAME}
 export PT_password=${PUPPET_FORGE_TOKEN}
 chmod u+x tasks/install_shell.sh
 tasks/install_shell.sh

--- a/docker/bin/install.sh
+++ b/docker/bin/install.sh
@@ -72,6 +72,6 @@ do
     # Add "--progress plain" for complete build output
     docker build --rm -f "${dockerfile}" . -t pa-dev:$platform.install \
            --build-arg BASE_IMAGE="${base_image}"
-    docker run -e PUPPET_FORGE_TOKEN --rm -ti pa-dev:$platform.install "${version}" "${collection}"
+    docker run -e PUPPET_FORGE_USERNAME -e PUPPET_FORGE_TOKEN --rm -ti pa-dev:$platform.install "${version}" "${collection}"
 done
 echo Complete

--- a/docker/bin/install.sh
+++ b/docker/bin/install.sh
@@ -19,15 +19,16 @@
 #          Default: 8.1.0
 set -e
 
-if [[ -z "${PUPPET_FORGE_TOKEN}" ]]; then
-    echo "$0: Environment variable PUPPET_FORGE_TOKEN must be set"
-    exit 1
-fi
-
 cd "$(dirname "$0")/../.."
 platforms=${1:-rocky}
 version=${2:-8.11.0}
 collection=${3:-puppetcore8}
+
+if [[ -z "${PUPPET_FORGE_TOKEN}" && "$collection" != puppetcore*-nightly && "$collection" =~ core ]]; then
+    echo "$0: Environment variable PUPPET_FORGE_TOKEN must be set"
+    exit 1
+fi
+
 for platform in ${platforms//,/ }
 do
     case $platform in

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -628,7 +628,7 @@ install_file() {
 
       repo="/etc/yum.repos.d/${collection/core/}-release.repo"
       rpm -Uvh --oldpackage --replacepkgs "$2"
-      if [[ "$collection" =~ core ]]; then
+      if [[ "$collection" != puppetcore*-nightly && "$collection" =~ core ]]; then
         if [[ -n $username ]]; then
           sed -i "s/^#\?username=.*/username=${username}/" "${repo}"
         fi
@@ -660,7 +660,7 @@ install_file() {
       fi
 
       run_cmd "zypper install --no-confirm '$2'"
-      if [[ "$collection" =~ core ]]; then
+      if [[ "$collection" != puppetcore*-nightly && "$collection" =~ core ]]; then
         if [[ -n $username ]]; then
           sed -i "s/^username=.*/username=${username}/" "/etc/zypp/credentials.d/PuppetcoreCreds"
         fi

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -841,7 +841,7 @@ case $platform in
     if [[ $(uname -p) == "arm" ]]; then
         arch="arm64"
     fi
-    if [[ "$collection" =~ "puppetcore" ]]; then
+    if [[ "$collection" != puppetcore*-nightly && "$collection" =~ core ]]; then
       if [[ -z "$version" ]]; then
         critical "You must provide a version to install the agent from puppetcore on MacOS/Windows."
         exit 1
@@ -853,7 +853,7 @@ case $platform in
         download_url="${mac_source}?type=native&version=${version}&os_name=osx&os_version=${platform_version}&os_arch=${arch}"
       fi
     else
-      download_url="${mac_source}/mac/${collection}/${platform_version}/${arch}/${filename}"
+      download_url="${mac_source}/mac/${collection/core/}/${platform_version}/${arch}/${filename}"
     fi
     ;;
   *)


### PR DESCRIPTION
nightly builds were failing to install on rpm/zypper and mac when using `collection => puppetcore*-nightly`, see the first two commits. This wasn't a problem in CI, because it's still using the `puppet8-nightly` collection ([here](https://github.com/puppetlabs/puppetlabs-puppet_agent/blob/278235a1c1139ed67e5f3934d6a8ee9546495ae8/task_spec/spec/acceptance/init_spec.rb#L74), [here](https://github.com/puppetlabs/puppetlabs-puppet_agent/blob/278235a1c1139ed67e5f3934d6a8ee9546495ae8/task_spec/spec/acceptance/init_spec.rb#L182), [here](https://github.com/puppetlabs/puppetlabs-puppet_agent/blob/278235a1c1139ed67e5f3934d6a8ee9546495ae8/task_spec/spec/acceptance/init_spec.rb#L246), [here](https://github.com/puppetlabs/puppetlabs-puppet_agent/blob/278235a1c1139ed67e5f3934d6a8ee9546495ae8/task_spec/spec/acceptance/init_spec.rb#L269)) but overriding [`yum_source`](https://github.com/puppetlabs/puppetlabs-puppet_agent/blob/278235a1c1139ed67e5f3934d6a8ee9546495ae8/task_spec/spec/acceptance/init_spec.rb#L60)

In a future ticket we should remove the non-core nightly collections, as the host was shutdown.

The next two commits fix `docker/bin/install.sh` when testing installs (not using beaker).

```
❯ docker/bin/install.sh sles 8.18.0.5.g99b09ffab puppetcore8-nightly                                                                               
...
18:36:08 +0000 INFO: Version parameter defined: 8.18.0.5.g99b09ffab
18:36:08 +0000 INFO: Downloading Puppet 8.18.0.5.g99b09ffab for SLES...
18:36:08 +0000 INFO: SLES platform! Lets get you an RPM...
18:36:08 +0000 INFO: Downloading https://yum-puppetcore.puppet.com/public/RPM-GPG-KEY-puppet
18:36:08 +0000 INFO:   to file /tmp/install.sh.8.6126/RPM-GPG-KEY-puppet
18:36:08 +0000 INFO: Trying wget...
warning: Rebuilding outdated index databases
warning: Generating 18 missing index(es), please wait...
18:36:08 +0000 INFO: Downloading https://artifactory.delivery.puppetlabs.net:443/artifactory/internal_nightly__local/yum/puppet8-nightly-release-sles-15.noarch.rpm
18:36:08 +0000 INFO:   to file /tmp/install.sh.8.6126/puppet8-nightly-release-sles-15.noarch.rpm
18:36:08 +0000 INFO: Trying wget...
18:36:08 +0000 INFO: installing puppetlabs yum repo with zypper...
...
(1/1) Installing: puppet8-nightly-release-3.0.0-4.sles15.noarch
...
Retrieving: puppet-agent-8.18.0.5.g99b09ffab-1.sles15.x86_64 (Puppet 8 Nightly Repository sles 15 - x86_64)                                                                                                                                                 (19/19),  23.3 MiB    
Retrieving: puppet-agent-8.18.0.5.g99b09ffab-1.sles15.x86_64.rpm
...
(19/19) Installing: puppet-agent-8.18.0.5.g99b09ffab-1.sles15.x86_64 ...
puppet 8.19.0
facter 4.19.0
```