### PR TITLE
(PA-7897) Update to pdk-templates 3.6.1.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,10 @@
 ---
-require:
+plugins:
 - rubocop-performance
 - rubocop-rspec
+- rubocop-rspec_rails
+- rubocop-factory_bot
+- rubocop-capybara
 AllCops:
   NewCops: enable
   DisplayCopNames: true
@@ -75,6 +78,8 @@ RSpec/NamedSubject:
   Enabled: false
 RSpec/SubjectStub:
   Enabled: false
+Style/FileNull:
+  Enabled: false
 RSpec/MessageSpies:
   EnforcedStyle: receive
 Style/Documentation:
@@ -122,6 +127,12 @@ Bundler/InsecureProtocolSource:
 Capybara/CurrentPathExpectation:
   Enabled: false
 Capybara/VisibilityMatcher:
+  Enabled: false
+FactoryBot/AttributeDefinedStatically:
+  Enabled: false
+FactoryBot/CreateList:
+  Enabled: false
+FactoryBot/FactoryClassName:
   Enabled: false
 Gemspec/DuplicatedAssignment:
   Enabled: false
@@ -297,8 +308,6 @@ Performance/UriDefaultParser:
   Enabled: false
 RSpec/Be:
   Enabled: false
-RSpec/Capybara/FeatureMethods:
-  Enabled: false
 RSpec/ContainExactly:
   Enabled: false
 RSpec/ContextMethod:
@@ -306,6 +315,8 @@ RSpec/ContextMethod:
 RSpec/ContextWording:
   Enabled: false
 RSpec/DescribeClass:
+  Enabled: false
+RSpec/Dialect:
   Enabled: false
 RSpec/EmptyHook:
   Enabled: false
@@ -322,12 +333,6 @@ RSpec/ExampleWithoutDescription:
 RSpec/ExpectChange:
   Enabled: false
 RSpec/ExpectInHook:
-  Enabled: false
-RSpec/FactoryBot/AttributeDefinedStatically:
-  Enabled: false
-RSpec/FactoryBot/CreateList:
-  Enabled: false
-RSpec/FactoryBot/FactoryClassName:
   Enabled: false
 RSpec/HooksBeforeExamples:
   Enabled: false
@@ -503,6 +508,12 @@ Capybara/SpecificFinders:
   Enabled: false
 Capybara/SpecificMatcher:
   Enabled: false
+FactoryBot/ConsistentParenthesesStyle:
+  Enabled: false
+FactoryBot/FactoryNameStyle:
+  Enabled: false
+FactoryBot/SyntaxMethods:
+  Enabled: false
 Gemspec/DeprecatedAttributeAssignment:
   Enabled: false
 Gemspec/DevelopmentDependencies:
@@ -603,27 +614,11 @@ RSpec/DuplicatedMetadata:
   Enabled: false
 RSpec/ExcessiveDocstringSpacing:
   Enabled: false
-RSpec/FactoryBot/ConsistentParenthesesStyle:
-  Enabled: false
-RSpec/FactoryBot/FactoryNameStyle:
-  Enabled: false
-RSpec/FactoryBot/SyntaxMethods:
-  Enabled: false
 RSpec/IdenticalEqualityAssertion:
   Enabled: false
 RSpec/NoExpectationExample:
   Enabled: false
 RSpec/PendingWithoutReason:
-  Enabled: false
-RSpec/Rails/AvoidSetupHook:
-  Enabled: false
-RSpec/Rails/HaveHttpStatus:
-  Enabled: false
-RSpec/Rails/InferredSpecType:
-  Enabled: false
-RSpec/Rails/MinitestAssertions:
-  Enabled: false
-RSpec/Rails/TravelAround:
   Enabled: false
 RSpec/RedundantAround:
   Enabled: false
@@ -634,6 +629,16 @@ RSpec/SortMetadata:
 RSpec/SubjectDeclaration:
   Enabled: false
 RSpec/VerifiedDoubleReference:
+  Enabled: false
+RSpecRails/AvoidSetupHook:
+  Enabled: false
+RSpecRails/HaveHttpStatus:
+  Enabled: false
+RSpecRails/InferredSpecType:
+  Enabled: false
+RSpecRails/MinitestAssertions:
+  Enabled: false
+RSpecRails/TravelAround:
   Enabled: false
 Security/CompoundHash:
   Enabled: false

--- a/.sync.yml
+++ b/.sync.yml
@@ -50,8 +50,6 @@ Gemfile:
   unmanaged: false
 .github/workflows/release_prep.yml:
   unmanaged: false
-spec/default_facts.yml:
-  delete: true
 spec/spec_helper.rb:
   unmanaged: true
 # puppet_url_without modules check in puppet-lint assumes any puppet:/// URL is

--- a/.sync.yml
+++ b/.sync.yml
@@ -9,6 +9,8 @@
       Enabled: false
     Style/ClassAndModuleChildren:
       Enabled: false
+    Style/FileNull:
+      Enabled: false
 Gemfile:
   optional:
     ":development":
@@ -29,16 +31,8 @@ Gemfile:
       - gem: beaker-module_install_helper
       - gem: beaker-puppet_install_helper
       - gem: nokogiri
-      - gem: 'bolt'
-        version: '~> 3.0'
-        condition: 'ENV["GEM_BOLT"]'
       - gem: 'beaker-task_helper'
         version: '~> 1.9'
-        condition: 'ENV["GEM_BOLT"]'
-      # The Faraday requirements in orchestrator_client 0.7.1 causes Bundler to
-      # resolve the dependency in unexpected ways and causes issues in CI
-      - gem: 'orchestrator_client'
-        version: '< 0.7.1'
         condition: 'ENV["GEM_BOLT"]'
     ":system_tests":
       - gem: voxpupuli-acceptance

--- a/Gemfile
+++ b/Gemfile
@@ -52,9 +52,13 @@ group :development do
   gem "pry", '~> 0.10',                                                                      require: false
   gem "simplecov-console", '~> 0.9',                                                         require: false
   gem "puppet-debugger", '~> 1.6',                                                           require: false
-  gem "rubocop", '~> 1.50.0',                                                                require: false
-  gem "rubocop-performance", '= 1.16.0',                                                     require: false
-  gem "rubocop-rspec", '= 2.19.0',                                                           require: false
+  gem "rubocop", '~> 1.73.0',                                                                require: false
+  gem "rubocop-performance", '~> 1.24.0',                                                    require: false
+  gem "rubocop-rspec", '~> 3.5.0',                                                           require: false
+  gem "rubocop-rspec_rails", '~> 2.31.0',                                                    require: false
+  gem "rubocop-factory_bot", '~> 2.27.0',                                                    require: false
+  gem "rubocop-capybara", '~> 2.22.0',                                                       require: false
+  gem "rubocop-ast", '< 1.43.0',                                                             require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "rb-readline", '= 0.5.5',                                                              require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "bigdecimal", '< 3.2.2',                                                               require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 6.0')
@@ -65,9 +69,7 @@ group :development do
   gem "beaker-module_install_helper",                                                        require: false
   gem "beaker-puppet_install_helper",                                                        require: false
   gem "nokogiri",                                                                            require: false
-  gem "bolt", '~> 3.0',                                                                      require: false if ENV["GEM_BOLT"]
   gem "beaker-task_helper", '~> 1.9',                                                        require: false if ENV["GEM_BOLT"]
-  gem "orchestrator_client", '< 0.7.1',                                                      require: false if ENV["GEM_BOLT"]
 end
 group :development, :release_prep do
   gem "puppet-strings", '~> 4.0',         require: false
@@ -76,17 +78,19 @@ group :development, :release_prep do
 end
 group :system_tests do
   gem "puppet_litmus", '~> 2.0',             require: false, platforms: [:ruby, :x64_mingw] if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gem "puppet_litmus", '~> 1.0',             require: false, platforms: [:ruby, :x64_mingw] if ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
+  gem "puppet_litmus", '~> 1.0', '!= 1.6.1', require: false, platforms: [:ruby, :x64_mingw] if ENV["PUPPET_FORGE_TOKEN"].to_s.empty?
   gem "CFPropertyList", '< 3.0.7',           require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "serverspec", '~> 2.41',               require: false
   gem "voxpupuli-acceptance", '~> 3',        require: false
 end
 
 gems = {}
+bolt_version = ENV.fetch('BOLT_GEM_VERSION', nil)
 puppet_version = ENV.fetch('PUPPET_GEM_VERSION', nil)
 facter_version = ENV.fetch('FACTER_GEM_VERSION', nil)
 hiera_version = ENV.fetch('HIERA_GEM_VERSION', nil)
 
+gems['bolt'] = location_for(bolt_version, nil, { source: gemsource_puppetcore })
 gems['puppet'] = location_for(puppet_version, nil, { source: gemsource_puppetcore })
 gems['facter'] = location_for(facter_version, nil, { source: gemsource_puppetcore })
 gems['hiera'] = location_for(hiera_version, nil, {}) if hiera_version

--- a/lib/facter/env_temp_variable.rb
+++ b/lib/facter/env_temp_variable.rb
@@ -2,6 +2,6 @@ require 'tmpdir'
 
 Facter.add(:env_temp_variable) do
   setcode do
-    (ENV['TEMP'] || Dir.tmpdir)
+    ENV['TEMP'] || Dir.tmpdir
   end
 end

--- a/metadata.json
+++ b/metadata.json
@@ -83,6 +83,6 @@
     }
   ],
   "pdk-version": "3.6.1",
-  "template-url": "https://github.com/puppetlabs/pdk-templates#3.5.1",
-  "template-ref": "tags/3.5.1-0-g9d5b193"
+  "template-url": "https://github.com/puppetlabs/pdk-templates#3.6.1.1",
+  "template-ref": "tags/3.6.1.1-0-g5fe78cc"
 }

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -1,0 +1,9 @@
+# Use default_module_facts.yml for module specific facts.
+#
+# Facts specified here will override the values provided by rspec-puppet-facts.
+---
+networking:
+  ip: "172.16.254.254"
+  ip6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
+  mac: "AA:AA:AA:AA:AA:AA"
+is_pe: false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ default_fact_files.each do |f|
 
   begin
     require 'deep_merge'
-    default_facts.deep_merge!(YAML.safe_load(File.read(f), permitted_classes: [], permitted_symbols: [], aliases: true))
+    default_facts.deep_merge!(YAML.safe_load_file(f, permitted_classes: [], permitted_symbols: [], aliases: true))
   rescue StandardError => e
     RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
   end


### PR DESCRIPTION
Blocked on https://github.com/puppetlabs/puppetlabs-puppet_agent/pull/822

* bumps rubocop to 1.73.x and updates rubocop.yml based on ruby 3.1 target version.
    
* If PUPPET_FORGE_TOKEN env variable is defined, install bolt dependency from puppetcore rubygem source. BOLT_GEM_VERSION can also be used to constrain the gem, like PUPPET_GEM_VERSION.
    
* puppet_litmus 1.6.1 added a minimum bolt 4 requirement. Exclude 1.6.1 until we're ready for bolt 4 in a separate ticket.
    
* drops orchestrator_client pin

* disable Style/FileNull as it breaks tests on windows

* Fixes "Could not retrieve fact networking.ip" warning

Also verified puppetcore workflow works:

```
❯ export BUNDLE_RUBYGEMS___PUPPETCORE__PUPPET__COM="forge-key:XXX"
❯ bundle install
Fetching gem metadata from https://rubygems-puppetcore.puppet.com/..
Fetching gem metadata from https://rubygems.org/......
Resolving dependencies...
Fetching bolt 5.0.1
Installing bolt 5.0.1
Fetching puppet_litmus 2.4.2
Installing puppet_litmus 2.4.2
Bundle complete! 39 Gemfile dependencies, 217 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
1 installed gem you directly depend on is looking for funding.
  Run `bundle fund` for details

❯ bundle info bolt       
  * bolt (5.0.1)
	Summary: Execute commands remotely over SSH and WinRM
	Homepage: https://github.com/puppetlabs/bolt-private
	Path: /home/josh/.rbenv/versions/3.2.10/lib/ruby/gems/3.2.0/gems/bolt-5.0.1
	Reverse Dependencies: 
		puppet_litmus (2.4.2) depends on bolt (>= 4.0, < 6.0)

❯ bundle info puppet
  * puppet (8.18.0)
	Summary: Puppet, an automated configuration management tool
	Homepage: https://github.com/puppetlabs/puppet-private
	Path: /home/josh/.rbenv/versions/3.2.10/lib/ruby/gems/3.2.0/gems/puppet-8.18.0
	Reverse Dependencies: 
		bolt (5.0.1) depends on puppet (~> 8.11)
		puppet-syntax (4.1.1) depends on puppet (>= 7, < 9)
```
