### PR TITLE
(PA-8250) Restore windows command to check puppet service

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -64,7 +64,11 @@ describe 'install task' do
     expect(results).to all(include('status' => 'success'))
 
     # Check that puppet agent service has been stopped due to 'stop_service' parameter set to true
-    service = run_command('/opt/puppetlabs/bin/puppet resource service puppet', 'target')
+    service = if target_platform.include?('win')
+                run_command('c:/"program files"/"puppet labs"/puppet/bin/puppet resource service puppet', 'target')
+              else
+                run_command('/opt/puppetlabs/bin/puppet resource service puppet', 'target')
+              end
     output = service[0]['value']['stdout']
     expect(output).to match(%r{ensure\s+=> 'stopped'})
 


### PR DESCRIPTION
Prior to 3890f86, we checked if the puppet service had stopped for all platforms in the "upgrade from 7.x to 7.y" case. However, I copied the check from the "latest platform" case, which assumed *nix. That always happened to work prior to my change, because we always build the agent on one windows platform and install on the rest. So windows was never a "latest" platform.

Restore the check for windows like we used to do in 7.x to 7.y.

```
❯ export BEAKER_HOSTGENERATOR_VERSION=git@github.com:puppetlabs/beaker-hostgenerator-private.git
❯ bundle install
❯ bundle exec beaker-hostgenerator windows2025-64target.a --hypervisor abs > hosts.yml
❯ BEAKER_LOG_LEVEL=debug GEM_BOLT=1 BEAKER_setfile=hosts.yml BEAKER_password=XXX bundle exec rake task_acceptance
...
install task
Installed puppet-agent on cute-graduating.delivery.puppetlabs.net: success
.  installs puppetcore8-nightly
/home/josh/.rbenv/versions/3.2.10/lib/ruby/gems/3.2.0/gems/rexml-3.4.4/lib/rexml/xpath.rb:67: warning: REXML::XPath.each, REXML::XPath.first, REXML::XPath.match dropped support for nodeset...
Upgraded puppet-agent to puppet9 on cute-graduating.delivery.puppetlabs.net: success
Successfully upgraded to puppet9 latest version: 8.99.99.61.g033468376
.  upgrades to puppetcore9-nightly


Finished in 4 minutes 41.7 seconds (files took 2 minutes 52.9 seconds to load)
2 examples, 0 failures
```

