### PR TITLE
(PA-8250) Windows 32-bit isn't supported in core 9

### DIFF
--- a/task_spec/spec/acceptance/init_spec.rb
+++ b/task_spec/spec/acceptance/init_spec.rb
@@ -105,7 +105,8 @@ describe 'install task' do
     ^sles-11-|
     ^solaris-10-|
     ^ubuntu-18.04-|
-    ^ubuntu-20.04-
+    ^ubuntu-20.04-|
+    ^windows-.*-32
   END
 
   it 'upgrades to puppetcore9-nightly' do


### PR DESCRIPTION
Add windows 32-bit to the list of platforms to skip updating to core 9

```
❯ bundle exec beaker-hostgenerator windows10ent-32target.a --hypervisor abs > hosts.yml                                 
❯ BEAKER_LOG_LEVEL=debug GEM_BOLT=1 BEAKER_setfile=hosts.yml BEAKER_password=XXX bundle exec rake task_acceptance
...
install task
Installed puppet-agent on lethal-raising.delivery.puppetlabs.net: success
.  installs puppetcore8-nightly
Platform windows-10ent-32 isn't supported in puppetcore9, skipping
.  upgrades to puppetcore9-nightly

Finished in 1 minute 15.72 seconds (files took 7.57 seconds to load)
2 examples, 0 failures
```
