### PR TITLE
(maint) Update old actions

### DIFF
--- a/.github/workflows/task_acceptance_tests.yaml
+++ b/.github/workflows/task_acceptance_tests.yaml
@@ -49,10 +49,10 @@ jobs:
           nslookup artifactory.delivery.puppetlabs.net
 
       - name: Checkout current PR code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install docker
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v4
         id: buildx
         with:
           install: true


### PR DESCRIPTION
Both the checkout@v4 and docker/setup-buildx-action@v1 actions use Node.js 20, which are deprecated. This commit updates both actions to their latest versions (checkout@v6 and docker/setup-buildx-action@v4).