### PR TITLE
(PA-7824) Use newest Bolt

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -37,14 +37,6 @@ Gemfile:
     ":system_tests":
       - gem: voxpupuli-acceptance
         version: '~> 3'
-      - gem: puppet_litmus
-        version:
-          - '~> 1.0'
-          - '!= 1.6.1'
-        condition: 'ENV["PUPPET_FORGE_TOKEN"].to_s.empty?'
-        platforms:
-          - ruby
-          - x64_mingw
 
 .github/workflows/release.yml:
   unmanaged: false

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,5 +2,5 @@
 * @puppetlabs/phoenix @bastelfreak
 
 # tasks
-/tasks @puppetlabs/bolt @bastelfreak
-/task_spec @puppetlabs/bolt @bastelfreak
+/tasks @bastelfreak
+/task_spec @bastelfreak

--- a/Gemfile
+++ b/Gemfile
@@ -76,12 +76,13 @@ group :development, :release_prep do
   gem "puppetlabs_spec_helper", '~> 8.0', require: false
   gem "puppet-blacksmith", '~> 7.0',      require: false
 end
+# We are overriding the default PDK template's Litmus logic in order to use the
+# latest Bolt in tests. See PA-7824.
 group :system_tests do
-  gem "puppet_litmus", '~> 2.0',             require: false, platforms: [:ruby, :x64_mingw] if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
-  gem "puppet_litmus", '~> 1.0', '!= 1.6.1', require: false, platforms: [:ruby, :x64_mingw] if ENV["PUPPET_FORGE_TOKEN"].to_s.empty?
-  gem "CFPropertyList", '< 3.0.7',           require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "serverspec", '~> 2.41',               require: false
-  gem "voxpupuli-acceptance", '~> 3',        require: false
+  gem "puppet_litmus", '~> 2.0',      require: false, platforms: [:ruby, :x64_mingw]
+  gem "CFPropertyList", '< 3.0.7',    require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "serverspec", '~> 2.41',        require: false
+  gem "voxpupuli-acceptance", '~> 3', require: false
 end
 
 gems = {}

--- a/task_spec/Rakefile
+++ b/task_spec/Rakefile
@@ -12,7 +12,7 @@ PuppetLint.configuration.send('disable_only_variable_string')
 PuppetLint.configuration.ignore_paths = ['spec/**/*.pp', 'pkg/**/*.pp']
 
 task 'task_acceptance' do
-  ENV['BEAKER_BOLT_VERSION'] = '3.0.0'
+  ENV['BEAKER_BOLT_VERSION'] = '5.0.0'
   Rake::Task['spec_prep'].invoke
   Rake::Task['beaker'].invoke
 end


### PR DESCRIPTION
This commit removes the pin for puppet_litmus in the Gemfile and adds both PuppetCore credentials and the PUPPET_FORGE_TOKEN env var in order to use puppet_litmus > 2, which uses newer (~> 5) versions of Bolt.