### PR TITLE
(PA-8275) Add ubuntu-26-aarch64 support to install task

### DIFF
--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -830,6 +830,7 @@ case $platform in
       "20.04") deb_codename="focal";;
       "22.04") deb_codename="jammy";;
       "24.04") deb_codename="noble";;
+      "26.04") deb_codename="resolute";;
     esac
     filetype="deb"
     filename="${collection/core/}-release-${deb_codename}.deb"


### PR DESCRIPTION
## Summary

Adds `"26.04") deb_codename="resolute";;` to the Ubuntu codename case block in `tasks/install_shell.sh`, enabling the bolt install task to resolve the correct package URL for Ubuntu 26.04 aarch64.

## Test plan

- [x] `bash -n tasks/install_shell.sh` exits 0
- [x] `bundle exec rake task_acceptance` passed locally with `ubuntu2604-AARCH64target.a` — both `puppetcore8-nightly` install and `puppetcore9-nightly` upgrade succeeded

Jira: [PA-8275](https://perforce.atlassian.net/browse/PA-8275)

🤖 Generated with [Claude Code](https://claude.com/claude-code)