### PR TITLE
(PA-8924) Remove macOS 11, 12, and 13 support

### DIFF
--- a/spec/classes/puppet_agent_osfamily_darwin_spec.rb
+++ b/spec/classes/puppet_agent_osfamily_darwin_spec.rb
@@ -37,7 +37,7 @@ describe 'puppet_agent' do
     let(:params) { { package_version: } }
 
     context 'when running a supported macOS' do
-      ['osx-11-x86_64', 'osx-12-x86_64'].each do |tag|
+      ['osx-14-x86_64', 'osx-15-x86_64'].each do |tag|
         context "on #{tag} with no aio_version" do
           let(:osmajor) { tag.split('-')[1] }
 
@@ -97,29 +97,29 @@ describe 'puppet_agent' do
     it { is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-5.10.200-1.osx10.13.dmg').with_source('puppet:///pe_packages/2000.0.0/osx-10.13-x86_64/puppet-agent-5.10.200-1.osx10.13.dmg') }
   end
 
-  describe 'when using package_version auto with macOS 11 (two numbers version productversion)' do
+  describe 'when using package_version auto with macOS 14 (two numbers version productversion)' do
     let(:params) do
       {
         package_version: 'auto',
       }
     end
     let(:facts) do
-      override_facts(facts, aio_agent_version: '1.10.99', is_pe: true, os: { macosx: { version: { major: '11.2', }, }, }, platform_tag: 'osx-11-x86_64', serverversion: '5.10.200')
+      override_facts(facts, aio_agent_version: '1.10.99', is_pe: true, os: { macosx: { version: { major: '14.2', }, }, }, platform_tag: 'osx-14-x86_64', serverversion: '5.10.200')
     end
 
-    it { is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-5.10.200-1.osx11.dmg').with_source('puppet:///pe_packages/2000.0.0/osx-11-x86_64/puppet-agent-5.10.200-1.osx11.dmg') }
+    it { is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-5.10.200-1.osx14.dmg').with_source('puppet:///pe_packages/2000.0.0/osx-14-x86_64/puppet-agent-5.10.200-1.osx14.dmg') }
   end
 
-  describe 'when using package_version auto with macOS 11 (one number version productversion)' do
+  describe 'when using package_version auto with macOS 14 (one number version productversion)' do
     let(:params) do
       {
         package_version: 'auto',
       }
     end
     let(:facts) do
-      override_facts(facts, aio_agent_version: '1.10.99', is_pe: true, os: { macosx: { version: { major: '11', }, }, }, platform_tag: 'osx-11-x86_64', serverversion: '5.10.200')
+      override_facts(facts, aio_agent_version: '1.10.99', is_pe: true, os: { macosx: { version: { major: '14', }, }, }, platform_tag: 'osx-14-x86_64', serverversion: '5.10.200')
     end
 
-    it { is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-5.10.200-1.osx11.dmg').with_source('puppet:///pe_packages/2000.0.0/osx-11-x86_64/puppet-agent-5.10.200-1.osx11.dmg') }
+    it { is_expected.to contain_file('/opt/puppetlabs/packages/puppet-agent-5.10.200-1.osx14.dmg').with_source('puppet:///pe_packages/2000.0.0/osx-14-x86_64/puppet-agent-5.10.200-1.osx14.dmg') }
   end
 end

--- a/tasks/install_shell.sh
+++ b/tasks/install_shell.sh
@@ -275,9 +275,6 @@ if [ -f "$PT__installdir/facts/tasks/bash.sh" ]; then
     major_version=$(echo "${major_version}" | cut -d '.' -f 1);
 
     case $major_version in
-      "11")    platform_version="11";;
-      "12")    platform_version="12";;
-      "13")    platform_version="13";;
       "14")    platform_version="14";;
       "15")    platform_version="15";;
       "26")    platform_version="26";;


### PR DESCRIPTION
## Summary

Removes macOS 11, 12, and 13 support from the `puppet_agent` module as part of platform end-of-life cleanup.

Jira: [PA-8924](https://perforce.atlassian.net/browse/PA-8924) (epic [PA-8920](https://perforce.atlassian.net/browse/PA-8920), "Remove macOS 13 FOSS support"). Scope was extended to also drop macOS 11 and 12.

## Changes

- **`tasks/install_shell.sh`** — remove the `"11"`, `"12"`, `"13"` cases from the Darwin `major_version` dispatch. These now fall through to the existing `*)` "No builds for platform" branch and exit non-zero, matching their removal from the supported set. macOS 14/15/26 remain.
- **`spec/classes/puppet_agent_osfamily_darwin_spec.rb`** — retarget the supported-macOS catalog-compile matrix (`osx-11`/`osx-12` → `osx-14`/`osx-15`) and the two productversion-parsing tests (macOS 11 → 14) to supported versions. The `10.13` tests exercise a separate `/^10\./` branch in `manifests/osfamily/darwin.pp` and are intentionally unchanged.

`metadata.json` lists `OSX` with no per-release enumeration, and `manifests/osfamily/darwin.pp` derives the macOS major version dynamically, so no changes are required there.

## Testing

- `bundle exec rake spec_standalone` — 1134 examples, 0 failures
- `bundle exec rake lint` (puppet-lint) — clean
- `bundle exec rubocop` — clean