### PR TITLE
Fix apt signed-by glob to match dev-build repo filenames

### DIFF
--- a/acceptance/helpers.rb
+++ b/acceptance/helpers.rb
@@ -229,7 +229,7 @@ module Beaker::DSL
           # This discrepancy causes apt to error, so we manually add signing info.
           if %r{debian|ubuntu}.match?(host['platform'])
             step '(Agent) Add apt signing information' do
-              on(host, "sed -e 's/^deb http/deb [signed-by=\\/etc\\/apt\\/keyrings\\/GPG-KEY-puppet.asc] http/' /etc/apt/sources.list.d/puppet*.list -i")
+              on(host, "sed -e 's/^deb http/deb [signed-by=\\/etc\\/apt\\/keyrings\\/GPG-KEY-puppet.asc] http/' /etc/apt/sources.list.d/*puppet*.list -i")
             end
           end
 


### PR DESCRIPTION
## Summary
- `set_up_initial_agent_on`'s "(Agent) Add apt signing information" workaround hardcoded a `puppet*.list` glob to find the apt repo file to patch with `signed-by=`.
- When installing via an explicit `puppet_agent_version` (the dev-builds route needed for newer platforms without an established public package repo — e.g. Debian 13/trixie, similar to the Fedora 41 / macOS 26 cases already noted elsewhere in this test suite), the repo file is instead named `pl-puppet-agent-<sha>-<codename>.list`, which the glob didn't match.
- This caused `sed: can't read /etc/apt/sources.list.d/puppet*.list: No such file or directory` (exit 2), aborting `test_upgrade_puppet8_to_puppet9.rb` on Debian 13 before the initial agent could even be installed.
- Fix: broaden the glob to `/etc/apt/sources.list.d/*puppet*.list`, which safely matches either naming convention on a freshly-provisioned test host.

## Test plan
- [ ] Rerun `acceptance/tests/test_upgrade_puppet8_to_puppet9.rb` against a Debian 13 (trixie) agent and confirm the "(Agent) Add apt signing information" step succeeds and the test proceeds past initial agent install.