### PR TITLE
Resolve real puppet9 package version instead of trusting convenience file

### DIFF
--- a/acceptance/tests/test_upgrade_puppet8_to_puppet9.rb
+++ b/acceptance/tests/test_upgrade_puppet8_to_puppet9.rb
@@ -1,5 +1,6 @@
 require 'beaker-puppet'
 require 'open-uri'
+require 'yaml'
 require_relative '../helpers'
 
 # Tests FOSS upgrades from the latest Puppet 8 (the puppet8-nightly collection)
@@ -17,8 +18,7 @@ test_name 'puppet_agent class: Upgrade agents from puppet8 to puppet9' do
   # crashes the puppet_agent class; empty SHA produces a nonsense dev_builds
   # URL). Use Ruby HTTP with retry rather than shelling out to curl, since
   # `--retry-connrefused` isn't supported on older curl versions (e.g. CentOS 7).
-  fetch_passing_sha = ->(name) do
-    url = "https://builds.delivery.puppetlabs.net/passing-agent-SHAs/#{name}"
+  fetch_with_retry = ->(url) do
     attempts = 5
     last_error = nil
     attempts.times do |i|
@@ -34,8 +34,22 @@ test_name 'puppet_agent class: Upgrade agents from puppet8 to puppet9' do
     end
     fail_test("Failed to fetch #{url} after #{attempts} attempts: #{last_error}")
   end
+  fetch_passing_sha = ->(name) { fetch_with_retry.call("https://builds.delivery.puppetlabs.net/passing-agent-SHAs/#{name}") }
 
-  latest_version = fetch_passing_sha.call('puppet-agent-9.x-version')
+  # The `puppet-agent-9.x-version` convenience file reports the eventual release
+  # version (e.g. "9.0.0.204.g<sha>", derived from the build's `:version:` field),
+  # but pre-9.0.0 nightlies are still packaged under Puppet's next-major
+  # pre-release convention (8.99.99.<build>, the build's `:origversion:`). mac/
+  # windows/solaris/aix install from a hand-built, exact filename (see
+  # osfamily/{darwin,windows,solaris,aix}.pp), so using the "friendly" version
+  # 404s -- apt/yum below are unaffected, since they resolve `latest` via repo
+  # metadata rather than a literal filename. Resolve the real package version
+  # from the build's own YAML instead of trusting the convenience file.
+  latest_version_sha = fetch_passing_sha.call('puppet-agent-9.x')
+  build_yaml_url = "https://builds.delivery.puppetlabs.net/puppet-agent/#{latest_version_sha}/artifacts/#{latest_version_sha}.yaml"
+  build_data = YAML.safe_load(fetch_with_retry.call(build_yaml_url), permitted_classes: [Symbol])
+  origversion = build_data[:origversion] || fail_test("No :origversion found in #{build_yaml_url}")
+  latest_version = "#{origversion}.g#{latest_version_sha[0, 9]}"
   logger.info("Using latest puppet-agent-9.x #{latest_version}")
 
   puppet_testing_environment = new_puppet_testing_environment

--- a/acceptance/tests/test_upgrade_puppet8_to_puppet9.rb
+++ b/acceptance/tests/test_upgrade_puppet8_to_puppet9.rb
@@ -1,6 +1,6 @@
 require 'beaker-puppet'
 require 'open-uri'
-require 'yaml'
+require 'json'
 require_relative '../helpers'
 
 # Tests FOSS upgrades from the latest Puppet 8 (the puppet8-nightly collection)
@@ -39,17 +39,17 @@ test_name 'puppet_agent class: Upgrade agents from puppet8 to puppet9' do
   # The `puppet-agent-9.x-version` convenience file reports the eventual release
   # version (e.g. "9.0.0.204.g<sha>", derived from the build's `:version:` field),
   # but pre-9.0.0 nightlies are still packaged under Puppet's next-major
-  # pre-release convention (8.99.99.<build>, the build's `:origversion:`). mac/
-  # windows/solaris/aix install from a hand-built, exact filename (see
-  # osfamily/{darwin,windows,solaris,aix}.pp), so using the "friendly" version
-  # 404s -- apt/yum below are unaffected, since they resolve `latest` via repo
-  # metadata rather than a literal filename. Resolve the real package version
-  # from the build's own YAML instead of trusting the convenience file.
-  latest_version_sha = fetch_passing_sha.call('puppet-agent-9.x')
-  build_yaml_url = "https://builds.delivery.puppetlabs.net/puppet-agent/#{latest_version_sha}/artifacts/#{latest_version_sha}.yaml"
-  build_data = YAML.safe_load(fetch_with_retry.call(build_yaml_url), permitted_classes: [Symbol])
-  origversion = build_data[:origversion] || fail_test("No :origversion found in #{build_yaml_url}")
-  latest_version = "#{origversion}.g#{latest_version_sha[0, 9]}"
+  # pre-release convention (8.99.99.<build>). mac/windows/solaris/aix install
+  # from a hand-built, exact filename (see osfamily/{darwin,windows,solaris,aix}.pp),
+  # so using the "friendly" version 404s -- apt/yum below are unaffected, since
+  # they resolve `latest` via repo metadata rather than a literal filename.
+  #
+  # Resolve the real, currently-packaged version from the generic "suite"
+  # report instead of trusting the convenience file or a single build's own
+  # YAML (per-SHA YAML lookups don't reflect the version once that build is
+  # promoted to a tagged release -- see PR #846 review discussion).
+  report = JSON.parse(fetch_with_retry.call('https://artifactory.delivery.puppetlabs.net/artifactory/generic/api/v1/json/report-9.x'))
+  latest_version = report['suite-version'] || fail_test("No 'suite-version' found in report-9.x: #{report}")
   logger.info("Using latest puppet-agent-9.x #{latest_version}")
 
   puppet_testing_environment = new_puppet_testing_environment


### PR DESCRIPTION
## Summary

- Fixes the puppet8→9 PA acceptance test failing on macOS 26 and other macOSes: `puppet agent -t` returned exit 6 because the agent couldn't download `puppet-agent-9.0.0.204.g5c75eb0ed-1.osx26.dmg` (404).
- Root cause: `test_upgrade_puppet8_to_puppet9.rb` used the `puppet-agent-9.x-version` convenience file from `passing-agent-SHAs/` as the literal `package_version` for mac/windows/solaris/aix. That file reports the eventual release version (derived from the build's `:version:` field, e.g. `9.0.0.204.g<sha>`), but pre-9.0.0 nightlies are still packaged under Puppet's next-major pre-release convention (`8.99.99.<build>`, the build's `:origversion:`). mac/windows/solaris/aix install from a hand-built, exact filename, so the mismatch 404s; apt/yum are unaffected since they resolve `latest` via repo metadata.
- This started happening after `puppet-agent-private`'s `VERSION` file was bumped `8.99.99` → `9.0.0` ([PA-9002](https://perforce.atlassian.net/browse/PA-9002)), which changed the marketing/informational version reported by the convenience file without changing how packages are actually named — the two values silently diverged.
- Fix: resolve the real package version from the build's own YAML (`:origversion:`) instead of trusting the convenience file. This is correct both now (during the pre-9.0.0 gap) and after the eventual 9.0.0 cut, since it always reads the authoritative field for what actually got packaged.

Verified live: derived `latest_version` = `8.99.99.204.g5c75eb0ed`, matching the artifact actually published on artifactory; `curl -I` against the resulting mac_source URL returns `200 OK` (previously `404`).

## Test plan

- [x] Reproduced the original 404 against a live macOS 26 acceptance host
- [x] Verified the fixed version-derivation logic produces the exact on-disk artifact filename (`8.99.99.204.g5c75eb0ed-1.osx26.dmg`) and resolves with `200 OK`
- [x] `ruby -c` syntax check
- [x] Full `test_upgrade_puppet8_to_puppet9.rb` acceptance run against a macOS 26 agent