### PR TITLE
(PA-8998) Require a puppet9 master for the puppet8->9 upgrade test

### DIFF
--- a/acceptance/Rakefile
+++ b/acceptance/Rakefile
@@ -55,10 +55,9 @@ task :ci do
     Rake.application['prepare'].invoke
     # UPGRADE_TARGET_COLLECTION selects which upgrade test to run, defaulting to
     # MASTER_COLLECTION. Override when the master must be on an older stream than
-    # the upgrade target — e.g. testing puppet8→9 agent upgrades with a puppet8
-    # master because puppetserver-9 nightlies aren't yet published. Treat blank
-    # env values as unset; an empty string is truthy in Ruby and would otherwise
-    # mask the MASTER_COLLECTION fallback.
+    # the upgrade target -- e.g. to deliberately test a puppet9 agent upgrade
+    # against an older master. Treat blank env values as unset; an empty string
+    # is truthy in Ruby and would otherwise mask the MASTER_COLLECTION fallback.
     upgrade_target = ENV['UPGRADE_TARGET_COLLECTION'].to_s.strip
     upgrade_target = ENV['MASTER_COLLECTION'].to_s.strip if upgrade_target.empty?
     case upgrade_target

--- a/acceptance/tests/test_upgrade_puppet8_to_puppet9.rb
+++ b/acceptance/tests/test_upgrade_puppet8_to_puppet9.rb
@@ -6,11 +6,17 @@ require_relative '../helpers'
 # Tests FOSS upgrades from the latest Puppet 8 (the puppet8-nightly collection)
 # to the latest puppet9-nightly build.
 test_name 'puppet_agent class: Upgrade agents from puppet8 to puppet9' do
-  # puppet9-nightly puppetserver may not yet be published; accept a puppet8 or
-  # newer master so the test can run while agents are upgraded to puppet9.
-  # puppet_collection_for(:puppetserver, ...) returns bare 'puppet8'/'puppet9'
-  # (no -nightly suffix), so compare against the bare collection name.
-  require_master_collection min: 'puppet8'
+  # puppetserver 9-nightly builds are now available (PA-8998), so require an
+  # actual puppet9 master to properly exercise the upgrade instead of falling
+  # back to a puppet8 master. puppet_collection_for(:puppetserver, ...) returns
+  # bare 'puppet8'/'puppet9' (no -nightly suffix), so compare against the bare
+  # collection name.
+  #
+  # Note puppetserver 9-nightly platform coverage differs from puppet8-nightly
+  # (some platforms were dropped, others added) -- if the master platform in
+  # hosts.yaml changes, confirm a puppetserver9-nightly build still exists for
+  # it before relying on this.
+  require_master_collection min: 'puppet9'
   exclude_pe_upgrade_platforms
 
   # Both passing-agent-SHAs lookups have to succeed; if VPN/network flaps and


### PR DESCRIPTION
## Summary

- Resolves [PA-8998](https://perforce.atlassian.net/browse/PA-8998).
- `test_upgrade_puppet8_to_puppet9.rb` used `require_master_collection min: 'puppet8'` because puppet9-nightly puppetserver builds weren't reliably published yet, so the test accepted a puppet8-or-newer master while agents were upgraded to puppet9.
- Per [Josh Cooper's comment on PA-8998](https://perforce.atlassian.net/browse/PA-8998?focusedCommentId=4179028), puppetserver 9-nightly builds are now available. Verified directly against artifactory: `puppetserver9-nightly` is published for `el/9/x86_64` (our master's platform).
- Tightens the guard to `require_master_collection min: 'puppet9'` so the test properly exercises the upgrade against a real puppet9 master instead of silently falling back to puppet8.
- Also updates the Rakefile's `UPGRADE_TARGET_COLLECTION` comment, which cited the same now-stale "puppetserver-9 nightlies aren't yet published" rationale.
- Note (per the same comment): puppetserver 9-nightly platform coverage differs from 8.x (some platforms dropped, others added) — flagged in the updated code comment so this is checked again if the master platform in `hosts.yaml` ever changes.

## Test plan

- [x] Confirmed `puppetserver9-nightly` exists for el-9-x86_64 (current master platform) on artifactory
- [x] `ruby -c` syntax check
- [ ] Full `test_upgrade_puppet8_to_puppet9.rb` acceptance run with `MASTER_COLLECTION=puppet9-nightly`