### PR TITLE
(PA-8337) Mark module compatible with puppet9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -79,7 +79,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "version_requirement": ">= 7.0.0 < 10.0.0"
     }
   ],
   "pdk-version": "3.6.1",


### PR DESCRIPTION
## Summary
- Bump `metadata.json`'s puppet `version_requirement` from `>= 7.0.0 < 9.0.0` to `>= 7.0.0 < 10.0.0` so the module is declared compatible with Puppet 9.
- The acceptance test for the puppet8 → puppet9 upgrade path (`acceptance/tests/test_upgrade_puppet8_to_puppet9.rb`) is already merged to `main`.
- Companion Jenkins job-group change: puppetlabs/ci-job-configs#10797 (adds the 8-to-9 upgrade CI job).

Jira: https://perforce.atlassian.net/browse/PA-8337

## Test plan
- [x] `pdk validate metadata` passes
- [x] Reviewed via `/review-pr` (code, test, type-analyzer agents) — two consecutive clean passes