### PR TITLE
Add puppetcore9 install support

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -120,7 +120,7 @@ Data type: `String`
 
 The Puppet Collection to track. Defaults to 'PC1'. Valid values are puppet7,
 puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly,
-puppetcore7, puppetcore8.
+puppetcore7, puppetcore8, puppetcore8-nightly, puppetcore9, puppetcore9-nightly
 
 Default value: `$puppet_agent::params::collection`
 
@@ -850,7 +850,7 @@ The version of puppet-agent to install (defaults to latest when no agent is inst
 
 ##### `collection`
 
-Data type: `Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly, puppetcore7, puppetcore8, puppetcore8-nightly, puppetcore9-nightly]]`
+Data type: `Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly, puppetcore7, puppetcore8, puppetcore8-nightly, puppetcore9, puppetcore9-nightly]]`
 
 The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)
 
@@ -930,7 +930,7 @@ The version of puppet-agent to install
 
 ##### `collection`
 
-Data type: `Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly, puppetcore7, puppetcore8, puppetcore8-nightly, puppetcore9-nightly]]`
+Data type: `Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly, puppetcore7, puppetcore8, puppetcore8-nightly, puppetcore9, puppetcore9-nightly]]`
 
 The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)
 
@@ -1010,7 +1010,7 @@ The version of puppet-agent to install
 
 ##### `collection`
 
-Data type: `Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly, puppetcore7, puppetcore8, puppetcore8-nightly, puppetcore9-nightly]]`
+Data type: `Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly, puppetcore7, puppetcore8, puppetcore8-nightly, puppetcore9, puppetcore9-nightly]]`
 
 The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)
 

--- a/docker/bin/helpers/run-upgrade.sh
+++ b/docker/bin/helpers/run-upgrade.sh
@@ -16,6 +16,9 @@ case $puppet_major in
 8)
     to_collection=puppetcore8
     ;;
+9)
+    to_collection=puppetcore9
+    ;;
 *)
     echo "Invalid version supplied" 1>&2
     exit 1

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,7 @@
 # @param collection
 #   The Puppet Collection to track. Defaults to 'PC1'. Valid values are puppet7,
 #   puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly,
-#   puppetcore7, puppetcore8.
+#   puppetcore7, puppetcore8, puppetcore8-nightly, puppetcore9, puppetcore9-nightly
 # @param is_pe
 #   Install from Puppet Enterprise repos. Enabled if communicating with a PE master.
 # @param manage_pki_dir

--- a/tasks/install.json
+++ b/tasks/install.json
@@ -7,7 +7,7 @@
     },
     "collection": {
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
-      "type": "Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly, puppetcore7, puppetcore8, puppetcore8-nightly, puppetcore9-nightly]]"
+      "type": "Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly, puppetcore7, puppetcore8, puppetcore8-nightly, puppetcore9, puppetcore9-nightly]]"
     },
     "absolute_source": {
       "description": "The absolute source location to find the Puppet agent package",

--- a/tasks/install_powershell.json
+++ b/tasks/install_powershell.json
@@ -8,7 +8,7 @@
     },
     "collection": {
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
-      "type": "Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly, puppetcore7, puppetcore8, puppetcore8-nightly, puppetcore9-nightly]]"
+      "type": "Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly, puppetcore7, puppetcore8, puppetcore8-nightly, puppetcore9, puppetcore9-nightly]]"
     },
     "absolute_source": {
       "description": "The absolute source location to find the Puppet agent package",

--- a/tasks/install_shell.json
+++ b/tasks/install_shell.json
@@ -9,7 +9,7 @@
     },
     "collection": {
       "description": "The Puppet collection to install from (defaults to puppet, which maps to the latest collection released)",
-      "type": "Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly, puppetcore7, puppetcore8, puppetcore8-nightly, puppetcore9-nightly]]"
+      "type": "Optional[Enum[puppet7, puppet8, puppet, puppet7-nightly, puppet8-nightly, puppet-nightly, puppetcore7, puppetcore8, puppetcore8-nightly, puppetcore9, puppetcore9-nightly]]"
     },
     "absolute_source": {
       "description": "The absolute source location to find the Puppet agent package",


### PR DESCRIPTION
Recreated from origin (was opened from a fork in #848, which meant CI couldn't access PUPPET_FORGE_TOKEN_PUBLIC). Closes #848.