### PR TITLE
(PA-9119) Diagnose dnf5 metadata staleness and fix versioncmp() truthiness bug

### DIFF
--- a/acceptance/tests/test_upgrade_puppet8_to_puppet9.rb
+++ b/acceptance/tests/test_upgrade_puppet8_to_puppet9.rb
@@ -120,7 +120,47 @@ node default {
       # Pre-release puppet9 nightlies report as 8.99.99.<build>.g<sha> (Puppet's
       # next-major pre-release convention); accept those alongside the eventual
       # stable 9.x.y form.
-      assert(puppet_agent_version_on(agent) =~ %r{^(?:9\.\d+\.\d+|8\.99\.99\.\d+).*})
+      installed_version = puppet_agent_version_on(agent)
+      # puppet_agent_version_on returns nil (rather than a non-matching
+      # string) when `facter aio_agent_version` itself fails to run -- e.g.
+      # exactly the "package removed, reinstall failed" failure mode these
+      # diagnostics exist for -- so guard before calling String methods on it.
+      is_upgraded = !installed_version.nil? && installed_version.match?(%r{^(?:9\.\d+\.\d+|8\.99\.99\.\d+).*})
+      unless is_upgraded
+        # Checked with a plain, non-raising shell test rather than
+        # fact_on/facter: this branch exists specifically for the case where
+        # the agent's Ruby/facter is broken or gone, and fact_on has no
+        # accept_all_exit_codes equivalent, so it would raise in exactly
+        # that scenario instead of running these diagnostics. Presence of
+        # /etc/yum.repos.d is also the precondition for the pc_repo.repo read
+        # a few lines below, so it doubles as that guard too.
+        is_rpm_family = on(agent, 'test -d /etc/yum.repos.d', accept_all_exit_codes: true).exit_code.zero?
+        if is_rpm_family
+          # Capture repo/package state before the test's teardown removes
+          # pc_repo and (attempts to) purge the package, which would
+          # otherwise destroy this evidence. RPM-family only: dnf/yum aren't
+          # meaningful on other platforms, and running them there just adds
+          # "command not found" noise on top of the real failure.
+          logger.error("=== repo/package diagnostics on #{agent} (installed version: #{installed_version.inspect}) ===")
+          # The dnf/yum provider's own reasoning about Package[puppet-agent]
+          # is only visible in this run's --debug output, which is discarded
+          # above whenever exit_code == 2 (no error). Re-surface the
+          # relevant lines here since that's exactly the scenario we need to
+          # see into.
+          logger.error('--- puppet agent -t --debug lines mentioning the package/dnf/yum decision ---')
+          logger.error(result.stdout.lines.grep(%r{puppet-agent|dnf|yum}i).join)
+          # Deliberately not re-running `dnf check-update` here -- doing so
+          # would itself refresh dnf5's metadata cache and destroy the very
+          # "cold cache" evidence these read-only commands are meant to
+          # capture. The real check-update invocation (including whether it
+          # forced a refresh) is already visible in the debug lines above.
+          logger.error(on(agent, 'cat /etc/yum.repos.d/pc_repo.repo', accept_all_exit_codes: true).stdout)
+          logger.error(on(agent, 'dnf repolist', accept_all_exit_codes: true).stdout)
+          logger.error(on(agent, 'dnf list --showduplicates puppet-agent', accept_all_exit_codes: true).stdout)
+          logger.error('=== end diagnostics ===')
+        end
+      end
+      assert(is_upgraded, "expected puppet9 on #{agent}, got installed version: #{installed_version.inspect}")
     end
   end
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -93,7 +93,7 @@ class puppet_agent::install (
         # any other type of source means we use a package manager (yum) with no 'source' parameter in the
         # package resource below
         $_package_version = $package_version
-        if $facts['os']['name'] == 'Fedora' and versioncmp($facts['os']['release']['major'], '41') {
+        if $facts['os']['name'] == 'Fedora' and versioncmp($facts['os']['release']['major'], '41') >= 0 {
           $_provider = undef
         } else {
           $_provider = 'yum'

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -146,6 +146,26 @@ describe 'puppet_agent' do
         it { is_expected.to contain_package('puppet-agent').with_provider(nil) }
       end
     end
+
+    # Regression test for a versioncmp() truthiness bug (PA-9119): versioncmp
+    # returns an Integer, and Puppet treats every Integer -- including 0 and
+    # negatives -- as truthy, so a bare `if versioncmp(...)` was true for
+    # every Fedora release, not just >= 41. Fedora releases below 41 must
+    # still get the explicit 'yum' provider.
+    context 'on a pre-dnf5 Fedora release (< 41)' do
+      # fedora-38 facts aren't available from every FacterDB version pinned
+      # across this module's supported Puppet/Ruby matrix (see the fallback
+      # above), so derive them the same way: reuse whichever Fedora facts
+      # `os_facts` above already resolved and override just the release.
+      pre_dnf5_os_name = 'fedora-38-x86_64'
+      pre_dnf5_facts = os_facts.values.first.dup
+      pre_dnf5_facts[:os] = pre_dnf5_facts[:os].merge('release' => { 'full' => '38', 'major' => '38' })
+
+      let(:facts) { global_facts(pre_dnf5_facts, pre_dnf5_os_name) }
+      let(:params) { { package_version: '6.18.0' } }
+
+      it { is_expected.to contain_package('puppet-agent').with_provider('yum') }
+    end
   end
 
   context 'supported_operating systems' do


### PR DESCRIPTION
## Problem

`acceptance/tests/test_upgrade_puppet8_to_puppet9.rb` failed deterministically on Fedora 41: `Package[puppet-agent]` (`ensure => 'latest'`) found no update immediately after `Yumrepo['pc_repo']` created the repo pointing at the newer puppet9-nightly build, in the same catalog run.

```
Notice: .../Yumrepo[pc_repo]/ensure: created
...
Debug: Package[puppet-agent](provider=dnf): Yum didn't find updates, current version (8.21.0.13...) is the latest
...
Minitest::Assertion: Expected nil to be truthy.
```

Confirmed via a live failing build: [Jenkins build #1, PLATFORM=fedora41-64default](https://jenkins-platform.delivery.puppetlabs.net/view/__experimental%20automatic/job/experimental_auto_puppetlabs-puppet-agent-module_intn-sys_pa-acceptance_8-nightly_to_9-nightly-main/1/PLATFORM=fedora41-64default.a-redhat9-64mdca,WORKER_LABEL=k8s-beaker/consoleFull).

Tracked in [PA-9119](https://perforce.atlassian.net/browse/PA-9119) and [PUP-12151](https://perforce.atlassian.net/browse/PUP-12151).

## Root cause

A dnf5 metadata-cache staleness bug: dnf5's on-disk repo metadata cache can lag a repo that was created or changed earlier in the same Puppet transaction. PA-9119's investigation deterministically reproduced this (100% correlation across 6 trials tied to cache-warm-before-repo-exists), ruled out publish-lag, and pinned it to Puppet's `dnf`/`yum` provider never forcing a metadata refresh when checking for updates.

**The actual fix lives in `puppet-private`**: puppetlabs/puppet-private#217 (adds a dnf5-gated `--refresh` to `check_updates`/`available_versions`). This PR is the module-side half: better failure diagnostics for this class of bug, plus an unrelated bug found while investigating.

## What's in this PR

1. **Acceptance test diagnostics** (`test_upgrade_puppet8_to_puppet9.rb`): on a post-upgrade version-assertion failure, log the repo/package state (the real `--debug` decision lines, `dnf repolist`, `dnf list --showduplicates`) before teardown destroys the evidence, so a recurrence is diagnosable from CI logs alone. Guarded so it only runs on RPM-family agents (checked with a non-raising `test -d /etc/yum.repos.d`, not `facter`/`fact_on` — this branch exists specifically for the case where the agent's facter is broken, and `fact_on` has no `accept_all_exit_codes` equivalent, so it would raise in exactly that scenario). Also fixed the pre-existing `nil.match?` crash risk: `puppet_agent_version_on` returns `nil` (not a non-matching string) when `facter aio_agent_version` itself fails, which would otherwise raise before the diagnostics or even the `assert` could run.

2. **`manifests/install.pp` bug fix**: found during PA-9119's investigation —
   ```puppet
   if $facts['os']['name'] == 'Fedora' and versioncmp($facts['os']['release']['major'], '41') {
   ```
   `versioncmp()` returns an Integer, and Puppet treats every Integer (including `0` and negatives) as truthy, so this was unconditionally true for every Fedora release, not just `>= 41`. Fixed to `versioncmp(...) >= 0`. This restores the pre-existing behavior for Fedora < 41 (explicit `'yum'` provider) that a recent change (`d058ce3`, introducing dnf5 handling for Fedora >= 41) unintentionally dropped for all Fedora releases. Added a regression test (`spec/classes/puppet_agent_spec.rb`) confirmed to fail against the buggy condition.

## Testing performed

- `bundle exec rake spec` — 1135 examples, 0 failures
- `bundle exec rake lint` / `rake syntax` / `rake metadata_lint` — clean
- `bundle exec rubocop` on both modified Ruby files — clean
- Manually verified the new `install.pp` regression test fails against the pre-fix `if versioncmp(...)` condition (reverted, confirmed red, restored)

## Related

- puppetlabs/puppet-private#217 (the actual provider fix this test diagnoses)
- [PA-9119](https://perforce.atlassian.net/browse/PA-9119)
- [PUP-12151](https://perforce.atlassian.net/browse/PUP-12151)

Base branch note: stacked on #847 (PA-8998, already open) since this test file's current state depends on it; the diff will narrow to just this PR's changes once #847 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)